### PR TITLE
Proposed changes to the lag branch

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -1648,16 +1648,14 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	int i, time_backwards = 0, count_stuck = 0, ret = 0;
 	unsigned int health_test_result;
 
+	if((delta_history = jent_gcd_init(JENT_POWERUP_TESTLOOPCOUNT))==NULL) {
+		return EMEM;
+	}
+
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 	if (enable_notime)
 		jent_force_internal_timer = 1;
 #endif
-
-	delta_history = jent_gcd_init(JENT_POWERUP_TESTLOOPCOUNT);
-	/*
-	 * No check whether allocation succeeds - it is legitimate to have NULL
-	 * here.
-	 */
 
 	/*
 	 * If the start-up health tests (including the APT and RCT) are not
@@ -1739,7 +1737,7 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 			time_backwards++;
 
 		/* Watch for common adjacent GCD values */
-		jent_gcd_add_value(delta_history, delta, i);
+		delta_history[i] = delta;
 	}
 
 	/* First, did we encounter a health test failure? */

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -518,7 +518,7 @@ static unsigned int jent_stuck(struct rand_data *ec, uint64_t current_delta)
  *
  * @ec [in] Reference to entropy collector
  *
- * @return a bitbask indicating which tests failed
+ * @return a bitmask indicating which tests failed
  * 	0 No health test failure
  * 	1 RCT failure
  * 	2 APT failure

--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -208,7 +208,7 @@ static void jent_lag_reset(struct rand_data *ec)
 	 JENT_LAG_MASK])
 
 /**
- * Insert a new entropy event into APT
+ * Insert a new entropy event into the lag predictor test
  *
  * @ec [in] Reference to entropy collector
  * @current_delta [in] Current time delta
@@ -238,7 +238,7 @@ static void jent_lag_insert(struct rand_data *ec, uint64_t current_delta)
 
 		if ((ec->lag_prediction_success_run >= ec->lag_local_cutoff) ||
 		    (ec->lag_prediction_success_count >= ec->lag_global_cutoff))
-			ec->health_failure = 1;
+			ec->health_failure |= JENT_LAG_FAILURE;
 	} else {
 		/* The prediction wasn't correct. End any run of successes.*/
 		ec->lag_prediction_success_run = 0;
@@ -406,7 +406,7 @@ static void jent_apt_insert(struct rand_data *ec, uint64_t current_delta)
 
 		/* Note, ec->apt_count starts with one. */
 		if (ec->apt_count >= ec->apt_cutoff)
-			ec->health_failure = 1;
+			ec->health_failure |= JENT_APT_FAILURE;
 	}
 
 	ec->apt_observations++;
@@ -467,27 +467,11 @@ static void jent_rct_insert(struct rand_data *ec, int stuck)
 		 */
 		if ((unsigned int)ec->rct_count >= (30 * ec->osr)) {
 			ec->rct_count = -1;
-			ec->health_failure = 1;
+			ec->health_failure |= JENT_RCT_FAILURE;
 		}
 	} else {
 		ec->rct_count = 0;
 	}
-}
-
-/**
- * Is there an RCT health test failure?
- *
- * @ec [in] Reference to entropy collector
- *
- * @return
- * 	0 No health test failure
- * 	1 Permanent health test failure
- */
-static int jent_rct_failure(struct rand_data *ec)
-{
-	if (ec->rct_count < 0)
-		return 1;
-	return 0;
 }
 
 /**
@@ -534,11 +518,13 @@ static unsigned int jent_stuck(struct rand_data *ec, uint64_t current_delta)
  *
  * @ec [in] Reference to entropy collector
  *
- * @return
+ * @return a bitbask indicating which tests failed
  * 	0 No health test failure
- * 	1 Permanent health test failure
+ * 	1 RCT failure
+ * 	2 APT failure
+ * 	4 Lag predictor test failure
  */
