### PR TITLE
Makefile: add target to build static library in addition to DSO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ LDFLAGS += $(foreach library,$(LIBRARIES),-l$(library))
 
 .PHONY: all scan install clean distclean
 
-all: $(NAME)
+all: $(NAME) $(NAME)-static
+
+$(NAME)-static: $(OBJS)
+	$(AR) rcs lib$(NAME).a $(OBJS)
 
 $(NAME): $(OBJS)
 	$(CC) -shared -Wl,-soname,lib$(NAME).so.$(LIBMAJOR) -o lib$(NAME).so.$(LIBVERSION) $(OBJS) $(LDFLAGS)
@@ -51,5 +54,6 @@ clean:
 	@- $(RM) $(NAME)
 	@- $(RM) $(OBJS)
 	@- $(RM) lib$(NAME).so*
+	@- $(RM) lib$(NAME).a
 
 distclean: clean


### PR DESCRIPTION
In an effort to incorporate the jitterentropy source with rngd, we had
discussed ways to clone the source file over to the rngd project.
Rather than do that I would like to propose that we instead enable this
library to be built as a static archive, suitable for compile time
linking into the rngd library.  rngd can pull the source code as a
submodule in its git tree, build the static archive and link it in as
needed

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>