### PR TITLE
Fix off-by-one error in boottime_test_record.sh

### DIFF
--- a/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
+++ b/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
@@ -64,6 +64,7 @@ else
 	$KCAPIRNG -n "jitterentropy_rng" -b 2000
 fi
 
+testruns=$((testruns+1))
 if [ $testruns -ge $TESTS ]; then
 	systemctl stop boottime_test_record
 	systemctl disable boottime_test_record


### PR DESCRIPTION
testruns starts at 00000, so the exit condition must be checked for testruns + 1

Consider the case where TESTS is set to 1. Then testruns would be 0, which is not greater than or equal to 1, so the script wouldn't exit.