### PR TITLE
Collect one additional timestamp, required to compute the delta values

### DIFF
--- a/tests/raw-entropy/recording_restart_kernelspace/README.md
+++ b/tests/raw-entropy/recording_restart_kernelspace/README.md
@@ -1,17 +1,17 @@
 # Tests of Entropy during early boot
 
-This test collects the first 1,000 entropy event values generated during boot
+This test collects the first 1,001 entropy event values generated during boot
 of the Linux kernel. The collection of raw entropy after reboot is compliant
 to SP800-90B section 3.1.4.
 
 The test infrastructure sets the Linux system up to reboot the system
-some 1,000 times to collect these 1,000 event values.
+some 1,000 times to collect these 1,001 event values.
 
 # Test procedure
 
 See boottime_test_record.sh.
 
-The result is a matrix where on each line the 1,000 successive time stamps
+The result is a matrix where on each line the 1,001 successive time stamps
 of the interrupts for one boot operation are recorded.
 
 The number of lines equals to the number of reboots.

--- a/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
+++ b/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
@@ -60,7 +60,7 @@ then
 	echo "Test tool $KCAPIRNG not found"
 	testruns=$TESTS
 else
-	( (  /usr/local/sbin/getrawentropy -f /sys/kernel/debug/jitterentropy_testing/jent_raw_hires > $OUTFILE.$testruns.data ) & )
+	( (  /usr/local/sbin/getrawentropy -f /sys/kernel/debug/jitterentropy_testing/jent_raw_hires -s 1001 > $OUTFILE.$testruns.data ) & )
 	$KCAPIRNG -n "jitterentropy_rng" -b 2000
 fi
 

--- a/tests/raw-entropy/recording_runtime_kernelspace/README.md
+++ b/tests/raw-entropy/recording_runtime_kernelspace/README.md
@@ -14,7 +14,7 @@ To obtain raw noise data from the Jitter RNG, follow these steps:
 2. Compile getrawentropy.c as documented in that file
 
 3. Execute as root to obtain the raw entropy data:
-	`getrawentropy -f /sys/kernel/debug/jitterentropy_testing/jent_raw_hires -s 1000000 > /dev/shm/lrng_raw_noise.data`
+	`getrawentropy -f /sys/kernel/debug/jitterentropy_testing/jent_raw_hires -s 1000001 > /dev/shm/lrng_raw_noise.data`
 
 4. In parallel to step 3, stimulate the generation of entropy, e.g. by using
    the following command with a tool from libkcapi using the following command


### PR DESCRIPTION
Computing 1000 time deltas (which are the actual noise values) requires 1001 timestamps.