### PR TITLE
Allow the developer to cause the library to use a larger memory region

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -138,6 +138,22 @@ extern "C" {
  */
 #define JENT_APT_MASK		(UINT64_C(0xffffffffffffffff))
 
+/* This parameter establishes the multiplicative factor that the desired
+ * memory region size should be larger than the observed cache size; the
+ * multiplicative factor is 2^JENT_CACHE_SHIFT_BITS.
+ * Set this to 0 if the desired memory region should be at least as large as
+ * the cache. If one wants most of the memory updates to result in a memory
+ * update, then this value should be at least 1.
+ * If the memory updates should dominantly result in a memory update, then
+ * the value should be set to at least 3.
+ * The actual size of the memory region is never larger than requested by
+ * the passed in JENT_MAX_MEMSIZE_* flag (if provided) or JENT_MEMORY_SIZE
+ * (if no JENT_MAX_MEMSIZE_* flag is provided).
+ */
+#ifndef JENT_CACHE_SHIFT_BITS
+#define JENT_CACHE_SHIFT_BITS 0
+#endif
+
 /***************************************************************************
  * Jitter RNG State Definition Section
  ***************************************************************************/

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -400,7 +400,7 @@ ssize_t jent_read_entropy_safe(struct rand_data **ec, char *data, size_t len)
  */
 static inline uint32_t jent_memsize(unsigned int flags)
 {
-	uint32_t memsize, max_memsize;
+	uint32_t cache_memsize=0, max_memsize=0, memsize=0;
 
 	max_memsize = JENT_FLAGS_TO_MAX_MEMSIZE(flags);
 
@@ -412,7 +412,11 @@ static inline uint32_t jent_memsize(unsigned int flags)
 	}
 
 	/* Allocate memory for adding variations based on memory access */
-	memsize = jent_cache_size_roundup();
+	cache_memsize = jent_cache_size_roundup();
+	memsize = cache_memsize << JENT_CACHE_SHIFT_BITS;
+	/*If this value is left-shifted too much, it may be cleared.*/
+	/*If so, set the maximum possible power of two.*/
+	if(cache_memsize > memsize) memsize = 0x80000000;
 
 	/* Limit the memory as defined by caller */
 	memsize = (memsize > max_memsize) ? max_memsize : memsize;


### PR DESCRIPTION
This PR adds support for the JENT_CACHE_SHIFT_BITS macro, which allows the developer to request a larger memory region. In this PR, the desired memory region size is now effectively `2^JENT_CACHE_SHIFT_BITS * jent_cache_size_roundup()`. The default behavior in this PR is to set JENT_CACHE_SHIFT_BITS to 0 (which is equivalent to the current baseline behavior), but this can be overridden during compilation.

In the current baseline code, there is no mechanism for requesting a memory region significantly larger than the available cache size. In some cases, the behavior of the JEnt library improves when using a larger memory region so there should be some way for the developer to induce such a setting.

In all cases, the size of the allocated memory region is mediated by the passed in `JENT_MAX_MEMSIZE_*` flag or `JENT_MEMORY_SIZE` (if no such flag is provided).