### PR TITLE
secure_memory: set allocation limits

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -262,6 +262,15 @@ static inline void *jent_zalloc(size_t len)
 {
 	void *tmp = NULL;
 #ifdef LIBGCRYPT
+	/* Set the maximum usable locked memory to 2 MiB at fist call.
+	 *
+	 * You may have to adapt or delete this, if you
+	 * also use libgcrypt at other places in your software!
+	 */
+	if (!gcry_control (GCRYCTL_INITIALIZATION_FINISHED_P)) {
+		gcry_control(GCRYCTL_INIT_SECMEM, 2097152, 0);
+		gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+	}
 	/* When using the libgcrypt secure memory mechanism, all precautions
 	 * are taken to protect our state. If the user disables secmem during
 	 * runtime, it is his decision and we thus try not to overrule his

--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -308,6 +308,7 @@ static inline void jent_zfree(void *ptr, unsigned int len)
 #ifdef LIBGCRYPT
 	/* gcry_free automatically wipes memory allocated with
 	 * gcry_(x)malloc_secure */
+	(void) len;
 	gcry_free(ptr);
 #elif defined(AWSLC)
 	/* AWS-LC stores the length of allocated memory internally and automatically wipes it in OPENSSL_free */

--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -272,7 +272,7 @@ static inline void *jent_zalloc(size_t len)
 	tmp = OPENSSL_malloc(len);
 #elif defined(OPENSSL)
 	/* We only call secure malloc initialization here,
-	 * if not already done. The 64 KiB reserved here
+	 * if not already done. The 2 MiB max. reserved here
 	 * are sufficient for jitterentropy but probably
 	 * too small for a whole application doing crypto
 	 * operations with OpenSSL.
@@ -283,7 +283,7 @@ static inline void *jent_zalloc(size_t len)
 	 * May preallocate more before making the first
 	 * call into jitterentropy!*/
 	if (CRYPTO_secure_malloc_initialized() ||
-	    CRYPTO_secure_malloc_init(65536, 32)) {
+	    CRYPTO_secure_malloc_init(2097152, 32)) {
 		tmp = OPENSSL_secure_malloc(len);
 	}
 #define CONFIG_CRYPTO_CPU_JITTERENTROPY_SECURE_MEMORY


### PR DESCRIPTION
Hi Stephan,

I'm currently testing the NTG.1 code with ESDM and ran into allocation size limits I did not see when testing with jitterentropy-library alone. After setting the allocation to a sufficiently large value (2 MiB) for both libgcrypt and OpenSSL ESDM is finally usable with this branch :+1: 

Users of the library should know, what they are doing, when using secure memory, as system/per-user mlock limits apply and need to be adapted, if necessary.

BR
Markus