### PR TITLE
Added broader gcd test to check for common divisors within `jent_time_entropy_init`

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -690,7 +690,7 @@ static int jent_force_internal_timer = 0;
  *
  * @brief The measurement loop triggers the read of the value from the
  * counter function. It conceptually acts as the low resolution
- * sampleS timer from a ring oscillator.
+ * samples timer from a ring oscillator.
  */
 static void *jent_notime_sample_timer(void *arg)
 {
@@ -834,7 +834,7 @@ static uint64_t jent_loop_shuffle(struct rand_data *ec,
 	(void)ec;
 	(void)bits;
 
-	return (1<<min);
+	return (1U<<min);
 
 #else /* JENT_CONF_DISABLE_LOOP_SHUFFLE */
 
@@ -865,7 +865,7 @@ static uint64_t jent_loop_shuffle(struct rand_data *ec,
 	 * We add a lower boundary value to ensure we have a minimum
 	 * RNG loop count.
 	 */
-	return (shuffle + (1<<min));
+	return (shuffle + (1U<<min));
 
 #endif /* JENT_CONF_DISABLE_LOOP_SHUFFLE */
 }
@@ -1187,6 +1187,7 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 	    (flags & JENT_FORCE_INTERNAL_TIMER))
 		return NULL;
 
+#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 	/*
 	 * If the initial test code concludes to force the internal timer
 	 * and the user requests it not to be used, do not allocate
@@ -1194,6 +1195,7 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 	 */
 	if (jent_force_internal_timer && (flags & JENT_DISABLE_INTERNAL_TIMER))
 		return NULL;
+#endif
 
 	entropy_collector = jent_zalloc(sizeof(struct rand_data));
 	if (NULL == entropy_collector)
@@ -1256,7 +1258,6 @@ void jent_entropy_collector_free(struct rand_data *entropy_collector)
 
 static int jent_time_entropy_init(unsigned int enable_notime)
 {
-	int i;
 	uint64_t delta_sum = 0;
 	uint64_t old_delta = 0;
 	unsigned int nonstuck = 0;
@@ -1298,7 +1299,7 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	 */
 
 #define CLEARCACHE 100
-	for (i = 0; (JENT_POWERUP_TESTLOOPCOUNT + CLEARCACHE) > i; i++) {
+	for (int i = 0; (JENT_POWERUP_TESTLOOPCOUNT + CLEARCACHE) > i; i++) {
 		uint64_t time = 0;
 		uint64_t time2 = 0;
 		uint64_t delta = 0;
@@ -1409,7 +1410,7 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	 * than 1 to ensure the entropy estimation
 	 * implied with 1 is preserved
 	 */
-	if ((delta_sum) <= JENT_POWERUP_TESTLOOPCOUNT) {
+	if (delta_sum <= JENT_POWERUP_TESTLOOPCOUNT) {
 		ret = EMINVARVAR;
 		goto out;
 	}

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -81,7 +81,6 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-
 /**
  * jent_version() - Return machine-usable version number of jent library
  *
@@ -140,7 +139,6 @@ static void jent_apt_insert(struct rand_data *ec, uint64_t current_delta)
 		ec->apt_base_set = 1;
 		return;
 	}
-
 
 	if (current_delta == ec->apt_base) {
 		ec->apt_count++;
@@ -1316,7 +1314,6 @@ static uint64_t jent_gcd64(uint64_t a, uint64_t b) {
   return a;
 }
 
-
 static int jent_time_entropy_init(unsigned int enable_notime)
 {
 	uint64_t delta_sum = 0;
@@ -1447,7 +1444,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 		/* test whether we have an increasing timer */
 		if (!(time2 > time))
 			time_backwards++;
-
 
 		/* Watch for common adjacent GCD values */
 		delta_gcd[i-CLEARCACHE] = jent_gcd64(delta, old_delta);

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1295,7 +1295,7 @@ void jent_entropy_collector_free(struct rand_data *entropy_collector)
 }
 
 /*A straight forward implementation of the Euclidean algorithm for GCD.*/
-uint64_t gcd64(uint64_t a, uint64_t b) {
+static uint64_t jent_gcd64(uint64_t a, uint64_t b) {
 	/* Make a greater a than or equal b. */
 	if (a < b) {
 		uint64_t c = a;
@@ -1450,7 +1450,7 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 
 
 		/* Watch for common adjacent GCD values */
-		delta_gcd[i-CLEARCACHE] = gcd64(delta, old_delta);
+		delta_gcd[i-CLEARCACHE] = jent_gcd64(delta, old_delta);
 
 		/*
 		 * ensure that we have a varying delta timer which is necessary

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1348,6 +1348,9 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	if (jent_fips_enabled())
 		ec.fips_enabled = 1;
 
+	/* Required by jent_measure_jitter */
+	jent_common_timer_gcd = 1;
+
 	/* We could perform statistical tests here, but the problem is
 	 * that we only have a few loop counts to do testing. These
 	 * loop counts may show some slight skew and we produce
@@ -1589,11 +1592,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 			 */
 			jent_common_timer_gcd = most_common_gcd;
 		}
-	} else {
-			/*
-			 * No dominant GCD was found.
-			 */
-			jent_common_timer_gcd = 1;
 	}
 
 	/*

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -229,6 +229,7 @@ unsigned int jent_version(void);
 #define EHEALTH		9 /* Health test failed during initialization */
 #define ERCT		10 /* RCT failed during initialization */
 #define EHASH		11 /* Hash self test failed */
+#define EMEM		12 /* Can't allocate memory for initialization */
 
 /* -- BEGIN statistical test functions only complied with CONFIG_CRYPTO_CPU_JITTERENTROPY_STAT -- */
 

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -57,6 +57,11 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 		goto out;
 	}
 
+	ret = jent_entropy_init();
+	if(!ret) {
+		printf("The initialization failed with error code %d\n", ret);
+		goto out;
+	}
 	ec = jent_entropy_collector_alloc(0, notime ?
 					     JENT_FORCE_INTERNAL_TIMER : 0);
 	if (!ec) {


### PR DESCRIPTION
In the `jent_time_entropy_init` function, there is a check to see if the deltas tend to be divisible by 100, but no other factors. This is fine so far as it goes, but other factors also occur.

This pull request includes checking for arbitrary common factors, and raises an error if these common factors are greater than or equal to 100. This also keeps track of the found common factor, and removes this factor from the delta values before further processing. For example, on an Intel system whose TSC value is always even, this makes `delta` the actual number of ticks rather than always having an even value.

As an aside, the self-test and ongoing behavior are conceptually distinct.

If you aren't comfortable with adjusting the delta values while running, then you could remove the division by the common factor when computing `current_delta`, remove the newly-superfluous `jent_common_timer_gcd` global, and remove the logic that sets `jent_common_timer_gcd`.

You would still be left with a better version of the prior `count_mod` test that could detect common factors >= 100.