### PR TITLE
Use ARM64 system counter, uint64_t instead of unsugned long

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -96,7 +96,8 @@
 /* Support rdtsc read on 64-bit and 32-bit x86 architectures */
 
 #ifdef __x86_64__
-# define DECLARE_ARGS(val, low, high)    unsigned long low, high
+/* specify 64 bit type since long is 32 bits in LLP64 x86_64 systems */
+# define DECLARE_ARGS(val, low, high)    uint64_t low, high
 # define EAX_EDX_VAL(val, low, high)     ((low) | (high) << 32)
 # define EAX_EDX_RET(val, low, high)     "=a" (low), "=d" (high)
 #elif __i386__
@@ -131,6 +132,13 @@ static inline void jent_get_nstime(uint64_t *out)
 	tmp = tmp << 32;
 	tmp = tmp | aixtime.tb_low;
 	*out = tmp;
+#  elif defined(__aarch64__)
+        uint64_t ctr_val;
+        /*
+         * Use the system counter for aarch64 (64 bit ARM).
+         */
+        asm volatile("mrs %0, cntvct_el0" : "=r" (ctr_val));
+        *out = ctr_val;
 # else /* __MACH__ */
 	/* we could use CLOCK_MONOTONIC(_RAW), but with CLOCK_REALTIME
 	 * we get some nice extra entropy once in a while from the NTP actions


### PR DESCRIPTION
 1.  Use uint64_t instead of unsigned long in DECLARE_ARGS definition  on x86_64 since some x86_64 systems are LLP64 (long is 32 bits).

2.  Add support for the system counter on aarch64 (Arm 64 bit) platforms.