### PR TITLE
Follow FreeBSD's 'man 9 style', which also applies to Linux

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -49,15 +49,16 @@
  * Compilation for OpenSSL    #define OPENSSL
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <limits.h>
 #include <time.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>

--- a/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
@@ -22,6 +22,9 @@
  * gcc -Wall -pedantic -Wextra -o getrawentropy getrawentropy.c
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <errno.h>
 #include <getopt.h>
 #include <limits.h>
@@ -29,8 +32,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/tests/raw-entropy/validation-restart/extractlsb.c
+++ b/tests/raw-entropy/validation-restart/extractlsb.c
@@ -23,12 +23,13 @@
  *
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 

--- a/tests/raw-entropy/validation-runtime-kernel/extractlsb.c
+++ b/tests/raw-entropy/validation-runtime-kernel/extractlsb.c
@@ -23,12 +23,13 @@
  *
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 

--- a/tests/raw-entropy/validation-runtime/extractlsb.c
+++ b/tests/raw-entropy/validation-runtime/extractlsb.c
@@ -23,12 +23,13 @@
  *
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 


### PR DESCRIPTION
<sys/types.h> should be the first header include - it sets up the type system for the platform.  Followed that other system (i.e. kernel) headers before userland headers.  Part of this source base followed the rule, this change makes it consistent.