### PR TITLE
Replace sed with tr in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS +=-Wl,-z,relro,-z,now -lpthread
 # Enable internal timer support
 CFLAGS += -DJENT_CONF_ENABLE_INTERNAL_TIMER
 
-GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | sed 's/\./\n/g' | wc -l`)
+GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | tr '.' '\n' | wc -l`)
 ifeq "$(GCCVERSIONFORMAT)" "3"
   GCC_GTEQ_490 := $(shell expr `$(CC) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
 else


### PR DESCRIPTION
According to POSIX, \n is not supported in the sed(1) substitute function.  The UNIX way is to use tr(1) for creating newline characters.  Newline in the replacement string of a sed substitution is a GNU extension.  Using tr fixes the build on OpenBSD.