### PR TITLE
fix a stack corruption on s390x

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -129,13 +129,46 @@ static inline void jent_get_nstime(uint64_t *out)
 
 static inline void jent_get_nstime(uint64_t *out)
 {
-	uint64_t clk;
+	/*
+	 * This is MVS+STCK code! Enable it with -S in the compiler.
+	 *
+	 * uint64_t clk;
+	 * __asm__ volatile("stck %0" : "=m" (clk) : : "cc");
+	 * *out = (uint64_t)(clk);
+	 */
 
-	/* this is MVS code! enable with -S in the compiler */
-	/*__asm__ volatile("stck %0" : "=m" (clk) : : "cc"); */
-	/* this is gcc */
+	/*
+	 * This is GCC+STCKE code. STCKE command and data format:
+	 * z/Architecture - Principles of Operation
+	 * http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+	 *
+	 * The current value of bits 0-103 of the TOD clock is stored in bytes
+	 * 1-13 of the sixteen-byte output:
+	 *
+	 * bits 0-7: zeros (reserved for future extention)
+	 * bits 8-111: TOD Clock value
+	 * bits 112-127: Programmable Field
+	 *
+	 * Output bit 59 (TOD-Clock bit 51) effectively increments every
+	 * microsecond. Bits 60 to 111 of STCKE output are fractions of
+	 * a miscrosecond: bit 59 is 1.0us, bit 60 is .5us, bit 61 is .25us,
+	 * bit 62 is .125us, bit 63 is 62.5ns, etc.
+	 *
+	 * Some of these bits can be implemented, some not. 64 bits of
+	 * the TOD clock are implemented usually nowadays, these are
+	 * bits 8-71 of the output.
+	 *
+	 * The stepping value of TOD-clock bit position 63, if implemented,
+	 * is 2^-12 microseconds, or approximately 244 picoseconds. This value
+	 * is called a clock unit.
+	 */
+
+	uint8_t clk[16];
+
 	asm volatile("stcke %0" : "=Q" (clk) : : "cc");
-	*out = (uint64_t)(clk);
+
+	/* s390x is big-endian, so just perfom a byte-by-byte copy */
+	*out = *(uint64_t *)(clk + 1);
 }
 
 #elif defined(__powerpc)


### PR DESCRIPTION
Output size of the STCKE command on s390x is 16 bytes, compared to 8 bytes of the STCK command. This leads to a stack corruption in `jent_get_nstime()` on an s390x system with a following stack trace for a codebase at 4544e113:

```
Core was generated by `/usr/sbin/rngd'.
Program terminated with signal SIGABRT, Aborted.
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=<optimized out>, no_tid=no_tid@entry=0) at pthread_kill.c:44
44	      return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=<optimized out>, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x000003ff93da0196 in __pthread_kill_internal (signo=<optimized out>, threadid=<optimized out>) at pthread_kill.c:78
#2  0x000003ff93d508f0 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x000003ff93d2a340 in __GI_abort () at abort.c:79
#4  0x000003ff93d92e60 in __libc_message (fmt=fmt@entry=0x3ff93e8e088 "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:150
#5  0x000003ff93e256fc in __GI___fortify_fail (msg=msg@entry=0x3ff93e8e070 "stack smashing detected") at fortify_fail.c:24
#6  0x000003ff93e256d8 in __stack_chk_fail () at stack_chk_fail.c:24
#7  0x000003ff94686d00 in jent_get_nstime (out=0x3ffe17f8b28) at ./jitterentropy-base-user.h:139
#8  0x000003ff94687200 in jent_get_nstime_internal (ec=0x2aa1a3cf1c0, out=0x3ffe17f8b28) at src/jitterentropy-timer.c:181
#9  0x000003ff946846b4 in jent_memaccess (ec=0x2aa1a3cf1c0, loop_cnt=0) at src/jitterentropy-noise.c:233
#10 0x000003ff94684804 in jent_measure_jitter (ec=0x2aa1a3cf1c0, loop_cnt=0, ret_current_delta=0x0) at src/jitterentropy-noise.c:353
#11 0x000003ff94682b34 in jent_time_entropy_init (osr=0, flags=48) at src/jitterentropy-base.c:578
#12 0x000003ff94682e5e in jent_entropy_init () at src/jitterentropy-base.c:712
#13 0x000002aa19a0e024 in init_jitter_entropy_source (ent_src=0x2aa19a172b0 <entropy_sources+576>) at rngd_jitter.c:432
#14 init_jitter_entropy_source (ent_src=0x2aa19a172b0 <entropy_sources+576>) at rngd_jitter.c:399
#15 0x000002aa19a049f8 in main (argc=<optimized out>, argv=<optimized out>) at rngd.c:1102
```

See also: https://bugzilla.redhat.com/show_bug.cgi?id=2140043

This issues was brought in by the recent f1727dff. Fix the s390x version of `jent_get_nstime()` and add some more detailed information on the STCKE command in a comment.

Assorted STCKE related links:

http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
https://groups.google.com/g/bit.listserv.ibm-main/c/qWWkdociQMQ/m/s3e9xJpDAwAJ
https://bit.listserv.ibm-main.narkive.com/KpxS1vIH/format-of-stck-instruction#post3
https://colinpaice.blog/2020/09/25/how-do-i-format-a-stck-from-a-c-program/