### PR TITLE
Allow the use of the "default" C compiler

### DIFF
--- a/tests/gcd/Makefile
+++ b/tests/gcd/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 - 2022, Stephan Mueller <smueller@chronox.de>
 #
 
-CC		:= gcc
+CC		?= gcc
 CFLAGS		+= -Wextra -Wall -pedantic -fPIC -O2 -std=gnu18
 #Hardening
 CFLAGS		+= -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wconversion -Wcast-align -Wmissing-field-initializers -Wshadow -Wswitch-enum

--- a/tests/raw-entropy/recording_runtime_kernelspace/attic/Makefile.foldtime
+++ b/tests/raw-entropy/recording_runtime_kernelspace/attic/Makefile.foldtime
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -Wextra -DROUNDS=100000000 -O0 -Wno-long-long
 
 program_NAME := jitterentropy-kernel-foldtime

--- a/tests/raw-entropy/recording_runtime_kernelspace/attic/Makefile.lfsrtime
+++ b/tests/raw-entropy/recording_runtime_kernelspace/attic/Makefile.lfsrtime
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -Wextra -DROUNDS=100000000 -O0 -Wno-long-long
 
 program_NAME := jitterentropy-kernel-lfsrtime

--- a/tests/raw-entropy/recording_userspace/Makefile.foldtime
+++ b/tests/raw-entropy/recording_userspace/Makefile.foldtime
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -DCONFIG_CRYPTO_CPU_JITTERENTROPY_STAT -DROUNDS=10000000 -I../../ -O0 -Wno-long-long 
 
 program_NAME := jitterentropy-foldtime

--- a/tests/raw-entropy/recording_userspace/Makefile.rng
+++ b/tests/raw-entropy/recording_userspace/Makefile.rng
@@ -6,11 +6,11 @@ CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0 -DCONFIG_CRYPTO_CPU_JITTERENTROPY_SEC
 CFLAGS +=-fwrapv --param ssp-buffer-size=4
 LDFLAGS +=-Wl,-z,relro,-z,now
 
-GCCVERSIONFORMAT := $(shell echo `gcc -dumpversion | sed 's/\./\n/g' | wc -l`)
+GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | sed 's/\./\n/g' | wc -l`)
 ifeq "$(GCCVERSIONFORMAT)" "3"
-  GCC_GTEQ_490 := $(shell expr `gcc -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
+  GCC_GTEQ_490 := $(shell expr `$(CC) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
 else
-  GCC_GTEQ_490 := $(shell expr `gcc -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
+  GCC_GTEQ_490 := $(shell expr `$(CC) -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
 endif
 
 ifeq "$(GCC_GTEQ_490)" "1"

--- a/tests/raw-entropy/validation-restart/Makefile
+++ b/tests/raw-entropy/validation-restart/Makefile
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -Wextra -O2
 
 program_NAME := extractlsb

--- a/tests/raw-entropy/validation-runtime-kernel/Makefile
+++ b/tests/raw-entropy/validation-runtime-kernel/Makefile
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -Wextra -O2
 
 program_NAME := extractlsb

--- a/tests/raw-entropy/validation-runtime/Makefile
+++ b/tests/raw-entropy/validation-runtime/Makefile
@@ -1,6 +1,6 @@
 # Compile Noise Source as user space application
 
-CC=gcc
+CC ?= gcc
 override CFLAGS +=-pedantic -Wall -Wextra -O2
 
 program_NAME := extractlsb


### PR DESCRIPTION
Consistently default and use 'gcc' if there isn't a different
native C compiler on a system.

This is a problem on FreeBSD systems that ship with Clang as 'cc',
and GCC is installed with a version# (e.g., gcc12 [12.2.0]).