### PR TITLE
build: Make DSO usabile in development environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ PREFIX := /usr/local
 # library target directory (either lib or lib64)
 LIBDIR := lib
 
+# include target directory
+INCDIR := include
+
 NAME := jitterentropy
 LIBMAJOR=$(shell cat jitterentropy-base.c | grep define | grep MAJVERSION | awk '{print $$3}')
 LIBMINOR=$(shell cat jitterentropy-base.c | grep define | grep MINVERSION | awk '{print $$3}')
@@ -49,8 +52,11 @@ install:
 	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man3/$(NAME).3
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(LIBDIR)
 	install -m 0755 -s lib$(NAME).so.$(LIBVERSION) $(DESTDIR)$(PREFIX)/$(LIBDIR)/
+	install -m 0644 jitterentropy.h $(DESTDIR)$(PREFIX)/$(INCDIR)/
+	install -m 0644 jitterentropy-base-user.h $(DESTDIR)$(PREFIX)/$(INCDIR)/
 	$(RM) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so.$(LIBMAJOR)
 	ln -s lib$(NAME).so.$(LIBVERSION) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so.$(LIBMAJOR)
+	ln -s lib$(NAME).so.$(LIBMAJOR) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so
 
 clean:
 	@- $(RM) $(NAME)


### PR DESCRIPTION
I'd like to move rng-tools away from using a static build of
jitterentropy, and replace it with a dynamic library linkage.  Doing so
makes the distribution of rng-tools a bit easier (people can install
libjitterentropy indepndently, and don't have to go get a second tarball
for building), and it eases security issues (in the event jitterentropy
usage fans out).  To do that though, we need two things:

1) The header files jitterentropy.h and jitterentropy-base-user.h need
to be availble in a standard location

2) The file libjitterentropy.so needs to be available and must point to
the latest version of the library.

This patch enables both of those items.  With this, all the needed files
are in place to allow other projects to detect the presence of the
jitterentropy library via the AC_SEARCH_LIB macro in autoconf.

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>