### PR TITLE
Use x86 specific jent_get_nstime in userspace when available

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -42,7 +42,11 @@
 #ifndef _JITTERENTROPY_H
 #define _JITTERENTROPY_H
 
+#ifdef __x86_64__
+#include "arch/jitterentropy-base-x86.h"
+#else
 #include "jitterentropy-base-user.h"
+#endif
 
 /* The entropy pool */
 struct rand_data


### PR DESCRIPTION
It was recently found that, on azure vms, the use of the CLOCK_REALTIME
clock in calls to get_nstime, that the returned value was too coarse to
make effective use of jitterentropy.  The hypervisor in that cloud
restricts the clock granularity to 100ms making it too coarse to be
useful as a time measurement in jitter calculations.  While azure may
fix this in the future, linux guests need a mechanism to get a more
granular clock time, if jitterentropy is to be an effective entropy
source

This can be fixed with this patch, which builds jitterentropy on x8664
systems such that the x86 specific jent_get_nstime is used, which uses
raw rdtsc instructions to get a more granular clock value

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>