-static int jent_health_failure(struct rand_data *ec)
+static unsigned int jent_health_failure(struct rand_data *ec)
 {
 	/* Test is only enabled in FIPS mode */
 	if (!ec->fips_enabled)
@@ -1470,6 +1456,7 @@ static void jent_random_data(struct rand_data *ec)
  *	-2	RCT failed
  *	-3	APT test failed
  *	-4	The timer cannot be initialized
+ *	-5	LAG failure
  */
 JENT_PRIVATE_STATIC
 ssize_t jent_read_entropy(struct rand_data *ec, char *data, size_t len)
@@ -1486,14 +1473,17 @@ ssize_t jent_read_entropy(struct rand_data *ec, char *data, size_t len)
 
 	while (len > 0) {
 		size_t tocopy;
+		unsigned int health_test_result;
 
 		jent_random_data(ec);
 
-		if (jent_health_failure(ec)) {
-			if (jent_rct_failure(ec))
+		if ((health_test_result = jent_health_failure(ec))) {
+			if (health_test_result & JENT_RCT_FAILURE)
 				ret = -2;
-			else
+			else if(health_test_result & JENT_APT_FAILURE)
 				ret = -3;
+			else
+				ret = -5;
 
 			goto err;
 		}
@@ -1586,7 +1576,11 @@ static struct rand_data
 	if (jent_fips_enabled() || (flags & JENT_FORCE_FIPS))
 		entropy_collector->fips_enabled = 1;
 
+	/* Initialize the APT */
 	jent_apt_init(entropy_collector, osr);
+
+	/* Initialize the Lag Predictor Test */
+	jent_lag_init(entropy_collector, osr);
 
 	/* Was jent_entropy_init run (establishing the common GCD)? */
 	if (jent_gcd_get(&entropy_collector->jent_common_timer_gcd)) {
@@ -1652,6 +1646,7 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	struct rand_data *ec;
 	uint64_t *delta_history;
 	int i, time_backwards = 0, count_stuck = 0, ret = 0;
+	unsigned int health_test_result;
 
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 	if (enable_notime)
@@ -1748,15 +1743,13 @@ static int jent_time_entropy_init(unsigned int enable_notime)
 	}
 
 	/* First, did we encounter a health test failure? */
-	/* Validate RCT */
-	if (jent_rct_failure(ec)) {
-		ret = ERCT;
-		goto out;
-	}
-
-	/* Ensure that the other health tests succeeded. */
-	if (jent_health_failure(ec)) {
-		ret = EHEALTH;
+	if ((health_test_result = jent_health_failure(ec))) {
+		/* Validate RCT */
+		if(health_test_result & JENT_RCT_FAILURE) {
+			ret = ERCT;
+		} else {
+			ret = EHEALTH;
+		}
 		goto out;
 	}
 

--- a/jitterentropy-gcd.c
+++ b/jitterentropy-gcd.c
@@ -129,9 +129,6 @@ uint64_t *jent_gcd_init(size_t nelem)
 	if (jent_gcd_tested())
 		return NULL;
 
-	if (jent_gcd_tested())
-		return NULL;
-
 	delta_history = jent_zalloc(nelem * sizeof(uint64_t));
 	if (!delta_history)
 		return NULL;

--- a/jitterentropy-gcd.c
+++ b/jitterentropy-gcd.c
@@ -146,6 +146,15 @@ void jent_gcd_fini(uint64_t *delta_history, size_t nelem)
 			   (unsigned int)(nelem * sizeof(uint64_t)));
 }
 
+/* This function forces the gcd to be recalculated the next time
+ * jent_entropy_init is called. This is used when simulating
+ * a "restart" in a software library.
+ */
+void jent_gcd_reset(void)
+{
+	jent_common_timer_gcd = 0;
+}
+
 int jent_gcd_get(uint64_t *value)
 {
 	if (!jent_gcd_tested())

--- a/jitterentropy-gcd.c
+++ b/jitterentropy-gcd.c
@@ -115,7 +115,8 @@ int jent_gcd_analyze(uint64_t *delta_history, size_t nelem)
 	}
 
 	/*  Adjust all deltas by the observed (small) common factor. */
-	jent_common_timer_gcd = running_gcd;
+	if (!jent_gcd_tested())
+		jent_common_timer_gcd = running_gcd;
 
 out:
 	return ret;
@@ -141,15 +142,6 @@ void jent_gcd_fini(uint64_t *delta_history, size_t nelem)
 	if (delta_history)
 		jent_zfree(delta_history,
 			   (unsigned int)(nelem * sizeof(uint64_t)));
-}
-
-/* This function forces the gcd to be recalculated the next time
- * jent_entropy_init is called. This is used when simulating
- * a "restart" in a software library.
- */
-void jent_gcd_reset(void)
-{
-	jent_common_timer_gcd = 0;
 }
 
 int jent_gcd_get(uint64_t *value)

--- a/jitterentropy-gcd.h
+++ b/jitterentropy-gcd.h
@@ -29,7 +29,6 @@ int jent_gcd_analyze(uint64_t *delta_history, size_t nelem);
 uint64_t *jent_gcd_init(size_t nelem);
 void jent_gcd_fini(uint64_t *delta_history, size_t nelem);
 int jent_gcd_get(uint64_t *value);
-void jent_gcd_reset(void);
 
 #ifdef __cplusplus
 }

