### PR TITLE
Simplify the delta calculation.

### DIFF
--- a/tests/raw-entropy/validation-restart-kernel/extractlsb.c
+++ b/tests/raw-entropy/validation-restart-kernel/extractlsb.c
@@ -198,9 +198,7 @@ int main(int argc, char *argv[])
 			prev_timestamp_set = 1;
 			continue;
 		}
-		delta = (timestamp > prev_timestamp) ?
-			timestamp - prev_timestamp :
-			timestamp - prev_timestamp;
+		delta = timestamp - prev_timestamp;
 		prev_timestamp = timestamp;
 
 		unchanged0s |= delta;

--- a/tests/raw-entropy/validation-runtime-kernel/extractlsb.c
+++ b/tests/raw-entropy/validation-runtime-kernel/extractlsb.c
@@ -198,9 +198,7 @@ int main(int argc, char *argv[])
 			prev_timestamp_set = 1;
 			continue;
 		}
-		delta = (timestamp > prev_timestamp) ?
-			timestamp - prev_timestamp :
-			timestamp - prev_timestamp;
+		delta = timestamp - prev_timestamp;
 		prev_timestamp = timestamp;
 
 		unchanged0s |= delta;


### PR DESCRIPTION
Essentially equivalent to the approach in https://github.com/smuellerDD/jitterentropy-library/pull/139 which fixes tests/raw-entropy/validation-runtime-kernel/extractlsb.c; this PR also fixes tests/raw-entropy/validation-restart-kernel/extractlsb.c.