### PR TITLE
Improve portability and compiler support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,28 @@ if(EXTERNAL_CRYPTO)
     list(APPEND JITTER_C_FLAGS  -D${EXTERNAL_CRYPTO})
 endif()
 
-if(MSVC)
-    list(APPEND JITTER_C_FLAGS  /Od /W4 /DYNAMICBASE)
-    set(JITTER_LINK_FLAGS ${JITTER_LINK_FLAGS})
+if(WIN32)
+    if(MSVC)
+        list(APPEND JITTER_C_FLAGS  /Od /W4 /DYNAMICBASE)
+    else()
+        list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -Wcast-align
+        -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -O0 -fwrapv -Wconversion)
+    endif()
+    set( ${JITTER_LINK_FLAGS})
 else()
     list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align
-    -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -fPIC -O0 -fwrapv -Wconversion)
+    -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -fPIC -O0 -fwrapv)
+
     if(NOT APPLE)
         list(APPEND JITTER_LINKER_FLAGS -Wl,-z,relro,-z,now)
+    endif()
+
+    if ((NOT GCC) OR (GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.3"))
+        # -Wconversion was changed from GCC version 4.3. Prior it was meant as
+        # an aid in translating code from old C to modern C. It was not meant
+        # to help detect troublesome implicit conversions.
+        # https://gcc.gnu.org/wiki/NewWconversion.
+        set(JITTER_COMPILE_FLAGS "${JITTER_COMPILE_FLAGS} -Wconversion")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ if(WIN32)
         list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -Wcast-align
         -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -O0 -fwrapv -Wconversion)
     endif()
-    set( ${JITTER_LINK_FLAGS})
 else()
     list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align
     -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -fPIC -O0 -fwrapv)

--- a/arch/jitterentropy-base-windows.h
+++ b/arch/jitterentropy-base-windows.h
@@ -42,12 +42,13 @@
 #ifndef _JITTERENTROPY_BASE_X86_H
 #define _JITTERENTROPY_BASE_X86_H
 
+#include <stdint.h>
+
 #if defined(_MSC_VER)
-typedef __int64 ssize_t;
+typedef int64_t ssize_t;
 #include <windows.h>
 #endif
 
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <intrin.h>
@@ -61,7 +62,7 @@ typedef __int64 ssize_t;
 #include <windows.h>
 #endif
 
-static void jent_get_nstime(uint64_t *out)
+static inline void jent_get_nstime(uint64_t *out)
 {
 #if defined(_M_ARM) || defined(_M_ARM64)
 


### PR DESCRIPTION
This is a set of small changes that improves portability and compiler support. They are:

* Add a cmake branch for non-MSVC compilers on Windows e.g. `clang-cl`.

* `__int64` is a language extension by Microsoft. Other compilers than MSVC does not seem happy with it. Fix by replacing with portable `int64_t` from `stdint.h` that is an equivalent type.

* For some reason, in some of my build environments `time` is shadowing a global declaration from some imported header file. Fix by renaming parameters and local variables.

* There are warnings, that turns into errors, originating from `-Wconversion` on older GCC versions. These are false-positives because prior to GCC 4.3 where `-Wconversion` didn't have anything to do with finding troublesome implicit conversions, it was an aid in converting from old C to modern C. Disable on those known old compilers.

* jitterentropy-base-windows.h distributes definitions of `jent_get_nstime()` throughout compilation units. However, many of these doesn't use the function causing unused function warnings for Windows clang builds. Tried different things but inlining was the only thing that worked.

* The variable `JITTER_LINK_FLAGS` doesn't seem to be used in the build, so removed it.

These changes make my build work down to older compilers such as GCC 4.1 and using e.g. `clang-cl` on Windows. MSVC and e.g. mingw are also happy with the changes.