### PR TITLE
Swap conditional order around FIPS flag

### DIFF
--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -437,7 +437,7 @@ static struct rand_data
 	entropy_collector->osr = osr;
 	entropy_collector->flags = flags;
 
-	if (jent_fips_enabled() || (flags & JENT_FORCE_FIPS))
+	if ((flags & JENT_FORCE_FIPS) || jent_fips_enabled())
 		entropy_collector->fips_enabled = 1;
 
 	/* Initialize the APT */


### PR DESCRIPTION
When `JENT_FORCE_FIPS` is specified by the caller, we can avoid the
relatively more expensive `jent_fips_enabled(...)` call, which typically
opens a file (`/proc/sys/crypto/fips_enabled`) and reads its value. When
specifying this flag without this patch, this dispatches at least two
calls to read this file -- once during initialization (such as via
`jent_entropy_init_ex(...)`), and once during collector allocation.

When incorporated into a project using syscall-based testing of random
(such as BoringCrypto), this results in excessive syscalls during
test suite execution.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

We already read the FIPS mode flag from BoringCrypto and thus would actually incur at least three reads to this file. Since we have the result, we should be able to simply pass the flag instead of repeatedly re-reading the file in the event of a FIPS mode system. :-)