### PR TITLE
Use clock_gettime_nsec_np(CLOCK_UPTIME_RAW) on modern Apple+Arm64

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -127,10 +127,21 @@ static inline void jent_get_nstime(uint64_t *out)
 static inline void jent_get_nstime(uint64_t *out)
 {
         uint64_t ctr_val;
+#if !defined(__MACH__)
         /*
-         * Use the system counter for aarch64 (64 bit ARM).
+         * Use the system counter for aarch64 (64 bit ARM)...
          */
         __asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
+#else
+        /*
+         * Except on modern Apple platforms. Especially on M1 generation Arm64
+         * CPUs, the system counter is too coarse. Instead, use
+         * clock_gettime_nsec_np(CLOCK_UPTIME_RAW), that is equivalent to
+         * march_absolute_time(), but scaled to nanoseconds. See e.g.
+         * https://www.manpagez.com/man/3/clock_gettime_nsec_np/.
+         */
+        ctr_val = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+#endif
         *out = ctr_val;
 }
 


### PR DESCRIPTION
Replace timer from system counter to `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` on modern Apple Arm64 platforms. The two are equivalent, but the latter is scaled. That is, `mach_absolute_time()` returns tick units while `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` scales the ticks to actual nanoseconds.

This affects, for example, Apple M1's. Tick units are multiple nanoseconds (I've seen ratios 125/3). Using `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` doesn't add entropy, but amplifies the sample deltas.

On other Arm64 systems, not modern Apple, continue to use the system counter.