### PR TITLE
jitterentropy-base: use clang pragma to disable optimization. Use GCC…

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -51,7 +51,9 @@
 
 #undef _FORTIFY_SOURCE
 
-#ifndef __clang__
+#ifdef __clang__
+#pragma clang optimize off
+#elif defined (__GNUC__)
 #pragma GCC optimize ("O0")
 #endif
 


### PR DESCRIPTION
… pragma only when gcc is used. Taken from modifications done in https://github.com/veracrypt/VeraCrypt/blob/master/src/Crypto/jitterentropy-base.c