### PR TITLE
Add a possibility to use hardware and OS timers and to choose between them

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -224,7 +224,14 @@ struct rand_data
 
 	unsigned int apt_base_set:1;	/* APT base reference set? */
 	unsigned int fips_enabled:1;
+
+	/* A timer type to use.
+	 * enable_hwtime == 1: a hardware timer is present and has passed checks
+	 * enable_hwtime == 0 && enable_notime == 0: use an OS timer
+	 * enable_hwtime == 0 && enable_notime == 1: use an internal busy-loop
+	 * timer */
 	unsigned int enable_notime:1;	/* Use internal high-res timer */
+	unsigned int enable_hwtime:1;	/* Use hardware high-res timer */
 
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 	volatile uint8_t notime_interrupt;	/* indicator to interrupt ctr */
@@ -302,6 +309,9 @@ struct rand_data
 #define JENT_FORCE_FIPS (1<<5)		  /* Force FIPS compliant mode
 					     including full SP800-90B
 					     compliance. */
+#define JENT_FORCE_HARDWARE_TIMER (1<<6)  /* Force the use of the hardware
+					     timer */
+#define JENT_FORCE_OS_CLOCK_TIMER (1<<7)  /* Force the use of the OS timer. */
 
 #ifdef JENT_CONF_DISABLE_LOOP_SHUFFLE
 # define JENT_MIN_OSR	3

--- a/src/jitterentropy-timer.h
+++ b/src/jitterentropy-timer.h
@@ -53,8 +53,14 @@ static inline void jent_notime_unsettick(struct rand_data *ec) { (void)ec; }
 
 static inline void jent_get_nstime_internal(struct rand_data *ec, uint64_t *out)
 {
-	(void)ec;
-	jent_get_nstime(out);
+	if (ec->enable_hwtime) {
+		jent_get_hwtime(out);
+	} else if (!ec->enable_notime) {
+		jent_get_swtime(out);
+	} else {
+		/* No timer available */
+		*out = 0;
+	}
 }
 
 static inline int jent_notime_enable(struct rand_data *ec, unsigned int flags)


### PR DESCRIPTION
Hello, Stephan,

Would you mind possibly taking a look at the following patch? It is not 100%
complete yet, as changes to `arch/` files are still to be made. But I would like
to understand if this approach is acceptable in general before digging in details.

So, since v3.0 jitterentropy uses `RDTSC` on an x86_64 and `clock_gettime()`
on other arches unconditionally. This has led to a regression versus v2.2 in
a certain corner case where RDTSC timer does not pass certain health checks
like RCT and a system in question has only 1 CPU core.

This change suggests a possibility to support both hardware (`RDTSC` on
an x86_64, `MFTB` on Power, etc) and OS (`clock_gettime()`) timers and
also an ability to choose which timer to use. This patch also introduces a kind
of a framework to easily add more timer types.

In a short code, the core of the suggested change is:

```
int jent_entropy_init(void)
{
...
    if (jent_has_hwtime())
        ret = jent_time_entropy_init(JENT_TIMER_HARDWARE);

    if (ret)
        ret = jent_time_entropy_init(JENT_TIMER_OS_CLOCK);

#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
    if (ret)
        ret = jent_time_entropy_init(JENT_TIMER_INTERNAL);
#endif /* JENT_CONF_ENABLE_INTERNAL_TIMER */
```

Details and a research for a mentioned corner case are:
- [issues/37](https://github.com/smuellerDD/jitterentropy-library/issues/37#issuecomment-869570719)
- [rhbz1974132#c17](https://bugzilla.redhat.com/show_bug.cgi?id=1974132#c17)

Though it looks like the latest v3.1.0 changes (thank you!) have [eliminated](https://bugzilla.redhat.com/show_bug.cgi?id=1974132#c20) the
issue, I would still suggest this change, as we may have other corner cases.
Also it unifies, in a way, handling of timer sources.

Thank you!