### PR TITLE
Fix potentially overflowing expression

### DIFF
--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -46,7 +46,7 @@ static uint64_t jent_loop_shuffle(struct rand_data *ec,
 	(void)ec;
 	(void)bits;
 
-	return (1U<<min);
+	return (1UL<<min);
 
 #else /* JENT_CONF_DISABLE_LOOP_SHUFFLE */
 
@@ -77,7 +77,7 @@ static uint64_t jent_loop_shuffle(struct rand_data *ec,
 	 * We add a lower boundary value to ensure we have a minimum
 	 * RNG loop count.
 	 */
-	return (shuffle + (1U<<min));
+	return (shuffle + (1UL<<min));
 
 #endif /* JENT_CONF_DISABLE_LOOP_SHUFFLE */
 }


### PR DESCRIPTION
Fix potentially overflowing expression "1U << min" with type "unsigned int"
(32 bits, unsigned) which is evaluated using 32-bit arithmetic, and then used
in a context that expects an expression of type "uint64_t" (64 bits, unsigned).

This was reported by a covscan (Coverity Scan static analysis tool).

Signed-off-by: Vladis Dronov <vdronov@redhat.com>