### PR TITLE
Makefile: allow the user to disable stack protector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Compile Noise Source as user space application
 
 CC ?= gcc
-CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0
 #Hardening
-CFLAGS +=-fstack-protector-all -fwrapv --param ssp-buffer-size=4
+CFLAGS ?=-fstack-protector-all --param ssp-buffer-size=4
+CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0 -fwrapv
 LDFLAGS +=-Wl,-z,relro,-z,now
 
 # Change as necessary


### PR DESCRIPTION
Allow the user to disable stack-protector by overriding CFLAGS as it is
not supported by all toolchains

Buildroot patch adding the similar patch with build failure output.
http://patchwork.ozlabs.org/patch/1185258/