### PR TITLE
Add minimal CMake config and improve windows MSVC support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(jitterentropy C)
+set(CMAKE_C_STANDARD 99)
+
+option(STACK_PROTECTOR "Compile Jitter with stack protector enabled" ON)
+option(INTERNAL_TIMER "Compile Jitter with the internal thread based timer" ON)
+option(EXTERNAL_CRYPTO "Compile Jitter and use an external libcrypto, valid options are [AWSLC, OPENSSL, LIBGCRYPT]")
+
+# CMake defines the variable MSVC to true automatically when building with MSVC, replicate that for other compilers
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set(CLANG 1)
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    set(GCC 1)
+endif()
+
+if(INTERNAL_TIMER)
+    list(APPEND JITTER_C_FLAGS -DJENT_CONF_ENABLE_INTERNAL_TIMER)
+endif()
+
+if(EXTERNAL_CRYPTO)
+    list(APPEND JITTER_C_FLAGS  -D${EXTERNAL_CRYPTO})
+endif()
+
+if(MSVC)
+    list(APPEND JITTER_C_FLAGS  /Od /W4 /DYNAMICBASE)
+    set(JITTER_LINK_FLAGS ${JITTER_LINK_FLAGS})
+else()
+    list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align
+    -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -fPIC -O0 -fwrapv -Wconversion)
+    list(APPEND JITTER_LINKER_FLAGS -Wl,-z,relro,-z,now)
+endif()
+
+if(STACK_PROTECTOR)
+    if(GCC)
+        if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.9.0")
+            list(APPEND JITTER_C_FLAGS -fstack-protector-strong)
+        else()
+            list(APPEND JITTER_C_FLAGS -fstack-protector-all)
+        endif()
+    elseif(CLANG)
+        list(APPEND JITTER_C_FLAGS -fstack-protector-strong)
+    endif()
+endif()
+
+file(GLOB JITTER_SRC "src/*.c")
+add_library(${PROJECT_NAME} ${JITTER_SRC})
+target_compile_options(${PROJECT_NAME} PRIVATE ${JITTER_C_FLAGS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${JITTER_LINKER_FLAGS})
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+
+if(EXTERNAL_CRYPTO STREQUAL "AWSLC")
+    # This header is unique from OpenSSL
+    set(EXTERNAL_CRYPTO_HEADER "openssl/base.h")
+    set(EXTERNAL_CRYPTO_LIBRARY_NAME libcrypto)
+elseif(EXTERNAL_CRYPTO STREQUAL "OPENSSL")
+    set(EXTERNAL_CRYPTO_HEADER "openssl/crypto.h")
+    set(EXTERNAL_CRYPTO_LIBRARY_NAME libcrypto)
+elseif(EXTERNAL_CRYPTO STREQUAL "LIBGCRYPT")
+    set(EXTERNAL_CRYPTO_HEADER "g10lib.h")
+    set(EXTERNAL_CRYPTO_LIBRARY_NAME libgcrypt)
+elseif(NOT EXTERNAL_CRYPTO)
+    message(STATUS "Using internal functions for everything")
+else()
+    message(FATAL_ERROR "Unknown EXTERNAL_CRYPTO option ${EXTERNAL_CRYPTO}")
+endif()
+
+if(EXTERNAL_CRYPTO)
+    find_path(LIBCRYPTO_INCLUDE_DIR
+            NAMES "${EXTERNAL_CRYPTO_HEADER}"
+            PATH_SUFFIXES include
+            )
+    message(STATUS "Found external crypto headers at ${LIBCRYPTO_INCLUDE_DIR}")
+    target_include_directories(${PROJECT_NAME} PUBLIC ${LIBCRYPTO_INCLUDE_DIR})
+    if(BUILD_SHARED_LIBS)
+        find_library(LIBCRYPTO_LIBRARY
+                NAMES "${EXTERNAL_CRYPTO_LIBRARY_NAME}.so" "${EXTERNAL_CRYPTO_LIBRARY_NAME}.dylib" "${EXTERNAL_CRYPTO_LIBRARY_NAME}.dll"
+                HINTS "${CMAKE_INSTALL_PREFIX}"
+                PATH_SUFFIXES build/crypto build lib64 lib
+                )
+    else()
+        find_library(LIBCRYPTO_LIBRARY
+                NAMES "${EXTERNAL_CRYPTO_LIBRARY_NAME}.so" "${EXTERNAL_CRYPTO_LIBRARY_NAME}.dylib" "${EXTERNAL_CRYPTO_LIBRARY_NAME}.dll"
+                HINTS "${CMAKE_INSTALL_PREFIX}"
+                PATH_SUFFIXES build/crypto build lib64 lib
+                )
+    endif()
+    message(STATUS "Found external crypto library ${LIBCRYPTO_LIBRARY}")
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBCRYPTO_LIBRARY})
+
+endif()
+
+if(INTERNAL_TIMER)
+    target_link_libraries(${PROJECT_NAME} PUBLIC pthread)
+endif()
+
+add_subdirectory(tests/gcd)
+add_subdirectory(tests/raw-entropy/recording_userspace)

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -49,7 +49,7 @@
  ***************************************************************************/
 
 /*
- * Enable timer-less timer support
+ * Enable timer-less timer support with JENT_CONF_ENABLE_INTERNAL_TIMER
  *
  * In case the hardware is identified to not provide a high-resolution time
  * stamp, this option enables a built-in high-resolution time stamp mechanism.
@@ -59,7 +59,6 @@
  * must offer POSIX threads. If this option is disabled, no linking
  * with the POSIX threads library is needed.
  */
