### PR TITLE
Fix an execution flow and an arguments order

### DIFF
--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -710,6 +710,8 @@ int jent_entropy_init_ex(unsigned int osr, unsigned int flags)
 	if (ret)
 		return ret;
 
+	ret = ENOTIME;
+
 	/* Test without internal timer unless caller does not want it */
 	if (!(flags & JENT_FORCE_INTERNAL_TIMER))
 		ret = jent_time_entropy_init(osr,

--- a/src/jitterentropy-timer.c
+++ b/src/jitterentropy-timer.c
@@ -202,8 +202,8 @@ int jent_notime_enable(struct rand_data *ec, unsigned int flags)
 	if (jent_force_internal_timer || (flags & JENT_FORCE_INTERNAL_TIMER)) {
 		/* Self test not run yet */
 		if (!jent_force_internal_timer &&
-		    jent_time_entropy_init(flags | JENT_FORCE_INTERNAL_TIMER,
-					   ec->osr))
+		    jent_time_entropy_init(ec->osr,
+					   flags | JENT_FORCE_INTERNAL_TIMER))
 			return EHEALTH;
 
 		ec->enable_notime = 1;


### PR DESCRIPTION
A value of `ret` is always 0 after the first `if (ret)` in
`jent_entropy_init_ex()`. This means `jent_time_entropy_init()`
in the third `if (ret && ...` is not called if
`JENT_FORCE_INTERNAL_TIMER` is set in `flags` and so
`ret = jent_time_entropy_init()` in the second `if` is skipped.
Fix this by assigning an initial non-zero value to `ret`.

Also fix an arguments ordering in `jent_notime_enable()`.

Signed-off-by: Vladis Dronov <vdronov@redhat.com>