### PR TITLE
NTG.1: add cryptographic post-processing with memory

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -183,12 +183,12 @@ extern "C" {
 #include "jitterentropy-base-user.h"
 #endif
 
-#define JENT_SHA3_256_SIZE_DIGEST_BITS	256
-#define JENT_SHA3_256_SIZE_DIGEST	(JENT_SHA3_256_SIZE_DIGEST_BITS >> 3)
+#define JENT_SHA3_512_SIZE_DIGEST_BITS	512
+#define JENT_SHA3_512_SIZE_DIGEST	(JENT_SHA3_512_SIZE_DIGEST_BITS >> 3)
 
 /*
  * The output 256 bits can receive more than 256 bits of min entropy,
- * of course, but the 256-bit output of SHA3-256(M) can only asymptotically
+ * of course, but the 256-bit output of SHA3-512_256(M) can only asymptotically
  * approach 256 bits of min entropy, not attain that bound. Random maps will
  * tend to have output collisions, which reduces the creditable output entropy
  * (that is what SP 800-90B Section 3.1.5.1.2 attempts to bound).
@@ -260,7 +260,7 @@ struct rand_data
 	 * calculate the next random value. */
 	void *hash_state;		/* SENSITIVE hash state entropy pool */
 	uint64_t prev_time;		/* SENSITIVE Previous time stamp */
-#define DATA_SIZE_BITS (JENT_SHA3_256_SIZE_DIGEST_BITS)
+#define DATA_SIZE_BITS (JENT_SHA3_512_SIZE_DIGEST_BITS / 2)
 
 #ifndef JENT_HEALTH_LAG_PREDICTOR
 	uint64_t last_delta;		/* SENSITIVE stuck test */

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -457,6 +457,7 @@ static int jent_selftest_run = 0;
 static struct rand_data
 *jent_entropy_collector_alloc_internal(unsigned int osr, unsigned int flags)
 {
+	const uint8_t initial_internal_state[DATA_SIZE_BITS / 8] = { 0 };
 	struct rand_data *entropy_collector;
 	uint32_t memsize = 0;
 
@@ -519,7 +520,10 @@ static struct rand_data
 		goto err;
 
 	/* Initialize the hash state */
-	jent_sha3_256_init(entropy_collector->hash_state);
+	jent_sha3_512_init(entropy_collector->hash_state);
+
+	/* Insert initial internal state (256 Bit zero bits) */
+	jent_sha3_update(entropy_collector->hash_state, initial_internal_state, sizeof(initial_internal_state));
 
 	/* Set the oversampling rate */
 	entropy_collector->osr = osr;
@@ -564,6 +568,17 @@ static struct rand_data
 		if (jent_notime_enable(entropy_collector, flags))
 			goto err;
 	}
+
+	/*
+	 * assure, that we always have 512 bit entropy in our hash state
+	 * before outputting a block by adding at least 256 bit before first usage.
+	 * 256 bit are always copied to the next state in jent_read_random_block.
+	 *
+	 * For NTG.1: already perform the startup stages here.
+	 */
+	do {
+		jent_random_data(entropy_collector);
+	} while(entropy_collector->startup_state != jent_startup_completed);
 
 	return entropy_collector;
 

--- a/src/jitterentropy-sha3.c
+++ b/src/jitterentropy-sha3.c
@@ -260,12 +260,12 @@ static inline void jent_sha3_init(struct jent_sha_ctx *ctx)
 	ctx->msg_len = 0;
 }
 