-#define JENT_CONF_ENABLE_INTERNAL_TIMER
 
 /*
  * Disable the loop shuffle operation
@@ -95,7 +94,11 @@
  * Jitter RNG State Definition Section
  ***************************************************************************/
 
+#if defined(_MSC_VER)
+#include "arch/jitterentropy-base-x86-windows.h"
+#else
 #include "jitterentropy-base-user.h"
+#endif
 
 #define SHA3_256_SIZE_DIGEST_BITS	256
 #define SHA3_256_SIZE_DIGEST		(SHA3_256_SIZE_DIGEST_BITS >> 3)
@@ -355,7 +358,11 @@ struct rand_data
 #ifdef JENT_PRIVATE_COMPILE
 # define JENT_PRIVATE_STATIC static
 #else /* JENT_PRIVATE_COMPILE */
-# define JENT_PRIVATE_STATIC __attribute__((visibility("default")))
+#if defined(_MSC_VER)
+#define JENT_PRIVATE_STATIC __declspec(dllexport)
+#else
+#define JENT_PRIVATE_STATIC __attribute__((visibility("default")))
+#endif
 #endif
 
 /* Number of low bits of the time value that we want to consider */
@@ -399,12 +406,12 @@ int jent_entropy_switch_notime_impl(struct jent_notime_thread *new_thread);
 
 /* -- BEGIN timer-less threading support functions to prevent code dupes -- */
 
+#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
+
 struct jent_notime_ctx {
 	pthread_attr_t notime_pthread_attr;	/* pthreads library */
 	pthread_t notime_thread_id;		/* pthreads thread ID */
 };
-
-#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 
 JENT_PRIVATE_STATIC
 int jent_notime_init(void **ctx);

--- a/src/jitterentropy-sha3.c
+++ b/src/jitterentropy-sha3.c
@@ -19,7 +19,7 @@
  */
 
 #include "jitterentropy-sha3.h"
-#include "jitterentropy-base-user.h"
+#include "jitterentropy.h"
 
 /***************************************************************************
  * Message Digest Implementation

--- a/tests/gcd/CMakeLists.txt
+++ b/tests/gcd/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(gcd gcd.c)
+target_include_directories(gcd PRIVATE ../../src)
+target_link_libraries(gcd ${PROJECT_NAME})

--- a/tests/raw-entropy/recording_userspace/CMakeLists.txt
+++ b/tests/raw-entropy/recording_userspace/CMakeLists.txt
@@ -1,0 +1,9 @@
+function(testprogram name)
+    add_executable(${name} ${name}.c)
+    target_link_libraries(${name} ${PROJECT_NAME})
+    if(NOT MSVC)
+        target_compile_options(${name} PRIVATE -Wno-unused-parameter)
+    endif()
+endfunction()
+
+testprogram(jitterentropy-rng)

--- a/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 
 #include "jitterentropy.h"


### PR DESCRIPTION
Add support for MSVC compiler. This involved fixing several compatibility issue and updating jitterentroipy.h to pick the right platform specific header.

Setup:
```
cd ~/
git clone git@github.com:smuellerDD/jitterentropy-library.git
mkdir jitter-build
cd jitter-build
```
Quickstart for new CMake build on LInux with Make
```
cmake ../jitterentropy-library
make
```

To use Ninja:
```
cmake -G Ninja ../jitterentropy-library
ninja
```

To use Ninja with AWS-LC:
```
cd ~/
git clone https://github.com/awslabs/aws-lc.git
mkdir aws-lc-build aws-lc-install
cd aws-lc-build
cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/aws-lc-install ../aws-lc
ninja install
cd ~/jitter-build
cmake -G Ninja -DEXTERNAL_CRYPTO=AWSLC -DCMAKE_PREFIX_PATH=~/aws-lc-install ../jitterentropy-library
```
Note: We install AWS-LC into the path defined with CMAKE_INSTALL_PREFIX and tell Jitter to use it by defining CMAKE_PREFIX_PATH.