### PR TITLE
Link libpthread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC ?= gcc
 #Hardening
 CFLAGS ?= -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align -Wmissing-field-initializers -Wshadow -Wswitch-enum
 CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0 -fwrapv -Wconversion
-LDFLAGS +=-Wl,-z,relro,-z,now
+LDFLAGS +=-Wl,-z,relro,-z,now -lpthread
 
 GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | sed 's/\./\n/g' | wc -l`)
 ifeq "$(GCCVERSIONFORMAT)" "3"


### PR DESCRIPTION
There was underlinkage when building with -Wl,--no-undefined:

```
gcc -shared -Wl,-soname,libjitterentropy.so.3 -o libjitterentropy.so.3.0.2 jitterentropy-base.o -O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4 -m64 -mtune=generic -Wl,-O2  -Wl,--no-undefined   -Wl,-z,relro,-z,now  -lrt
/usr/bin/x86_64-openmandriva-linux-gnu-ld: jitterentropy-base.o: in function `jent_notime_settick':
/tmp/abf/rpmbuild/BUILD/jitterentropy-library-3.0.2/jitterentropy-base.c:733: undefined reference to `pthread_create'
/usr/bin/x86_64-openmandriva-linux-gnu-ld: jitterentropy-base.o: in function `jent_notime_unsettick':
/tmp/abf/rpmbuild/BUILD/jitterentropy-library-3.0.2/jitterentropy-base.c:744: undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
```