### PR TITLE
A Lag Predictor based health test

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -165,7 +165,8 @@ static void jent_lag_insert(struct rand_data *ec, uint64_t current_delta)
 		if(ec->lag_delta_history[(ec->lag_observations - i - 1)&JENT_LAG_MASK] == current_delta) {
 			/*The ith predictor (which guesses i+1 symbols in the past) successfully guessed.*/
 			ec->lag_scoreboard[i] ++;
-			if(ec->lag_scoreboard[i] >= ec->lag_scoreboard[ec->lag_best_predictor])
+			//Keep track of the best predictor (tie goes to the shortest lag)
+			if(ec->lag_scoreboard[i] > ec->lag_scoreboard[ec->lag_best_predictor])
 				ec->lag_best_predictor = i;
 		}
 	}
@@ -174,8 +175,7 @@ static void jent_lag_insert(struct rand_data *ec, uint64_t current_delta)
 	ec->lag_delta_history[(ec->lag_observations) & JENT_LAG_MASK] = current_delta;
 	ec->lag_observations++;
 
-	/* lag_best_predictor now is the index of the predictor with the largest number of correct guesses
-	 * (tie goes to the larger predictor)
+	/* lag_best_predictor now is the index of the predictor with the largest number of correct guesses.
 	 * This establishes our next guess.
 	 */
 

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -184,6 +184,19 @@ static void jent_lag_insert(struct rand_data *ec, uint64_t current_delta)
 		jent_lag_reset(ec);
 }
 
