### PR TITLE
Bash backwards compatibility

### DIFF
--- a/tests/raw-entropy/validation-restart-kernel/processdata.sh
+++ b/tests/raw-entropy/validation-restart-kernel/processdata.sh
@@ -116,7 +116,7 @@ do
 		fi
 
 		echo "Converting recorded entropy data $in_file into different bit output with mask $mask" >> $LOGFILE
-		./$EXTRACT $in_file $out_file $SAMPLES $mask &>> $LOGFILE
+		./$EXTRACT $in_file $out_file $SAMPLES $mask >> $LOGFILE 2>&1
 	done
 done
 

--- a/tests/raw-entropy/validation-runtime-kernel/processdata.sh
+++ b/tests/raw-entropy/validation-runtime-kernel/processdata.sh
@@ -112,7 +112,7 @@ do
 	fi
 
 	echo "Converting recorded entropy data $in_file into different bit output with mask $mask" >> $LOGFILE
-	./$EXTRACT $in_file $out_file $SAMPLES $mask &>> $LOGFILE
+	./$EXTRACT $in_file $out_file $SAMPLES $mask >> $LOGFILE 2>&1
 done
 
 echo "" | tee -a $LOGFILE


### PR DESCRIPTION
Older versions of Bash (e.g. those used on macOS) don't support &>>.