### PR TITLE
APT and RCT health test fixes and improvements

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1224,8 +1224,8 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 	entropy_collector->osr = osr;
 
 	/* Establish the apt_cutoff based on the presumed entropy rate of 1/osr. */
-	if(osr > 14) {
-		entropy_collector->apt_cutoff = 511;
+	if(osr >= ARRAY_SIZE(jent_apt_cutoff_lookup)) {
+		entropy_collector->apt_cutoff = jent_apt_cutoff_lookup[ARRAY_SIZE(jent_apt_cutoff_lookup)-1];
 	} else {
 		entropy_collector->apt_cutoff = jent_apt_cutoff_lookup[osr-1];
 	}

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1288,6 +1288,9 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	if (jent_fips_enabled())
 		ec.fips_enabled = 1;
 
+	/* Setup the cutoff for the APT test. */
+	ec.apt_cutoff = jent_apt_cutoff_lookup[JENT_MIN_OSR - 1];
+
 	/* We could perform statistical tests here, but the problem is
 	 * that we only have a few loop counts to do testing. These
 	 * loop counts may show some slight skew and we produce

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -81,7 +81,6 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-
 /**
  * jent_version() - Return machine-usable version number of jent library
  *

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1227,7 +1227,7 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 	if(osr > 14) {
 		entropy_collector->apt_cutoff = 511;
 	} else {
-		entropy_collector->apt_cutoff = apt_cutoff_lookup[osr-1];
+		entropy_collector->apt_cutoff = jent_apt_cutoff_lookup[osr-1];
 	}
 
 	if (jent_fips_enabled() || (flags & JENT_FORCE_FIPS))

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -142,7 +142,6 @@ static void jent_apt_insert(struct rand_data *ec, uint64_t current_delta)
 		return;
 	}
 
-
 	if (current_delta == ec->apt_base) {
 		ec->apt_count++;
 
@@ -1277,7 +1276,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	int count_stuck = 0;
 	int ret = 0;
 	struct rand_data ec;
-
 
 	memset(&ec, 0, sizeof(ec));
 

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -115,7 +115,7 @@
  * (by FIPS 140-2 IG 7.19 Resolution # 16, we cannot choose a cutoff value that renders the
  * test unable to fail)
  */
-static const unsigned int jent_apt_cutoff_lookup[14]={324, 421, 458, 476, 487, 493, 498, 501, 504, 506, 507, 508, 509, 510};
+static const unsigned int jent_apt_cutoff_lookup[15]={324, 421, 458, 476, 487, 493, 498, 501, 504, 506, 507, 508, 509, 510, 511};
 
 /* The entropy pool */
 struct rand_data

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -115,7 +115,7 @@
  * (by FIPS 140-2 IG 7.19 Resolution # 16, we cannot choose a cutoff value that renders the
  * test unable to fail)
  */
-const unsigned int apt_cutoff_lookup[14]={324, 421, 458, 476, 487, 493, 498, 501, 504, 506, 507, 508, 509, 510};
+static const unsigned int jent_apt_cutoff_lookup[14]={324, 421, 458, 476, 487, 493, 498, 501, 504, 506, 507, 508, 509, 510};
 
 /* The entropy pool */
 struct rand_data

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -109,13 +109,11 @@
  * In in the syntax of R, this is C = 2 + qbinom(1 − 2^(−30), 511, 2^(-1/osr)).
  * (The original formula wasn't correct because the first symbol must necessarily
  * have been observed, so there is no chance of observing 0 of these symbols.)
- * This library doesn't count the first instance of the symbol, so we actually need
- * C = 1 + qbinom(1 − 2^(−30), 511, 2^(-1/osr)).
- * For any value above 14, this yields the maximal allowable value of 511
+ * For any value above 14, this yields the maximal allowable value of 512
  * (by FIPS 140-2 IG 7.19 Resolution # 16, we cannot choose a cutoff value that renders the
  * test unable to fail)
  */
-static const unsigned int jent_apt_cutoff_lookup[15]={324, 421, 458, 476, 487, 493, 498, 501, 504, 506, 507, 508, 509, 510, 511};
+static const unsigned int jent_apt_cutoff_lookup[15]={325, 422, 459, 477, 488, 494, 499, 502, 505, 507, 508, 509, 510, 511, 512};
 
 /* The entropy pool */
 struct rand_data
@@ -149,8 +147,8 @@ struct rand_data
 	unsigned int apt_cutoff; /* Calculated using a corrected version of the SP800-90B sec 4.4.2 formula*/
 #define JENT_APT_WINDOW_SIZE	512	/* Data window size */
 	/* LSB of time stamp to process */
-	unsigned int apt_observations;	/* Number of collected observations */
-	unsigned int apt_count;		/* APT counter */
+	unsigned int apt_observations;	/* Number of collected observations in the current window. */
+	unsigned int apt_count;		/* The number of  times the reference symbol been encounted in the window. */
 	uint64_t apt_base;		/* APT base reference */
 	unsigned int apt_base_set:1;	/* APT base reference set? */
 


### PR DESCRIPTION
The existing RCT and APT cutoffs weren’t calculated correctly; the RCT was rounded incorrectly (the cutoff should have been `30*osr` not `31*osr` for the targeted alpha value), and the prior APT cutoff didn’t account for a difference in the meaning of `apt_count` in this library (which would have required `JENT_APT_CUTOFF==324`) vs `B` in 90B (which would have required `C=325`). 

Additionally, the library generally assumes a min entropy lower bound entropy of 1/osr, but the APT cutoff was fixed and based on the old assumption of 1 bit of min entropy per raw sample (the estimate has since been reduced to 1/3 by default). This pull request makes the cutoff dependent on the choice of osr (and thus the presumed entropy level), which is consistent with how the RCT cutoff is treated.

Finally, the APT test that was implemented wasn’t quite what was specified in 90B (due to reuse of the last symbol of a window as the first symbol of the next window). I doubt this difference had any real impact, but it does impact SP 800-90B validation.

Resolves #45.
Resolves #46.