### PR TITLE
Make man pages reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ install: install-man install-shared install-includes
 install-man:
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/share/man/man3
 	install -m 644 doc/$(NAME).3 $(DESTDIR)$(PREFIX)/share/man/man3/
-	gzip -f -9 $(DESTDIR)$(PREFIX)/share/man/man3/$(NAME).3
+	gzip -n -f -9 $(DESTDIR)$(PREFIX)/share/man/man3/$(NAME).3
 
 install-shared:
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(LIBDIR)


### PR DESCRIPTION
Instructs the man page to be gzip'ed without the file name or timestamp
so that it builds reproducibly.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>