### PR TITLE
Makefile: restore build reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LIBMINOR=$(shell cat $(SRCDIR)/jitterentropy-base.c | grep define | grep MINVERS
 LIBPATCH=$(shell cat $(SRCDIR)/jitterentropy-base.c | grep define | grep PATCHLEVEL | awk '{print $$3}')
 LIBVERSION := $(LIBMAJOR).$(LIBMINOR).$(LIBPATCH)
 
-C_SRCS := $(wildcard $(SRCDIR)/*.c) 
+C_SRCS := $(sort $(wildcard $(SRCDIR)/*.c))
 C_OBJS := ${C_SRCS:.c=.o}
 OBJS := $(C_OBJS)
 


### PR DESCRIPTION
wildcards result in an unpredictable order, and thus different binary outputs
in otherwise identical builds.

Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>