### PR TITLE
Fix potential memory leak during failed collector creation.

### DIFF
--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -485,6 +485,8 @@ static struct rand_data
 err:
 	if (entropy_collector->mem != NULL)
 		jent_zfree(entropy_collector->mem, memsize);
+	if (entropy_collector->hash_state != NULL)
+		sha3_dealloc(entropy_collector->hash_state);
 	jent_zfree(entropy_collector, sizeof(struct rand_data));
 	return NULL;
 }


### PR DESCRIPTION
In the error cleanup block of jent_entropy_collector_alloc_internal(), the hash_state should also be zeroed and freed.

Conflicting flags of JENT_DISABLE_INTERNAL_TIMER and JENT_FORCE_INTERNAL_TIMER will cause a EHEALTH return from jent_notime_enable() and jump to the error cleanup block after hash_state has been allocated.