### PR TITLE
Fix typo

### DIFF
--- a/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
+++ b/tests/raw-entropy/recording_restart_kernelspace/boottime_test_record.sh
@@ -54,7 +54,7 @@ echo $((testruns+1)) > $STATE
 # for i in jent_raw_noise_restart.????.data; do mv $i $(echo $i | cut -d. -f1).0$(echo $i | cut -d. -f2).$(echo $i | cut -d. -f3) ; done
 printf -v testruns "%05d" $testruns
 
-if [ !-x "$KCAPIRNG" ]
+if [ ! -x "$KCAPIRNG" ]
 then
 	echo "Test tool $KCAPIRNG not found" > $OUTFILE.$testruns.data
 	echo "Test tool $KCAPIRNG not found"


### PR DESCRIPTION
Apparently this whitespace is important:
```
[joachim@joachim-xps ~]$ pwd
/home/joachim
[joachim@joachim-xps ~]$ [ ! -x "/home/joachim" ] && echo "bla"
[joachim@joachim-xps ~]$ [ !-x "/home/joachim" ] && echo "bla"
bash: !-x: event not found
```