### PR TITLE
Add check to the list of PHONY targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CFLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir))
 LDFLAGS += $(foreach library,$(LIBRARIES),-l$(library))
 
-.PHONY: all scan install clean distclean
+.PHONY: all scan install clean distclean check
 
 all: $(NAME) $(NAME)-static
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ LDFLAGS += $(foreach library,$(LIBRARIES),-l$(library))
 
 .PHONY: all scan install clean distclean
 
-all: $(NAME)
+all: $(NAME) $(NAME)-static
+
+$(NAME)-static: $(OBJS)
+	$(AR) rcs lib$(NAME).a $(OBJS)
 
 $(NAME): $(OBJS)
 	$(CC) -shared -Wl,-soname,lib$(NAME).so.$(LIBMAJOR) -o lib$(NAME).so.$(LIBVERSION) $(OBJS) $(LDFLAGS)
@@ -51,5 +54,6 @@ clean:
 	@- $(RM) $(NAME)
 	@- $(RM) $(OBJS)
 	@- $(RM) lib$(NAME).so*
+	@- $(RM) lib$(NAME).a
 
 distclean: clean


### PR DESCRIPTION
Sorry, I forgot to add in this PHONY target to the initial makefile change.  It allows automake projects to run selftests, and without this target the rng-tools selftests fail to complete.