-void jent_sha3_256_init(struct jent_sha_ctx *ctx)
+void jent_sha3_512_init(struct jent_sha_ctx *ctx)
 {
 	jent_sha3_init(ctx);
-	ctx->r = JENT_SHA3_256_SIZE_BLOCK;
-	ctx->rword = JENT_SHA3_256_SIZE_BLOCK / sizeof(uint64_t);
-	ctx->digestsize = JENT_SHA3_256_SIZE_DIGEST;
+	ctx->r = JENT_SHA3_512_SIZE_BLOCK;
+	ctx->rword = JENT_SHA3_512_SIZE_BLOCK / sizeof(uint64_t);
+	ctx->digestsize = JENT_SHA3_512_SIZE_DIGEST;
 }
 
 static inline void jent_sha3_fill_state(struct jent_sha_ctx *ctx,
@@ -361,22 +361,27 @@ void jent_sha3_final(struct jent_sha_ctx *ctx, uint8_t *digest)
 int jent_sha3_tester(void)
 {
 	HASH_CTX_ON_STACK(ctx);
-	static const uint8_t msg_256[] = { 0x5E, 0x5E, 0xD6 };
-	static const uint8_t exp_256[] = { 0xF1, 0x6E, 0x66, 0xC0, 0x43, 0x72,
-					   0xB4, 0xA3, 0xE1, 0xE3, 0x2E, 0x07,
-					   0xC4, 0x1C, 0x03, 0x40, 0x8A, 0xD5,
-					   0x43, 0x86, 0x8C, 0xC4, 0x0E, 0xC5,
-					   0x5E, 0x00, 0xBB, 0xBB, 0xBD, 0xF5,
-					   0x91, 0x1E };
-	uint8_t act[JENT_SHA3_256_SIZE_DIGEST] = { 0 };
+	static const uint8_t msg_512[] = { 0x5E, 0x5E, 0xD6 };
+	static const uint8_t exp_512[] = { 0x73, 0xDE, 0xE5, 0x10, 0x3A, 0xE5,
+					   0xC1, 0x7E, 0x38, 0xFA, 0x2C, 0xE2,
+					   0xF4, 0x4B, 0x6F, 0x4C, 0xCA, 0x67,
+					   0x99, 0x1B, 0xDC, 0x9E, 0x9A, 0x9E,
+					   0x23, 0x19, 0xF9, 0xC5, 0x9A, 0x23,
+					   0x3A, 0x9A, 0xE8, 0x59, 0xB2, 0x83,
+					   0xE1, 0xF2, 0x03, 0x10, 0xF5, 0x96,
+					   0x04, 0x0A, 0x7D, 0x6A, 0x2C, 0xC9,
+					   0xA5, 0x49, 0xDE, 0x80, 0x09, 0x38,
+					   0x4B, 0xB7, 0x0B, 0x0B, 0xE5, 0xA5,
+					   0x55, 0x66, 0x6A, 0xD7 };
+	uint8_t act[JENT_SHA3_512_SIZE_DIGEST] = { 0 };
 	unsigned int i;
 
-	jent_sha3_256_init(&ctx);
-	jent_sha3_update(&ctx, msg_256, 3);
+	jent_sha3_512_init(&ctx);
+	jent_sha3_update(&ctx, msg_512, 3);
 	jent_sha3_final(&ctx, act);
 
-	for (i = 0; i < JENT_SHA3_256_SIZE_DIGEST; i++) {
-		if (exp_256[i] != act[i])
+	for (i = 0; i < JENT_SHA3_512_SIZE_DIGEST; i++) {
+		if (exp_512[i] != act[i])
 			return 1;
 	}
 

--- a/src/jitterentropy-sha3.h
+++ b/src/jitterentropy-sha3.h
@@ -28,9 +28,9 @@ extern "C"
 #endif
 
 #define JENT_SHA3_SIZE_BLOCK(bits)	((1600 - 2 * bits) >> 3)
-#define JENT_SHA3_256_SIZE_BLOCK                                               \
-	JENT_SHA3_SIZE_BLOCK(JENT_SHA3_256_SIZE_DIGEST_BITS)
-#define JENT_SHA3_MAX_SIZE_BLOCK	JENT_SHA3_256_SIZE_BLOCK
+#define JENT_SHA3_512_SIZE_BLOCK                                               \
+	JENT_SHA3_SIZE_BLOCK(JENT_SHA3_512_SIZE_DIGEST_BITS)
+#define JENT_SHA3_MAX_SIZE_BLOCK	JENT_SHA3_512_SIZE_BLOCK
 
 struct jent_sha_ctx {
 	uint64_t state[25];
@@ -45,7 +45,7 @@ struct jent_sha_ctx {
 #define HASH_CTX_ON_STACK(name)						       \
 	struct jent_sha_ctx name
 
-void jent_sha3_256_init(struct jent_sha_ctx *ctx);
+void jent_sha3_512_init(struct jent_sha_ctx *ctx);
 void jent_sha3_update(struct jent_sha_ctx *ctx, const uint8_t *in,
 		      size_t inlen);
 void jent_sha3_final(struct jent_sha_ctx *ctx, uint8_t *digest);


### PR DESCRIPTION
This is currently missing, in order to reach NTG.1 compliance.