### PR TITLE
Processdata.sh fails for some values of $RESULTS_DIR

### DIFF
--- a/tests/raw-entropy/validation-restart/processdata.sh
+++ b/tests/raw-entropy/validation-restart/processdata.sh
@@ -146,7 +146,7 @@ do
 
 		for bits in $bits_list
 		do
-			outfile=$RESULTS_DIR/${filepath}.minentropy_${mask}_${bits}bits.single.txt
+			outfile=${filepath}.minentropy_${mask}_${bits}bits.single.txt
 			inprocess_file=$outfile
 			if [ ! -f $outfile ]
 			then
@@ -156,7 +156,7 @@ do
 				echo "File $outfile already generated"
 			fi
 
-			outfile=$RESULTS_DIR/${filepath}.minentropy_${mask}_${bits}bits.var.txt
+			outfile=${filepath}.minentropy_${mask}_${bits}bits.var.txt
 			inprocess_file=$outfile
 			if [ ! -f $outfile ]
 			then

--- a/tests/raw-entropy/validation-runtime/processdata.sh
+++ b/tests/raw-entropy/validation-runtime/processdata.sh
@@ -124,7 +124,7 @@ do
 
 		for bits in $bits_list
 		do	
-			outfile=$RESULTS_DIR/${filepath}.minentropy_${mask}_${bits}bits.single.txt
+			outfile=${filepath}.minentropy_${mask}_${bits}bits.single.txt
 			inprocess_file=$outfile
 			if [ ! -f $outfile ]
 			then
@@ -135,7 +135,7 @@ do
 				echo "File $outfile already generated"
 			fi
 
-			outfile=$RESULTS_DIR/${filepath}.minentropy_${mask}_${bits}bits.var.txt
+			outfile=${filepath}.minentropy_${mask}_${bits}bits.var.txt
 			inprocess_file=$outfile
 			if [ ! -f $outfile ]
 			then


### PR DESCRIPTION
There is a bug in both processdata.sh scripts where for some values of
$RESULTS_DIR the $outfile is calculated wrong. There are four
instances of this error.

In most cases, $filepath is already a full path, so it is wrong to prepend
$RESULTS_DIR to it.  This happens to work with some relative paths, but
doesn't work for most relative or absolute paths.

Note: there is a case in validate-runtime/processdata.sh where $filepath
is only the base name (line 160). In that case, $filepath is not an accurate
variable name.  I did not fix that case.