### PR TITLE
Fix ec dereference before a NULL check

### DIFF
--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -188,7 +188,7 @@ static void jent_memaccess(struct rand_data *ec, uint64_t loop_cnt)
 		uint32_t u[4];
 		uint8_t b[sizeof(uint32_t) * 4];
 	} prngState = { .u = {0x8e93eec0, 0xce65608a, 0xa8d46b46, 0xe83cef69} };
-	uint32_t addressMask = ec->memmask;
+	uint32_t addressMask;
 
 	/* Ensure that macros cannot overflow jent_loop_shuffle() */
 	BUILD_BUG_ON((MAX_ACC_LOOP_BIT + MIN_ACC_LOOP_BIT) > 63);
@@ -197,6 +197,7 @@ static void jent_memaccess(struct rand_data *ec, uint64_t loop_cnt)
 
 	if (NULL == ec || NULL == ec->mem)
 		return;
+	addressMask = ec->memmask;
 
 	/*
 	 * Mix the current data into prngState


### PR DESCRIPTION
Move `addressMask` assignment after a check if `ec` is not
NULL, the same way it is done for `wrap` in the second
variant of `jent_memaccess()`.