### PR TITLE
Bug mkcppcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(analyze_plists): %.plist: %.c
 scan: $(analyze_plists)
 
 cppcheck:
-	cppcheck --force -q --enable=performance --enable=warning --enable=portability *.h *.c */*.h */*.c
+	cppcheck --force -q --enable=performance --enable=warning --enable=portability *.h *.c */*.h */*.c */*/*/*.c
 
 install: install-man install-shared install-includes
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(analyze_plists): %.plist: %.c
 scan: $(analyze_plists)
 
 cppcheck:
-	cppcheck --force -q --enable=performance --enable=warning --enable=portability *.h *.c
+	cppcheck --force -q --enable=performance --enable=warning --enable=portability *.h *.c */*.h */*.c
 
 install: install-man install-shared install-includes
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(analyze_plists): %.plist: %.c
 scan: $(analyze_plists)
 
 cppcheck:
-	cppcheck --force -q --enable=performance --enable=warning --enable=portability *.h *.c */*.h */*.c */*/*/*.c
+	cppcheck --force -q --enable=performance --enable=warning --enable=portability $(shell find * -name \*.h -o -name \*.c)
 
 install: install-man install-shared install-includes
 


### PR DESCRIPTION
Catch up with v3.1.0, which created a src/ directory for the split up jitterentropy-base.c into various smaller code files.  Also cpptest the tests to catch bugs.