### PR TITLE
[SP 800-90B] Start-up health test fix

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1259,7 +1259,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	int i;
 	uint64_t delta_sum = 0;
 	uint64_t old_delta = 0;
-	unsigned int nonstuck = 0;
 	int time_backwards = 0;
 	int count_mod = 0;
 	int count_stuck = 0;
@@ -1342,8 +1341,6 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 
 		if (stuck)
 			count_stuck++;
-		else 
-			nonstuck++;
 
 		/* Validate RCT */
 		if (jent_rct_failure(&ec)) {


### PR DESCRIPTION
Use the noise source (`jent_measure_jitter`) within `jent_time_entropy_init` so that the start-up health tests clearly use output from the noise source.

Absent this change (or some other change where `jent_measure_jitter` is used within `jent_time_entropy_init`) it isn't really clear that the functionality in `jent_time_entropy_input` can be treated as start-up health tests, rending the library non-SP 800-90B compliant.