### PR TITLE
windows: use _WIN32 to guard __declspec(dllexport)

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -192,7 +192,7 @@ extern "C" {
 #ifdef JENT_PRIVATE_COMPILE
 # define JENT_PRIVATE_STATIC static
 #else /* JENT_PRIVATE_COMPILE */
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #define JENT_PRIVATE_STATIC __declspec(dllexport)
 #else
 #define JENT_PRIVATE_STATIC __attribute__((visibility("default")))


### PR DESCRIPTION
This switches the guard around `__declspec(dllexport)` for `JENT_PRIVATE_STATIC` from `_MSC_VER` to `_WIN32`. 

* `_MSC_VER` is only defined by MSVC, so non-MSVC Windows toolchains (MinGW-GCC, Clang/clang-mingw) were falling through to the `__attribute__((visibility("default")))` branch. That attribute is accepted on those compilers but is ignored for PE/COFF DLL export, so the symbols weren't actually being exported from the shared library when non-MSVC compilers were used.
* `_WIN32` covers every Windows target and routes them all to `dllexport`, which is the mechanism that actually works there. This is also consistent with the existing `__MINGW32__` handling a few lines below for `JENT_PTHREAD`.
* For reference, this matches the condition AWS-LC uses to gate `__declspec(dllexport)` for its shared-library builds (see [target.h](https://github.com/aws/aws-lc/blob/864b432cd7bf8218289a14131e2bde817609e6d0/include/openssl/target.h#L105) and [base.h.in](https://github.com/aws/aws-lc/blob/864b432cd7bf8218289a14131e2bde817609e6d0/include/openssl/base.h.in#L80)).