+/**
+ * Return a prior delta value using the lag test's history.
+ *
+ * @ec [in] Reference to entropy collector
+ * @back [in] The number of elements back in history (0 is the prior element)
+ *
+ * @return
+ * 	The prior delta value (if there was a prior value) or 0 otherwise.
+ */
+static uint64_t jent_last_delta(struct rand_data *ec, unsigned int back)
+{
+	return ec->lag_delta_history[(ec->lag_observations - back - 1)&JENT_LAG_MASK];
+}
 
 /***************************************************************************
  * Adaptive Proportion Test
@@ -327,11 +340,12 @@ static inline uint64_t jent_delta(uint64_t prev, uint64_t next)
  */
 static unsigned int jent_stuck(struct rand_data *ec, uint64_t current_delta)
 {
-	uint64_t delta2 = jent_delta(ec->last_delta, current_delta);
-	uint64_t delta3 = jent_delta(ec->last_delta2, delta2);
-
-	ec->last_delta = current_delta;
-	ec->last_delta2 = delta2;
+	/* Note that delta2_n = delta_n - delta_{n-1} */
+	uint64_t delta2 = jent_delta(jent_last_delta(ec, 0U), current_delta);
+	/* Note that delta3_n = delta2_n - delta2_{n-1}
+	 *                    = delta2_n - (delta_{n-1} - delta_{n-2})
+	 */
+	uint64_t delta3 = jent_delta(jent_delta(jent_last_delta(ec, 1U), jent_last_delta(ec, 0U)), delta2);
 
 	/*
 	 * Insert the result of the comparison of two back-to-back time
@@ -1386,28 +1400,27 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	 * following sanity checks verify that we have a high-resolution
 	 * timer.
 	 */
+	/* To initialize the prior time. */
+	jent_measure_jitter(&ec, 0, NULL);
 
 #define CLEARCACHE 100
 	for (i = 0; (JENT_POWERUP_TESTLOOPCOUNT + CLEARCACHE) > i; i++) {
-		uint64_t time = 0;
-		uint64_t time2 = 0;
+		uint64_t prior_time = 0;
+		uint64_t current_time = 0;
 		uint64_t delta = 0;
 		unsigned int lowdelta = 0;
 		unsigned int stuck;
 
 		/* Invoke core entropy collection logic */
-		jent_get_nstime_internal(&ec, &time);
-		ec.prev_time = time;
-		jent_memaccess(&ec, 0);
-		jent_hash_time(&ec, time, 0, 0);
-		jent_get_nstime_internal(&ec, &time2);
+		stuck = jent_measure_jitter(&ec, 0, &delta);
+		prior_time = ec.prev_time - delta;
+		current_time = ec.prev_time;
 
 		/* test whether timer works */
-		if (!time || !time2) {
+		if (!current_time || !current_time) {
 			ret = ENOTIME;
 			goto out;
 		}
-		delta = jent_delta(time, time2);
 		/*
 		 * test whether timer is fine grained enough to provide
 		 * delta even when called shortly after each other -- this
@@ -1417,8 +1430,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 			ret = ECOARSETIME;
 			goto out;
 		}
-
-		stuck = jent_stuck(&ec, delta);
 
 		/*
 		 * up to here we did not modify any variable that will be
@@ -1461,11 +1472,11 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 		}
 
 		/* test whether we have an increasing timer */
-		if (!(time2 > time))
+		if (!(current_time > prior_time))
 			time_backwards++;
 
 		/* use 32 bit value to ensure compilation on 32 bit arches */
-		lowdelta = (unsigned int)(time2 - time);
+		lowdelta = (unsigned int)(current_time - prior_time);
 		if (!(lowdelta % 100))
 			count_mod++;
 

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1382,6 +1382,10 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	if (jent_fips_enabled())
 		ec.fips_enabled = 1;
 
+	/* Setup the cutoff for the Lag test. */
+	ec.lag_global_cutoff = jent_lag_global_cutoff_lookup[JENT_MIN_OSR - 1];
+	ec.lag_local_cutoff = jent_lag_local_cutoff_lookup[JENT_MIN_OSR - 1];
+
 	/* We could perform statistical tests here, but the problem is
 	 * that we only have a few loop counts to do testing. These
 	 * loop counts may show some slight skew and we produce

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1300,6 +1300,7 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 	entropy_collector->osr = osr;
 
 
+	/* Establish the lag global and local cutoffs based on the presumed entropy rate of 1/osr. */
 	if(osr >= ARRAY_SIZE(jent_lag_global_cutoff_lookup)) {
 		entropy_collector->lag_global_cutoff = jent_lag_global_cutoff_lookup[ARRAY_SIZE(jent_lag_global_cutoff_lookup)-1];
 		entropy_collector->lag_local_cutoff = jent_lag_local_cutoff_lookup[ARRAY_SIZE(jent_lag_local_cutoff_lookup)-1];

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1400,27 +1400,28 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	 * following sanity checks verify that we have a high-resolution
 	 * timer.
 	 */
-	/* To initialize the prior time. */
-	jent_measure_jitter(&ec, 0, NULL);
 
 #define CLEARCACHE 100
 	for (i = 0; (JENT_POWERUP_TESTLOOPCOUNT + CLEARCACHE) > i; i++) {
-		uint64_t prior_time = 0;
-		uint64_t current_time = 0;
+		uint64_t time = 0;
+		uint64_t time2 = 0;
 		uint64_t delta = 0;
 		unsigned int lowdelta = 0;
 		unsigned int stuck;
 
 		/* Invoke core entropy collection logic */
-		stuck = jent_measure_jitter(&ec, 0, &delta);
-		prior_time = ec.prev_time - delta;
-		current_time = ec.prev_time;
+		jent_get_nstime_internal(&ec, &time);
+		ec.prev_time = time;
+		jent_memaccess(&ec, 0);
+		jent_hash_time(&ec, time, 0, 0);
+		jent_get_nstime_internal(&ec, &time2);
 
 		/* test whether timer works */
-		if (!current_time || !current_time) {
+		if (!time || !time2) {
 			ret = ENOTIME;
 			goto out;
 		}
+		delta = jent_delta(time, time2);
 		/*
 		 * test whether timer is fine grained enough to provide
 		 * delta even when called shortly after each other -- this
@@ -1430,6 +1431,8 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 			ret = ECOARSETIME;
 			goto out;
 		}
+
+		stuck = jent_stuck(&ec, delta);
 
 		/*
 		 * up to here we did not modify any variable that will be
@@ -1472,11 +1475,11 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 		}
 
 		/* test whether we have an increasing timer */
-		if (!(current_time > prior_time))
+		if (!(time2 > time))
 			time_backwards++;
 
 		/* use 32 bit value to ensure compilation on 32 bit arches */
-		lowdelta = (unsigned int)(current_time - prior_time);
+		lowdelta = (unsigned int)(time2 - time);
 		if (!(lowdelta % 100))
 			count_mod++;
 

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1299,7 +1299,6 @@ struct rand_data *jent_entropy_collector_alloc(unsigned int osr,
 		osr = JENT_MIN_OSR;
 	entropy_collector->osr = osr;
 
-
 	/* Establish the lag global and local cutoffs based on the presumed entropy rate of 1/osr. */
 	if(osr >= ARRAY_SIZE(jent_lag_global_cutoff_lookup)) {
 		entropy_collector->lag_global_cutoff = jent_lag_global_cutoff_lookup[ARRAY_SIZE(jent_lag_global_cutoff_lookup)-1];

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -137,8 +137,6 @@ struct rand_data
 	uint8_t data[SHA3_256_SIZE_DIGEST]; /* SENSITIVE Actual random number */
 	uint64_t prev_time;		/* SENSITIVE Previous time stamp */
 #define DATA_SIZE_BITS (SHA3_256_SIZE_DIGEST_BITS)
-	uint64_t last_delta;		/* SENSITIVE stuck test */
-	uint64_t last_delta2;		/* SENSITIVE stuck test */
 	unsigned int osr;		/* Oversampling rate */
 #define JENT_MEMORY_BLOCKS 64
 #define JENT_MEMORY_BLOCKSIZE 32
@@ -160,7 +158,7 @@ struct rand_data
 	unsigned int lag_best_predictor; /* The currently selected predictor lag (-1). */
 	unsigned int lag_observations; /* The total number of collected observations since the health test was last reset. */
 #define JENT_LAG_WINDOW_SIZE (1U<<17) /* This is the size of the window used by the predictor. The predictor is reset between windows. */
-#define JENT_LAG_HISTORY_SIZE 8 /*The amount of history to base predictions on. This must be a power of 2.*/
+#define JENT_LAG_HISTORY_SIZE 8 /*The amount of history to base predictions on. This must be a power of 2. Must be 4 or greater.*/
 #define JENT_LAG_MASK (JENT_LAG_HISTORY_SIZE - 1)
 	uint64_t lag_delta_history[JENT_LAG_HISTORY_SIZE]; /*The delta history for the lag predictor. */
 	unsigned int lag_scoreboard[JENT_LAG_HISTORY_SIZE]; /* The scoreboard that tracks how successful each predictor lag is. */

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -105,22 +105,27 @@
 #define ENTROPY_SAFETY_FACTOR		64
 
 /*
- * These cutoffs are configured using an entropy estimate of 1/osr under an alpha value
- * of 2^(-30) for a window size of 50000.
+ * These cutoffs are configured using an entropy estimate of 1/osr under an alpha=2^(-24) 
+ * for a window size of 50000. The other health tests use alpha=2^-30, but operate
+ * on much smaller block sizes, so this larger selection of alpha makes the behavior
+ * per 50,000 sample blocks similar.
+ *
  * The global cutoffs are calculated using the 
  * InverseBinomialCDF(n=(JENT_LAG_WINDOW_SIZE-JENT_LAG_HISTORY_SIZE), p=2^(-1/osr); 1-alpha)
+ *
  * The local cutoffs are somewhat more complicated. For background, see Feller's 
  * _Introduction to Probability Theory and It's Applications_ Vol. 1, Chapter 13, section 7 
  * (in particular see equation 7.11, where x is a root of the denominator of equation 7.6).
  * We'll proceed using the notation of SP 800-90B Section 6.3.8 (which is developed in
  * Kelsey-McKay-Turan paper "Predictive Models for Min-entropy Estimation".)
- * Here, we set p=2^(-1/osr), seeking probability of less than (1-2^(-30)) 
- * (that is, there is a very very large probability that there is _no_ run of length r).
+ * Here, we set p=2^(-1/osr), seeking probability of less than (1-alpha) 
+ * (that is, there is a very very large probability that there is _no_ run of 
+ * length r).
  * 
- * We have to iteratively look for an appropriate value for r.
+ * We have to iteratively look for an appropriate value for the cutoff r.
  */
-static const unsigned int jent_lag_global_cutoff_lookup[20] = {25607, 35873, 40123, 42424, 43862, 44845, 45558, 46098, 46522, 46863, 47143, 47377, 47575, 47745, 47893, 48023, 48137, 48238, 48329, 48411};
-static const unsigned int jent_lag_local_cutoff_lookup[20] = {45, 88, 130, 172, 214, 255, 296, 337, 377, 417, 458, 498, 538, 577, 617, 657, 696, 736, 775, 815};
+static const unsigned int jent_lag_global_cutoff_lookup[20] = {25527, 35801, 40059, 42367, 43810, 44796, 45512, 46055, 46481, 46824, 47105, 47341, 47541, 47712, 47861, 47992, 48107, 48209, 48301, 48383};
+static const unsigned int jent_lag_local_cutoff_lookup[20] = {39, 76, 112, 148, 184, 219, 254, 289, 323, 357, 392, 426, 460, 494, 527, 561, 595, 628, 661, 695};
 
 /* The entropy pool */
 struct rand_data

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -105,8 +105,8 @@
 #define ENTROPY_SAFETY_FACTOR		64
 
 /*
- * These cutoffs are configured using an entropy estimate of 1/osr under an alpha=2^(-25)
- * for a window size of 16384. The other health tests use alpha=2^-30, but operate
+ * These cutoffs are configured using an entropy estimate of 1/osr under an alpha=2^(-22)
+ * for a window size of 131072. The other health tests use alpha=2^-30, but operate
  * on much smaller window sizes. This larger selection of alpha makes the behavior
  * per-lag-window similar to the APT test.
  *
@@ -124,8 +124,8 @@
  *
  * We have to iteratively look for an appropriate value for the cutoff r.
  */
-static const unsigned int jent_lag_global_cutoff_lookup[20] = {8473, 11807, 13179, 13919, 14380, 14694, 14921, 15093, 15228, 15336, 15424, 15498, 15561, 15615, 15661, 15702, 15737, 15769, 15798, 15823};
-static const unsigned int jent_lag_local_cutoff_lookup[20] = {38, 75, 111, 146, 181, 215, 249, 283, 317, 351, 385, 418, 451, 485, 518, 551, 583, 616, 649, 682};
+static const unsigned int jent_lag_global_cutoff_lookup[20] = {66443, 93504, 104761, 110875, 114707, 117330, 119237, 120686, 121823, 122739, 123493, 124124, 124660, 125120, 125520, 125871, 126181, 126457, 126704, 126926};
+static const unsigned int jent_lag_local_cutoff_lookup[20] = {38, 75, 111, 146, 181, 215, 250, 284, 318, 351, 385, 419, 452, 485, 518, 551, 584, 617, 650, 683};
 
 /* The entropy pool */
 struct rand_data
@@ -159,8 +159,8 @@ struct rand_data
 	unsigned int lag_prediction_success_run; /* The size of the current run of successes. Compared to the local cutoff. */
 	unsigned int lag_best_predictor; /* The currently selected predictor lag (-1). */
 	unsigned int lag_observations; /* The total number of collected observations since the health test was last reset. */
-#define JENT_LAG_WINDOW_SIZE 16384 /* This is the size of the window used by the predictor. The predictor is reset between windows. */
-#define JENT_LAG_HISTORY_SIZE 128 /*The amount of history to base predictions on. This must be a power of 2.*/
+#define JENT_LAG_WINDOW_SIZE (1U<<17) /* This is the size of the window used by the predictor. The predictor is reset between windows. */
+#define JENT_LAG_HISTORY_SIZE 8 /*The amount of history to base predictions on. This must be a power of 2.*/
 #define JENT_LAG_MASK (JENT_LAG_HISTORY_SIZE - 1)
 	uint64_t lag_delta_history[JENT_LAG_HISTORY_SIZE]; /*The delta history for the lag predictor. */
 	unsigned int lag_scoreboard[JENT_LAG_HISTORY_SIZE]; /* The scoreboard that tracks how successful each predictor lag is. */

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -99,11 +99,25 @@
  * The value "64" is justified in Appendix A.4 of the current 90C draft,
  * and aligns with NIST's in "epsilon" definition in this document, which is
  * that a string can be considered "full entropy" if you can bound the min
- * entropy in each bit of output to at least 1-epsilson, where epsilon is
+ * entropy in each bit of output to at least 1-epsilon, where epsilon is
  * required to be <= 2^(-32).
  */
 #define ENTROPY_SAFETY_FACTOR		64
 
+/*
+ * These cutoffs are configured using an entropy estimate of 1/osr under an alpha value
+ * of 2^(-30) for a window size of 50000.
+ * The global cutoffs are calculated using the InverseBinomialCDF(n=50,000-256, p=2^(-1/osr); 1-2^(-30))
+ * The local cutoffs are somewhat more complicated. For background, see Feller's 
+ * _Introduction to Probability Theory and It's Applications_ Vol. 1, Chapter 13, section 7 
+ * (in particular see equation 7.11, where x is a root of the denominator of equation 7.6).
+ * We'll proceed using the notation of SP 800-90B Section 6.3.8 (which is developed in
+ * Kelsey-McKay-Turan paper "Predictive Models for Min-entropy Estimation".)
+ * Here, we set p=2^(-1/osr), seeking probability of less than (1-2^(-30)) 
+ * (that is, there is a very very large probability that there is _no_ run of length r).
+ * 
+ * We have to iteratively look for an appropriate value for r.
+ */
 static const unsigned int jent_lag_global_cutoff_lookup[20] = {25542, 35782, 40021, 42316, 43750, 44730, 45441, 45980, 46403, 46743, 47022, 47255, 47453, 47623, 47771, 47900, 48014, 48115, 48206, 48287};
 static const unsigned int jent_lag_local_cutoff_lookup[20] = {45, 88, 130, 172, 214, 255, 296, 337, 377, 417, 458, 498, 538, 577, 617, 657, 696, 736, 775, 815};
 
@@ -132,20 +146,18 @@ struct rand_data
 	unsigned int memaccessloops;	/* Number of memory accesses per random
 					 * bit generation */
 
-	/*Lag predictor test to look for reoccuring patterns.*/
-	unsigned int lag_global_cutoff;
-	unsigned int lag_local_cutoff;
-	unsigned int lag_prediction_success_count;
-	unsigned int lag_prediction_success_run;
-	unsigned int lag_prediction_success_run_max;
-	unsigned int lag_best_predictor;
-	unsigned int lag_observations;
-/*This must be a power of 2.*/
-#define JENT_LAG_WINDOW_SIZE 50000
-#define JENT_LAG_HISTORY_SIZE 128
+	/*Lag predictor test to look for reoccurring patterns.*/
+	unsigned int lag_global_cutoff;	/* The lag global cutoff selected based on the selection of osr. */
+	unsigned int lag_local_cutoff; /* The lag local cutoff selected based on the selection of osr. */
+	unsigned int lag_prediction_success_count; /* The number of times the lag predictor was correct. Compared to the global cutoff. */
+	unsigned int lag_prediction_success_run; /* The size of the current run of successes. Compared to the local cutoff. */
+	unsigned int lag_best_predictor; /* The currently selected predictor lag (-1). */
+	unsigned int lag_observations; /* The total number of collected observations since the health test was last reset. */
+#define JENT_LAG_WINDOW_SIZE 50000 /* This is the size of the window used by the predictor. The predictor is reset between windows. */
+#define JENT_LAG_HISTORY_SIZE 128 /*The amount of history to base predictions on. This must be a power of 2.*/
 #define JENT_LAG_MASK (JENT_LAG_HISTORY_SIZE - 1)
-	uint64_t lag_delta_history[JENT_LAG_HISTORY_SIZE];
-	unsigned int lag_scoreboard[JENT_LAG_HISTORY_SIZE];
+	uint64_t lag_delta_history[JENT_LAG_HISTORY_SIZE]; /*The delta history for the lag predictor. */
+	unsigned int lag_scoreboard[JENT_LAG_HISTORY_SIZE]; /* The scoreboard that tracks how successful each predictor lag is. */
 
 	/* Repetition Count Test */
 	int rct_count;			/* Number of stuck values */

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -107,7 +107,8 @@
 /*
  * These cutoffs are configured using an entropy estimate of 1/osr under an alpha value
  * of 2^(-30) for a window size of 50000.
- * The global cutoffs are calculated using the InverseBinomialCDF(n=50,000-256, p=2^(-1/osr); 1-2^(-30))
+ * The global cutoffs are calculated using the 
+ * InverseBinomialCDF(n=(JENT_LAG_WINDOW_SIZE-JENT_LAG_HISTORY_SIZE), p=2^(-1/osr); 1-alpha)
  * The local cutoffs are somewhat more complicated. For background, see Feller's 
  * _Introduction to Probability Theory and It's Applications_ Vol. 1, Chapter 13, section 7 
  * (in particular see equation 7.11, where x is a root of the denominator of equation 7.6).
@@ -118,7 +119,7 @@
  * 
  * We have to iteratively look for an appropriate value for r.
  */
-static const unsigned int jent_lag_global_cutoff_lookup[20] = {25542, 35782, 40021, 42316, 43750, 44730, 45441, 45980, 46403, 46743, 47022, 47255, 47453, 47623, 47771, 47900, 48014, 48115, 48206, 48287};
+static const unsigned int jent_lag_global_cutoff_lookup[20] = {25607, 35873, 40123, 42424, 43862, 44845, 45558, 46098, 46522, 46863, 47143, 47377, 47575, 47745, 47893, 48023, 48137, 48238, 48329, 48411};
 static const unsigned int jent_lag_local_cutoff_lookup[20] = {45, 88, 130, 172, 214, 255, 296, 337, 377, 417, 458, 498, 538, 577, 617, 657, 696, 736, 775, 815};
 
 /* The entropy pool */

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -104,6 +104,9 @@
  */
 #define ENTROPY_SAFETY_FACTOR		64
 
+static const unsigned int jent_lag_global_cutoff_lookup[20] = {25542, 35782, 40021, 42316, 43750, 44730, 45441, 45980, 46403, 46743, 47022, 47255, 47453, 47623, 47771, 47900, 48014, 48115, 48206, 48287};
+static const unsigned int jent_lag_local_cutoff_lookup[20] = {45, 88, 130, 172, 214, 255, 296, 337, 377, 417, 458, 498, 538, 577, 617, 657, 696, 736, 775, 815};
+
 /* The entropy pool */
 struct rand_data
 {
@@ -128,6 +131,21 @@ struct rand_data
 	unsigned int memblocksize; 	/* Size of one memory block in bytes */
 	unsigned int memaccessloops;	/* Number of memory accesses per random
 					 * bit generation */
+
+	/*Lag predictor test to look for reoccuring patterns.*/
+	unsigned int lag_global_cutoff;
+	unsigned int lag_local_cutoff;
+	unsigned int lag_prediction_success_count;
+	unsigned int lag_prediction_success_run;
+	unsigned int lag_prediction_success_run_max;
+	unsigned int lag_best_predictor;
+	unsigned int lag_observations;
+/*This must be a power of 2.*/
+#define JENT_LAG_WINDOW_SIZE 50000
+#define JENT_LAG_HISTORY_SIZE 128
+#define JENT_LAG_MASK (JENT_LAG_HISTORY_SIZE - 1)
+	uint64_t lag_delta_history[JENT_LAG_HISTORY_SIZE];
+	unsigned int lag_scoreboard[JENT_LAG_HISTORY_SIZE];
 
 	/* Repetition Count Test */
 	int rct_count;			/* Number of stuck values */


### PR DESCRIPTION
In the investigation of issue #21, it became clear that under certain circumstances (in that case, when the optimizer was turned on) long repeating sequences could come to dominate the entropy assessment of the source. In response to this observation, the optimizer was disabled (in commit 20184e97af8f227cc0787c4155ff4f3b2b7f1fe3), which resolved this issue for the specific platforms where the problem was first reported. I think this type of failure might reoccur on other platforms and should be viewed as an observed failure mode. In terms of SP 800-90B, that suggests that the library should have some sort of health test that detects this failure mode.

If we examine the entropy estimates produced by the SP 800-90B tests while the entropy source is in one of these failure modes, we find that the MultiMMC Predictor, LZ78Y Predictor, t-tuple, and Lag Predictor estimators showed unusually low assessments. The MultiMMC Predictor, LZ78Y Predictor, and t-tuple estimators don't lend themselves to adaption to an online health test, but the Lag Predictor health test is amenable to this use.

This pull request provides an implementation of a variant of the Lag Predictor estimator (SP 800-90B Section 6.3.8) as a health test. It includes cutoffs targeted for the level of significance (alpha) used in the other health tests. Much like the Lag Prediction Estimator from SP 800-90B, this health test looks for both global predictability (successfully predicting more symbols than expected, given an assumed entropy level of `1/osr`) and local predictability (the presence of runs of successful predictions longer than would be expected, again given the assumed entropy level of `1/osr`). Either type of predictability triggers a health test failure.

~~I'm putting this here mainly to spark discussion on the possible need for such a test, appropriate approaches to detecting this failure mode, and what level of significance is appropriate for this test.~~

I think that this PR is appropriate for merging at this point.

As a side observation, increasing the depth of the predictor (`JENT_LAG_HISTORY_SIZE`) seems to lead to worse (rather than better) predictions; if this test didn't perturb the noise source at all, this could not happen (unless, of course, I've made some sort of implementation error; testing seems to indicate that everything seems to be working). It seems that this may instead be a consequence of increased  churn in the RAM cache for larger history depth, so increasing the depth of the predictor has the side effect of making the system less predictable.

I'm very interested in any questions or comments on this pull request.

Resolves #47.