--- a/jitterentropy-gcd.h
+++ b/jitterentropy-gcd.h
@@ -29,15 +29,7 @@ int jent_gcd_analyze(uint64_t *delta_history, size_t nelem);
 uint64_t *jent_gcd_init(size_t nelem);
 void jent_gcd_fini(uint64_t *delta_history, size_t nelem);
 int jent_gcd_get(uint64_t *value);
-
-static inline void jent_gcd_add_value(uint64_t *delta_history, uint64_t delta,
-				      int idx)
-{
-	/* Watch for common adjacent GCD values */
-	if (delta_history)
-		delta_history[idx] = delta;
-}
-
+void jent_gcd_reset(void);
 
 #ifdef __cplusplus
 }

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -83,7 +83,7 @@
 /*
  * Shall the LAG predictor health test be enabled?
  */
-#undef JENT_HEALTH_LAG_PREDICTOR
+#define JENT_HEALTH_LAG_PREDICTOR
 
 /***************************************************************************
  * Jitter RNG State Definition Section
@@ -199,10 +199,10 @@ struct rand_data
 					 * symbol been encountered in the
 					 * window. */
 	uint64_t apt_base;		/* APT base reference */
-	unsigned int apt_base_set:1;	/* APT base reference set? */
+	unsigned int health_failure;	/* Permanent health failure */
 
+	unsigned int apt_base_set:1;	/* APT base reference set? */
 	unsigned int fips_enabled:1;
-	unsigned int health_failure:1;	/* Permanent health failure */
 	unsigned int enable_notime:1;	/* Use internal high-res timer */
 
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
@@ -370,6 +370,11 @@ static inline void jent_notime_fini(void *ctx) { (void)ctx; }
 #define ERCT		10 /* RCT failed during initialization */
 #define EHASH		11 /* Hash self test failed */
 #define EMEM		12 /* Can't allocate memory for initialization */
+
+/* -- BEGIN error masks for health tests -- */
+#define JENT_RCT_FAILURE	1 /* Failure was in the RCT health test. */
+#define JENT_APT_FAILURE	2 /* Failure was in the RCT health test. */
+#define JENT_LAG_FAILURE	4 /* Failure was in the Lag predictor health test. */
 
 /* -- BEGIN statistical test functions only complied with CONFIG_CRYPTO_CPU_JITTERENTROPY_STAT -- */
 

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -61,6 +61,7 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	FILE *out = NULL;
 	uint64_t *duration, *duration_min;
 	int ret = 0;
+	unsigned int health_test_result;
 
 	duration = calloc(rounds, sizeof(uint64_t));
 	if (!duration)
@@ -124,6 +125,21 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	for (size = 0; size < rounds; size++)
 		fprintf(out, "%" PRIu64 " %" PRIu64 "\n", duration[size], duration_min[size]);
 
