### PR TITLE
Improve asm/volatile keyword portability

### DIFF
--- a/arch/jitterentropy-base-power.h
+++ b/arch/jitterentropy-base-power.h
@@ -55,7 +55,7 @@ static inline void jent_get_nstime(uint64_t *out)
 	unsigned long low;
 	unsigned long newhigh;
 	uint64_t result;
-        asm volatile(
+        __asm__ __volatile__(
 		"Lcpucycles:mftbu %0;mftb %1;mftbu %2;cmpw %0,%2;bne Lcpucycles"
 		: "=r" (high), "=r" (low), "=r" (newhigh)
 		);

--- a/arch/jitterentropy-base-s390.h
+++ b/arch/jitterentropy-base-s390.h
@@ -51,9 +51,9 @@ static inline void jent_get_nstime(uint64_t *out)
 {
 	uint64_t clk;
 	/* this is MVS code! enable with -S in the compiler */
-	/*__asm__ volatile("stck %0" : "=m" (clk) : : "cc"); */
+	/*__asm__ __volatile__("stck %0" : "=m" (clk) : : "cc"); */
 	/* this is gcc */
-	asm volatile("stcke %0" : "=Q" (clk) : : "cc");
+	__asm__ __volatile__("stcke %0" : "=Q" (clk) : : "cc");
 	*out = (uint64_t)(clk);
 }
 

--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -113,7 +113,7 @@ static inline void jent_get_nstime(uint64_t *out)
 #ifdef __sun__
 	__asm("rdtsc" : EAX_EDX_RET(val, low, high));
 #else
-	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	__asm__ __volatile__("rdtsc" : EAX_EDX_RET(val, low, high));
 #endif
 	*out = EAX_EDX_VAL(val, low, high);
 }
@@ -130,7 +130,7 @@ static inline void jent_get_nstime(uint64_t *out)
         /*
          * Use the system counter for aarch64 (64 bit ARM).
          */
-        asm volatile("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
+        __asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
         *out = ctr_val;
 }
 
@@ -142,7 +142,7 @@ static inline void jent_get_nstime(uint64_t *out)
 	 * This is MVS+STCK code! Enable it with -S in the compiler.
 	 *
 	 * uint64_t clk;
-	 * __asm__ volatile("stck %0" : "=m" (clk) : : "cc");
+	 * __asm__ __volatile__("stck %0" : "=m" (clk) : : "cc");
 	 * *out = (uint64_t)(clk);
 	 */
 
@@ -174,7 +174,7 @@ static inline void jent_get_nstime(uint64_t *out)
 
 	uint8_t clk[16];
 
-	asm volatile("stcke %0" : "=Q" (clk) : : "cc");
+	__asm__ __volatile__("stcke %0" : "=Q" (clk) : : "cc");
 
 	/* s390x is big-endian, so just perfom a byte-by-byte copy */
 	*out = *(uint64_t *)(clk + 1);
@@ -199,12 +199,12 @@ static inline void jent_get_nstime(uint64_t *out)
 	unsigned long newhigh;
 	uint64_t result;
 #ifdef POWER_PC_USE_NEW_INSTRUCTIONS /* Newer PPC CPUs do not support mftbu/mftb */
-    asm volatile(
+    __asm__ __volatile__(
         "Lcpucycles:mfspr %0, 269;mfspr %1, 268;mfspr %2, 269;cmpw %0,%2;bne Lcpucycles"
 		: "=r" (high), "=r" (low), "=r" (newhigh)
 		);
 #else
-    asm volatile(
+    __asm__ __volatile__(
 		"Lcpucycles:mftbu %0;mftb %1;mftbu %2;cmpw %0,%2;bne Lcpucycles"
 		: "=r" (high), "=r" (low), "=r" (newhigh)
 		);

--- a/tests/raw-entropy/recording_runtime_kernelspace/attic/jitterentropy-foldtime.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/attic/jitterentropy-foldtime.c
@@ -110,7 +110,7 @@ void jent_get_nstime(__u64 *out)
 
 #elif (defined(__i386__) || defined(__x86_64__))
 	DECLARE_ARGS(val, low, high);
-	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	__asm__ __volatile__("rdtsc" : EAX_EDX_RET(val, low, high));
 	*out = EAX_EDX_VAL(val, low, high);
 
 #else

--- a/tests/raw-entropy/recording_runtime_kernelspace/attic/jitterentropy-lfsrtime.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/attic/jitterentropy-lfsrtime.c
@@ -108,7 +108,7 @@ void jent_get_nstime(__u64 *out)
 
 #elif (defined(__i386__) || defined(__x86_64__))
 	DECLARE_ARGS(val, low, high);
-	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	__asm__ __volatile__("rdtsc" : EAX_EDX_RET(val, low, high));
 	*out = EAX_EDX_VAL(val, low, high);
 
 #else


### PR DESCRIPTION
We have cases that doesn't work well with `asm volatile`. We can improve portability by using functionally equivalent keywords as done in this PR.

See e.g. https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html for more details.