### PR TITLE
Update jitterentropy.h and jitterentropy-base-x86.h to support more compilers

### DIFF
--- a/arch/jitterentropy-base-x86.h
+++ b/arch/jitterentropy-base-x86.h
@@ -66,7 +66,7 @@ typedef uint64_t __u64;
 static inline void jent_get_nstime(uint64_t *out)
 {
 	DECLARE_ARGS(val, low, high);
-	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	__asm__ __volatile__("rdtsc" : EAX_EDX_RET(val, low, high));
 	*out = EAX_EDX_VAL(val, low, high);
 }
 

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -42,6 +42,10 @@
 #ifndef _JITTERENTROPY_H
 #define _JITTERENTROPY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***************************************************************************
  * Jitter RNG Configuration Section
  *
@@ -459,5 +463,9 @@ uint64_t jent_lfsr_var_stat(struct rand_data *ec, unsigned int min);
 #endif /* CONFIG_CRYPTO_CPU_JITTERENTROPY_STAT */
 
 /* -- END of statistical test function -- */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _JITTERENTROPY_H */


### PR DESCRIPTION
In jitterentropy.h add [`extern "C"`](https://docs.microsoft.com/en-us/cpp/cpp/extern-cpp?view=msvc-170) to specify the functions use C calling conventions for C++ consumers. This enables C++ projects to easily include Jitter's C headers and use libjitter when built.

In jitterentropy-base-x86.h use the [GCC extension](https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html#Alternate-Keywords) version of `__asm__` and `__volatile__` keywords that can be built even when using -std or -ansi. 