### PR TITLE
Correct delta sampling variance test to take into account over sampling rate

### DIFF
--- a/src/jitterentropy-gcd.c
+++ b/src/jitterentropy-gcd.c
@@ -96,7 +96,7 @@ static int jent_gcd_analyze_internal(uint64_t *delta_history, size_t nelem,
 	return 0;
 }
 
-int jent_gcd_analyze(uint64_t *delta_history, size_t nelem)
+int jent_gcd_analyze(uint64_t *delta_history, size_t nelem, size_t osr)
 {
 	uint64_t running_gcd, delta_sum;
 	int ret = jent_gcd_analyze_internal(delta_history, nelem, &running_gcd,
@@ -106,10 +106,12 @@ int jent_gcd_analyze(uint64_t *delta_history, size_t nelem)
 		return 0;
 
 	/*
-	 * Variations of deltas of time must on average be larger than 1 to
-	 * ensure the entropy estimation implied with 1 is preserved.
+	 * We assume 1/osr bits of entropy per sample. On average, variations
+	 * of deltas must be larger than 1 over osr cases; we do not capture
+	 * fractions. Hence delta_sum < (nelem / osr) means we cannot satisfy the
+	 * 1/osr bits of entropy per sample assumption.
 	 */
-	if (delta_sum <= nelem - 1) {
+	if ((delta_sum * osr) < nelem) {
 		ret = EMINVARVAR;
 		goto out;
 	}

--- a/src/jitterentropy-gcd.h
+++ b/src/jitterentropy-gcd.h
@@ -27,7 +27,7 @@ extern "C"
 {
 #endif
 
-int jent_gcd_analyze(uint64_t *delta_history, size_t nelem);
+int jent_gcd_analyze(uint64_t *delta_history, size_t nelem, size_t osr);
 uint64_t *jent_gcd_init(size_t nelem);
 void jent_gcd_fini(uint64_t *delta_history, size_t nelem);
 int jent_gcd_get(uint64_t *value);

--- a/tests/gcd/gcd.c
+++ b/tests/gcd/gcd.c
@@ -45,13 +45,18 @@ int main(int argc, char *argv[])
 	uint64_t val;
 	unsigned int i;
 
+	/*
+	 * Assumed over sampling rate. Equal to the default over sampling rate.
+	 */
+	const size_t osr = JENT_MIN_OSR;
+
 	(void)argc;
 	(void)argv;
 
 	for (i = 0; i < ELEM; i++)
 		jent_gcd_add_value(gcd, i * EXP_GCD, i);
 
-	if (jent_gcd_analyze(gcd, ELEM))
+	if (jent_gcd_analyze(gcd, ELEM, osr))
 		return 1;
 
 	jent_gcd_fini(gcd, ELEM);


### PR DESCRIPTION
Currently, the poweron selftest assumes 1 bit of entropy per sample. But, the over sampling rate can modify this assumption through the `osr` parameter. That is, the assumption globally is `1/osr` bit of entropy per sample.

This is not taken into account in the poweron selftest; in fact, the default over sampling is `osr = 3`. This is not an issue for entropy produced. It just meant that the poweron selftest was harder to pass. After this PR, the selftest becomes a bit easier to pass, but it aligns with the system assumptions made by the consumer.

To fix, correct the computation to assume variance is at least 1 in at least 1 out of `osr` samples.
A modified fix from https://github.com/smuellerDD/jitterentropy-library/pull/150.