+	if((health_test_result = jent_health_failure(ec))) {
+		printf("The main context encountered the following health testing failure(s):");
+		if(health_test_result & JENT_RCT_FAILURE) printf(" RCT");
+		if(health_test_result & JENT_APT_FAILURE) printf(" APT");
+		if(health_test_result & JENT_LAG_FAILURE) printf(" Lag");
+		printf("\n");
+	}
+
+	if((health_test_result = jent_health_failure(ec_min))) {
+		printf("The minimum context encountered the following health testing failure(s):");
+		if(health_test_result & JENT_RCT_FAILURE) printf(" RCT");
+		if(health_test_result & JENT_APT_FAILURE) printf(" APT");
+		if(health_test_result & JENT_LAG_FAILURE) printf(" Lag");
+		printf("\n");
+	}
 out:
 	free(duration);
 	free(duration_min);

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -29,7 +29,7 @@
 #include "jitterentropy-base.c"
 
 #ifndef REPORT_COUNTER_TICKS
-#define REPORT_COUNTER_TICKS 0
+#define REPORT_COUNTER_TICKS 1
 #endif
 
 /***************************************************************************
@@ -85,7 +85,7 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 		goto out;
 	}
 
-	if(report_counter_ticks) {
+	if(!report_counter_ticks) {
 		/* For this analysis, we want the raw values, not values that have had common factors removed. */
 		ec->jent_common_timer_gcd = 1;
 		ec_min->jent_common_timer_gcd = 1;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -45,9 +45,6 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	int ret = 0;
 	unsigned int health_test_result;
 
-	/* Force the global gcd into its 'unset' state.*/
-	jent_gcd_reset();
-
 	duration = calloc(rounds, sizeof(uint64_t));
 	if (!duration)
 		return 1;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -25,36 +25,18 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "jitterentropy-gcd.h"
-
-int jent_gcd_analyze(uint64_t *delta_history, size_t nelem)
-{
-	(void)delta_history;
-	(void)nelem;
-	return 0;
-}
-
-uint64_t *jent_gcd_init(size_t nelem) { (void)nelem; return NULL; }
-
-void jent_gcd_fini(uint64_t *delta_history, size_t nelem)
-{
-	(void)delta_history;
-	(void)nelem;
-}
-
-int jent_gcd_get(uint64_t *value)
-{
-	*value = 1;
-	return 0;
-}
-
+#include "jitterentropy-gcd.c"
 #include "jitterentropy-base.c"
+
+#ifndef REPORT_COUNTER_TICKS
+#define REPORT_COUNTER_TICKS 0
+#endif
 
 /***************************************************************************
  * Statistical test logic not compiled for regular operation
  ***************************************************************************/
 static int jent_one_test(const char *pathname, unsigned long rounds,
-			 int notime)
+			 int notime, int report_counter_ticks)
 {
 	unsigned long size = 0;
 	struct rand_data *ec = NULL, *ec_min = NULL;
@@ -62,6 +44,9 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	uint64_t *duration, *duration_min;
 	int ret = 0;
 	unsigned int health_test_result;
+
+	/* Force the global gcd into its 'unset' state.*/
+	jent_gcd_reset();
 
 	duration = calloc(rounds, sizeof(uint64_t));
 	if (!duration)
@@ -98,6 +83,12 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	if (!ec_min) {
 		ret = 1;
 		goto out;
+	}
+
+	if(report_counter_ticks) {
+		/* For this analysis, we want the raw values, not values that have had common factors removed. */
+		ec->jent_common_timer_gcd = 1;
+		ec_min->jent_common_timer_gcd = 1;
 	}
 
 	if (notime) {
@@ -195,7 +186,7 @@ int main(int argc, char * argv[])
 		snprintf(pathname, sizeof(pathname), "%s-%.4lu.data", argv[3],
 			 i);
 
-		ret = jent_one_test(pathname, rounds, notime);
+		ret = jent_one_test(pathname, rounds, notime, REPORT_COUNTER_TICKS);
 
 		if (ret)
 			return ret;


### PR DESCRIPTION
This make the lag test enabled by default (at the cost of 104 bytes on systems with a 32-bit int), fixes the exiting lag test integration bug, and make the health test reporting a bit more granular.