### PR TITLE
jent_read_entropy_safe() may return with dangling pointer in *ec.

### DIFF
--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -308,6 +308,7 @@ ssize_t jent_read_entropy_safe(struct rand_data **ec, char *data, size_t len)
 			 * memory size
 			 */
 			jent_entropy_collector_free(*ec);
+			*ec = NULL;
 
 			/* Perform new health test with updated OSR */
 			if (jent_entropy_init_ex(osr, flags))


### PR DESCRIPTION
On a failure of jent_read_entropy() where the entropy collector will be reallocated, jent_entropy_collector_free() is used to release *ec, but *ec is not set to NULL. If a failure occurs in the following call to jent_entropy_collector_ex() then the function will return with a dangling pointer remaining in *ec. Set *ec to NULL after freeing to prevent this.