### PR TITLE
Add sanity check in install.sh

### DIFF
--- a/tests/raw-entropy/recording_restart_kernelspace/install.sh
+++ b/tests/raw-entropy/recording_restart_kernelspace/install.sh
@@ -3,6 +3,12 @@
 #	Install the linux kernel and the service running the boottime test
 
 # Note: restorecon is needed for Fedora 
+if [ ! -x /usr/local/sbin/getrawentropy ];
+then
+	echo "getrawentropy must be installed in /usr/local/sbin"
+	exit 1
+fi
+
 cp boottime_test_record.sh /usr/local/sbin/ &&
 chmod u+x /usr/local/sbin/boottime_test_record.sh &&
 cp boottime_test_record.service /etc/systemd/system/ &&
@@ -12,4 +18,3 @@ restorecon -v -R /
 echo "To improve the reboot speed change the timeout in /etc/default/grub as follows"
 echo "GRUB_TIMEOUT=1"
 echo "Then run grub2-mkconfig to update the grub configuration file for the new setting to take effect."
-


### PR DESCRIPTION
install.sh doesn't copy over getrawentropy, this must be done manually. We add a sanity check to make sure the user doesn't forget to do so.