### PR TITLE
LLM fixes with Claude Fable 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,20 @@
 cmake_minimum_required(VERSION 3.20)
 
+# Derive the version from jitterentropy.h (the single source of truth, as the
+# Makefile does) so the pkg-config / CMake package files cannot drift from the
+# library version.
+foreach(_jent_comp MAJVERSION MINVERSION PATCHLEVEL)
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/jitterentropy.h" _jent_line
+         REGEX "^#define[ \t]+JENT_${_jent_comp}[ \t]+[0-9]+")
+    string(REGEX MATCH "[0-9]+" JENT_${_jent_comp} "${_jent_line}")
+    if(NOT DEFINED JENT_${_jent_comp} OR JENT_${_jent_comp} STREQUAL "")
+        message(FATAL_ERROR "Cannot parse JENT_${_jent_comp} from jitterentropy.h")
+    endif()
+endforeach()
+
 project(jitterentropy
     LANGUAGES C
-    VERSION 3.7.0
+    VERSION ${JENT_MAJVERSION}.${JENT_MINVERSION}.${JENT_PATCHLEVEL}
 )
 set(CMAKE_C_STANDARD 11)
 
@@ -99,7 +111,12 @@ endif()
 file(GLOB JITTER_SRC "src/*.c" "arch/*.c")
 add_library(${PROJECT_NAME})
 target_sources(${PROJECT_NAME} PRIVATE ${JITTER_SRC})
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "jitterentropy.h")
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    PUBLIC_HEADER "jitterentropy.h"
+    # Match the Makefile: libjitterentropy.so.<maj>.<min>.<patch> with
+    # SONAME libjitterentropy.so.<maj>.
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
 target_compile_options(${PROJECT_NAME} PRIVATE ${JITTER_C_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${JITTER_LINKER_FLAGS})
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,10 @@ if(EXTERNAL_CRYPTO)
     target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBCRYPTO_LIBRARY})
 endif()
 
-if(INTERNAL_TIMER AND NOT ${ANDROID})
+# Note: "NOT ANDROID", not "NOT ${ANDROID}" - with ANDROID undefined the
+# expansion would leave "AND NOT" with no operand, which CMake evaluates to
+# false, silently dropping the pthread link dependency on every regular build.
+if(INTERNAL_TIMER AND NOT ANDROID)
     if(NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
         target_link_libraries(${PROJECT_NAME} PUBLIC pthread)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,10 @@ if(STACK_PROTECTOR)
     endif()
 endif()
 
-file(GLOB JITTER_SRC "src/*.c" "arch/*.c")
+# CONFIGURE_DEPENDS: re-evaluate the glob on every build so an added/removed
+# source file cannot silently produce an archive with missing objects from a
+# stale configure.
+file(GLOB JITTER_SRC CONFIGURE_DEPENDS "src/*.c" "arch/*.c")
 add_library(${PROJECT_NAME})
 target_sources(${PROJECT_NAME} PRIVATE ${JITTER_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ install-static:
 clean:
 	@- $(RM) $(NAME)
 	@- $(RM) $(OBJS)
+	@- $(RM) $(addprefix $(SRCDIR)/,$(C_OBJS)) $(addprefix $(ARCHDIR)/,$(C_OBJS))
 	@- $(RM) lib$(NAME).so*
 	@- $(RM) lib$(NAME).a
 	@- $(RM) $(analyze_plists)

--- a/arch/android/Android.mk
+++ b/arch/android/Android.mk
@@ -16,19 +16,20 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := jitterentropy
-LOCAL_CFLAGS    := -O0 -DCRYPTO_CPU_JITTERENTROPY_STAT
-LOCAL_SRC_FILES := jitterentropy-base.c jitterentropy-stat.c jitterentropy-foldtime.c
+JENT_ROOT := $(LOCAL_PATH)/../..
 
-# compile into a shared library that can be pulled into an APK
-LOCAL_STATIC_LIBRARIES := android_native_app_glue
+LOCAL_MODULE := jitterentropy
+
+# The entropy collection core must not be optimized (see the __OPTIMIZE__
+# guard in src/jitterentropy-base.c). Bionic ships pthreads inside libc, so
+# the internal timer needs no extra link library on Android.
+LOCAL_CFLAGS := -O0 -DJENT_CONF_ENABLE_INTERNAL_TIMER
+
+LOCAL_C_INCLUDES := $(JENT_ROOT) $(JENT_ROOT)/src $(JENT_ROOT)/arch
+
+# The library consists of all core sources in src/ plus the OS/architecture
+# helpers in arch/ (the same set the Makefile and CMakeLists.txt build).
+LOCAL_SRC_FILES := $(patsubst $(LOCAL_PATH)/%,%,\
+	$(wildcard $(JENT_ROOT)/src/*.c $(JENT_ROOT)/arch/*.c))
+
 include $(BUILD_SHARED_LIBRARY)
-$(call import-module,android/native_app_glue)
-
-# compilation of a standalone-binary that must be manually moved to
-# Android /data partition for execution.
-#include $(BUILD_EXECUTABLE)
-
-# compilation of the CPU Jitter RNG app
-#LOCAL_SRC_FILES := jitterentropy-base.c jitterentropy-main-user.c
-

--- a/arch/jitterentropy-arch-cache.c
+++ b/arch/jitterentropy-arch-cache.c
@@ -125,6 +125,9 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
 }
 
 /*
+ * Compiled only for the backends that use it, so the other platforms do not
+ * carry dead code (and clang's -Wunused-function noise) around.
+ *
  * x86 data-cache discovery via CPUID leaf 4 (deterministic cache parameters,
  * Intel SDM Vol. 2A; also supported by modern AMD CPUs), shared by every x86
  * backend that can issue CPUID. The instruction is issued through the supplied
@@ -141,6 +144,9 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
  *   ECX         S = number of sets - 1
  * Total size = (W + 1) * (P + 1) * (L + 1) * (S + 1).
  */
+#if defined(JENT_ARCH_CACHE_BSD_CPUID) || \
+    (defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_X86))
+
 typedef int (*jent_cpuid_count_t)(unsigned int leaf, unsigned int subleaf,
 				  unsigned int *eax, unsigned int *ebx,
 				  unsigned int *ecx, unsigned int *edx);
@@ -197,6 +203,10 @@ static inline uint32_t jent_cache_size_roundup_cpuid(jent_cpuid_count_t cpuid,
 	/* smallest power of 2 strictly greater than the summed cache size */
 	return cache_size + 1;
 }
+
+#endif /* JENT_ARCH_CACHE_BSD_CPUID || (LINUX_KERNEL && CONFIG_X86) */
+
+#if defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_ARM64)
 
 /*
  * AArch64 data-cache discovery via the cache ID registers, shared by any
@@ -262,6 +272,8 @@ static inline uint32_t jent_cache_size_roundup_arm64(uint64_t clidr, int ccidx,
 	/* smallest power of 2 strictly greater than the summed cache size */
 	return cache_size + 1;
 }
+
+#endif /* JENT_ARCH_CACHE_LINUX_KERNEL && CONFIG_ARM64 */
 
 #if defined(JENT_ARCH_CACHE_LINUX) || defined(JENT_ARCH_CACHE_APPLE)
 

--- a/arch/jitterentropy-arch-memory.c
+++ b/arch/jitterentropy-arch-memory.c
@@ -102,7 +102,13 @@
  * mirrors the dispatch priority in jent_zalloc() below: the crypto libraries
  * take precedence over the OS mlock paths.
  */
-#if defined(LIBGCRYPT) || defined(OPENSSL)
+#if defined(JENT_ARCH_MEM_LINUX_KERNEL)
+  /*
+   * Kernel memory is never paged out to swap, does not appear in user space
+   * core dumps and is wiped on free via kvfree_sensitive().
+   */
+# define JENT_MEM_SECURE
+#elif defined(LIBGCRYPT) || defined(OPENSSL)
 # define JENT_MEM_SECURE
 #elif defined(AWSLC)
   /* AWS-LC memory is wiped but not locked; not advertised as secure. */
@@ -122,7 +128,9 @@ int jent_secure_memory_supported(void)
 
 void jent_memset_secure(void *s, size_t n)
 {
-#if defined(AWSLC) || defined(OPENSSL)
+#if defined(JENT_ARCH_MEM_LINUX_KERNEL)
+	memzero_explicit(s, n);
+#elif defined(AWSLC) || defined(OPENSSL)
 	OPENSSL_cleanse(s, n);
 #elif defined(JENT_ARCH_MEM_WINDOWS)
 	SecureZeroMemory(s, n);

--- a/arch/jitterentropy-arch-memory.c
+++ b/arch/jitterentropy-arch-memory.c
@@ -95,7 +95,7 @@
 #endif /* JENT_ARCH_MEM_LINUX_KERNEL */
 
 #define JENT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-#define JENT_IS_POWER_OF_2(n) (JENT_BUILD_BUG_ON((n & (n - 1)) != 0))
+#define JENT_IS_POWER_OF_2(n) (JENT_BUILD_BUG_ON(((n) & ((n) - 1)) != 0))
 
 /*
  * Whether the active backend provides secure (locked / wiped) memory. This

--- a/arch/jitterentropy-arch-memory.h
+++ b/arch/jitterentropy-arch-memory.h
@@ -66,7 +66,9 @@
  *                      madvise(MADV_NOCORE) on FreeBSD, best effort. With
  *                      JENT_CONF_RELAX_MLOCK only the mlock failure is
  *                      tolerated; the layout is unchanged.
- *   - Linux Kernel  -> kvmalloc + jent_memset_secure
+ *   - Linux Kernel  -> kvmalloc + kvfree_sensitive; counts as secure since
+ *                      kernel memory is never paged out to swap, does not
+ *                      appear in user space core dumps and is wiped on free
  *   - other         -> plain malloc
  *
  * Whether the active path provides locked / wiped memory is reported at

--- a/arch/jitterentropy-arch-ncpu.c
+++ b/arch/jitterentropy-arch-ncpu.c
@@ -48,6 +48,8 @@
 
 #ifdef LINUX_KERNEL
 
+#include <linux/cpumask.h>	/* num_online_cpus() */
+
 #define JENT_ARCH_NCPU_LINUX_KERNEL
 
 #else /* LINUX_KERNEL */
@@ -198,7 +200,13 @@ long jent_ncpu(void)
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 #error "Linux kernel does not support internal timer"
 #endif
-	return 1;
+	/*
+	 * Only consumed by the jent_status() JSON output in kernel builds: the
+	 * sole other user, the timer-less noise-source thread setup, is
+	 * compiled out (see the #error above), so reporting the real count
+	 * cannot enable that path.
+	 */
+	return (long)num_online_cpus();
 
 #else
 	/*

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -150,7 +150,7 @@
           # JSON status to the kernel log; only useful on test systems like
           # these images.
           boot.extraModprobeConfig = ''
-            options jitter_rng verbose=1
+            options jitter_rng verbose=1 ntg1=1 cache_all=1
           '';
           environment.systemPackages = [
             (toolsFor pkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -397,6 +397,13 @@
           # The NDK host toolchain in nixpkgs is x86_64-linux only.
           // lib.optionalAttrs (system == "x86_64-linux") {
             android = androidFor system;
+            # 32-bit x86 build of the kernel module, compiled natively via the
+            # pkgsi686Linux package set (x86_64 hosts execute i686 binaries
+            # directly). Exercises the 32-bit code paths, e.g. the div64
+            # helpers replacing the libgcc 64-bit division routines that the
+            # kernel does not provide.
+            jitterentropy-module-i686 =
+              moduleFor pkgs.pkgsi686Linux pkgs.pkgsi686Linux.linuxPackages.kernel;
           });
 
       # `nix flake check` boots every VM and runs its assertions. Individual

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       lib = nixpkgs.lib;
 
       # VMs run under QEMU on the host architecture.
-      systems = [ "x86_64-linux" "aarch64-linux" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "i686-linux" ];
       forAllSystems = f: lib.genAttrs systems (system: f system);
 
       # Userspace library and tools, built with the project's CMake build.

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,59 @@
           };
         };
 
+      # Android build of the userspace library via ndk-build, verifying
+      # arch/android/Android.mk against the real NDK toolchain. The NDK is
+      # unfree, so a dedicated nixpkgs instance accepts its license for this
+      # output only; every other output stays on the unmodified package set.
+      # APP_PLATFORM=android-30 is the floor for the C11 <threads.h> that the
+      # internal-timer thread helper uses on Linux/bionic.
+      androidFor = system:
+        let
+          pkgsAndroid = import nixpkgs {
+            inherit system;
+            config = {
+              allowUnfree = true;
+              android_sdk.accept_license = true;
+            };
+          };
+          ndk = (pkgsAndroid.androidenv.composeAndroidPackages {
+            includeNDK = true;
+          }).ndk-bundle;
+        in pkgsAndroid.stdenv.mkDerivation {
+          pname = "jitterentropy-android";
+          version = "3.7.1";
+          src = self;
+          nativeBuildInputs = [ ndk ];
+          dontConfigure = true;
+
+          buildPhase = ''
+            runHook preBuild
+            ndk-build \
+              NDK_PROJECT_PATH=null \
+              APP_BUILD_SCRIPT=$(pwd)/arch/android/Android.mk \
+              APP_PLATFORM=android-30 \
+              APP_ABI="arm64-v8a x86_64" \
+              APP_OPTIM=release \
+              NDK_OUT=$TMPDIR/obj \
+              NDK_LIBS_OUT=$TMPDIR/libs \
+              -j"$NIX_BUILD_CORES" V=1
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib
+            cp -r $TMPDIR/libs/* $out/lib/
+            runHook postInstall
+          '';
+
+          meta = {
+            description =
+              "Jitter RNG userspace library built with the Android NDK";
+            license = lib.licenses.bsd3;
+          };
+        };
+
       # Out-of-tree kernel module (jitter_rng.ko) built against a given kernel.
       # The with* arguments mirror the CONFIG_EXTERNAL_JITTERENTROPY_* options
       # in linux_kernel/Kbuild.config and are passed on the make command line,
@@ -340,7 +393,11 @@
           # selection is tunable via .override { withChardev, withHwrng,
           # withTestInterface }.
           jitterentropy-module = moduleFor pkgs pkgs.linuxPackages.kernel;
-        } // isosFor system pkgs);
+        } // isosFor system pkgs
+          # The NDK host toolchain in nixpkgs is x86_64-linux only.
+          // lib.optionalAttrs (system == "x86_64-linux") {
+            android = androidFor system;
+          });
 
       # `nix flake check` boots every VM and runs its assertions. Individual
       # VMs can be run with e.g. `nix build .#checks.x86_64-linux.vm-linux_6_6`.

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,15 @@
             imports = [ (machineFor kernelPackages) ];
             boot.kernelParams = [ "clocksource=tsc" "tsc=reliable" ];
             virtualisation.qemu.options = [ "-cpu" "host" ];
+            # The O_NONBLOCK test needs a poller that runs while a concurrent
+            # reader holds the instance lock. On one vCPU that requires the
+            # kernel to preempt the lock holder inside the locked section;
+            # non-preemptible kernel builds (5.10, plain PREEMPT_VOLUNTARY)
+            # only reschedule at the reader's cond_resched() after unlock, so
+            # the poller would always find the lock free and never see
+            # EAGAIN. A second vCPU makes the contention real concurrency,
+            # independent of the kernel's preemption model.
+            virtualisation.cores = 2;
           };
 
           testScript = ''

--- a/flake.nix
+++ b/flake.nix
@@ -210,7 +210,7 @@
           services.getty.autologinUser = lib.mkForce "root";
           console.keyMap = "de";
           environment.shellAliases = {
-            "sample_kernel" = "getrawentropy --samples 1000000 --debugfs-file /sys/kernel/debug/jitter_rng/jent_raw_hires";
+            "sample_kernel" = "getrawentropy --ntg1 --samples 1000000 --debugfs-file /sys/kernel/debug/jitter_rng/jent_raw_hires";
             "clock_rdtsc" = "echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource";
             "jitter_hwrng" = "echo jitterentropy > /sys/class/misc/hw_random/rng_current";
             "show_hwrng" = "cat /sys/class/misc/hw_random/rng_current";
@@ -331,16 +331,34 @@
           '';
         };
 
-      # Every kernel package set exposed by nixpkgs that provides a real kernel
-      # derivation. tryEval guards the sets that fail to evaluate (unfree,
-      # unsupported on the current system, ...). Note that board-specific
-      # kernels (e.g. linux_rpi*) only boot on a matching host architecture.
+      # One kernel module package per nixpkgs kernel, plus the default and
+      # latest kernels, mirroring the VM test and image sets. Interface
+      # selection is tunable on every attribute via .override { withChardev,
+      # withHwrng, withTestInterface }.
+      modulesFor = pkgs:
+        (lib.mapAttrs'
+          (name: ps:
+            lib.nameValuePair "jitterentropy-module-${name}"
+              (moduleFor pkgs ps.kernel))
+          (kernelSetsFor pkgs)) // {
+            jitterentropy-module = moduleFor pkgs pkgs.linuxPackages.kernel;
+            jitterentropy-module-latest =
+              moduleFor pkgs pkgs.linuxPackages_latest.kernel;
+          };
+
+      # The numbered kernel package sets exposed by nixpkgs (linux_6_12, ...)
+      # plus the mainline testing kernel — the flavored variants (zen,
+      # xanmod, hardened, libre, rpi, ...) are of no interest here. tryEval
+      # guards the sets that fail to evaluate (unsupported on the current
+      # system, ...).
       kernelSetsFor = pkgs:
-        lib.filterAttrs (_name: ps:
+        lib.filterAttrs (name: ps:
           let
             r = builtins.tryEval
               (lib.isAttrs ps && ps ? kernel && lib.isDerivation ps.kernel);
-          in r.success && r.value) pkgs.linuxKernel.packages;
+          in (builtins.match "linux_[0-9]+_[0-9]+" name != null
+            || name == "linux_testing") && r.success && r.value)
+          pkgs.linuxKernel.packages;
 
       # One VM test per nixpkgs kernel, plus the default and latest kernels.
       vmTestsFor = pkgs:
@@ -383,17 +401,56 @@
             iso = mkIso system "default" pkgs.linuxPackages;
             iso-latest = mkIso system "latest" pkgs.linuxPackages_latest;
           };
+
+      # A bootable SD card image for the 64-bit Raspberry Pi boards (Zero 2,
+      # 3, 4, 5) booting the shared machine configuration on the chosen
+      # kernel, for exercising the Jitter RNG on real hardware without a
+      # bootable CD path. Build with e.g. `nix build .#sd-image-linux_6_18`;
+      # the image lands in
+      # result/sd-image/jitterentropy-<name>-<kernel version>.img.zst.
+      mkSdImage = system: name: kernelPackages:
+        (lib.nixosSystem {
+          modules = [
+            "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+            (machineFor kernelPackages)
+            ({ config, lib, ... }: {
+              nixpkgs.hostPlatform = system;
+              image.baseName = lib.mkForce
+                "jitterentropy-${name}-${config.boot.kernelPackages.kernel.version}";
+              # The base profile pulled in by sd-image-aarch64.nix enables
+              # ZFS whenever the platform supports it; not every kernel here
+              # has a compatible ZFS module (latest, rpi, ...), and the test
+              # image does not need ZFS.
+              boot.supportedFilesystems.zfs = lib.mkForce false;
+              # Throwaway test image, no state to migrate.
+              system.stateVersion = lib.trivial.release;
+            })
+          ];
+        }).config.system.build.sdImage;
+
+      # One SD image per kernel set, plus the default and latest kernels,
+      # mirroring the ISO set. The nixos-hardware vendor kernels (rpi3, rpi4,
+      # rpi5) are among them; the default mainline kernel is the combination
+      # the upstream image targets.
+      sdImagesFor = system: pkgs:
+        (lib.mapAttrs'
+          (name: ps:
+            lib.nameValuePair "sd-image-${name}" (mkSdImage system name ps))
+          (kernelSetsFor pkgs)) // {
+            sd-image = mkSdImage system "default" pkgs.linuxPackages;
+            sd-image-latest = mkSdImage system "latest" pkgs.linuxPackages_latest;
+          };
     in {
       packages = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
         in {
           default = toolsFor pkgs;
           jitterentropy-tools = toolsFor pkgs;
-          # Module built against the nixpkgs default kernel. Interface
-          # selection is tunable via .override { withChardev, withHwrng,
-          # withTestInterface }.
-          jitterentropy-module = moduleFor pkgs pkgs.linuxPackages.kernel;
-        } // isosFor system pkgs
+        } // modulesFor pkgs
+          // isosFor system pkgs
+          # The SD images boot Raspberry Pi boards, which are aarch64.
+          // lib.optionalAttrs (system == "aarch64-linux")
+            (sdImagesFor system pkgs)
           # The NDK host toolchain in nixpkgs is x86_64-linux only.
           // lib.optionalAttrs (system == "x86_64-linux") {
             android = androidFor system;
@@ -403,7 +460,7 @@
             # helpers replacing the libgcc 64-bit division routines that the
             # kernel does not provide.
             jitterentropy-module-i686 =
-              moduleFor pkgs.pkgsi686Linux pkgs.pkgsi686Linux.linuxPackages.kernel;
+              moduleFor pkgs.pkgsi686Linux pkgs.pkgsi686Linux.linuxPackages_latest.kernel;
           });
 
       # `nix flake check` boots every VM and runs its assertions. Individual

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -148,7 +148,7 @@ extern "C" {
 				 memory access? By default it is only the L1
 				 cache size. */
 
-#ifdef LINUX_KERNEL
+#if defined(LINUX_KERNEL) && !defined(UINT32_C)
 #define UINT32_C(c)	c ## U
 #endif
 

--- a/linux_kernel/Kbuild.config
+++ b/linux_kernel/Kbuild.config
@@ -46,10 +46,11 @@ CONFIG_EXTERNAL_JITTERENTROPY=m
 # Dependencies: N/A
 # The option can either be either commented out or 'y'.
 #
-# When enabled, the kernel crypto API RNG `jitter_rng` (when compiled
-# with CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE=n or this option being unset)
-# or `jitterentropy_rng` (when compiled with
-# CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE=y) is registered
+# When enabled, the kernel crypto API RNG `jitter_rng` (when
+# CONFIG_BUILTIN_JITTERENTROPY is unset - the name avoids a clash with the
+# in-kernel Jitter RNG copy) or `jitterentropy_rng` (when compiled with
+# CONFIG_BUILTIN_JITTERENTROPY=y as part of the kernel) is registered; see
+# jent_alg.base.cra_name in jitterentropy_kcapi.c
 #
 CONFIG_EXTERNAL_JITTERENTROPY_KCAPI=y
 

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -244,8 +244,10 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
 * `flags_raw`: the effective flags value as a plain hexadecimal number (e.g.
   `0x00000060`), directly reusable as the `flags=` module parameter.
 
-* `osr`: the OSR module parameter value as a plain number (`0` selects the
-  default), directly reusable as the `osr=` module parameter.
+* `osr`: the effective OSR as a plain number, directly reusable as the `osr=`
+  module parameter. Reports the value the collectors actually run with: an
+  `osr=` request below the library minimum (including the default `0`) is
+  raised to that minimum.
 
 * `statistics`: module-wide statistics in JSON format. It currently reports the
   character-device instances (one Jitter RNG entropy collector is allocated per

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -222,6 +222,19 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
 
 * `version`: the Jitter RNG library version (e.g. `3.7.1`).
 
+* `flags`: human-readable breakdown of the effective flags value shared by the
+  kernel interfaces (raw value, the state of every used `JENT_*` flag bit and
+  the decoded memory-size and hash-loop fields):
+
+		flags:                       0x00000060
+		JENT_DISABLE_MEMORY_ACCESS:  off
+		JENT_FORCE_INTERNAL_TIMER:   off
+		JENT_DISABLE_INTERNAL_TIMER: off
+		JENT_FORCE_FIPS:             on
+		JENT_NTG1:                   on
+		JENT_CACHE_ALL:              off
+		max memory size:             auto (derived from cache size)
+		hash loop count:             default
 
 * `statistics`: module-wide statistics in JSON format. It currently reports the
   character-device instances (one Jitter RNG entropy collector is allocated per

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -53,6 +53,30 @@ Compilation:
 
 3. Insert the compiled Linux kernel `jitter_rng.ko`
 
+### Module Parameters
+
+The module offers the following load-time parameters:
+
+* `osr`: OSR applied to all Jitter RNG instances (0 selects the default).
+
+* `flags`: numeric flags value applied to all Jitter RNG instances, using the
+  `JENT_*` flag bits from `jitterentropy.h`.
+
+* `ntg1`: boolean shortcut enabling AIS 20/31 NTG.1 compliant operation
+  without knowing the numeric value of the `JENT_NTG1` flag bit. Equivalent to
+  setting that bit in `flags`.
+
+* `force_fips`: boolean shortcut forcing FIPS compliant operation without
+  knowing the numeric value of the `JENT_FORCE_FIPS` flag bit. Equivalent to
+  setting that bit in `flags`.
+
+* `verbose`: enable verbose logging.
+
+The shortcut parameters are folded into `flags` during module initialization,
+so reading the `flags` sysfs file reports the effective configuration. Example:
+
+	insmod jitter_rng.ko ntg1=1 osr=3
+
 ## Build in Tree
 
 When the use of the Jitter RNG as a kernel module is insufficient, e.g. when its

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -227,39 +227,45 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
 
 * `version`: the Jitter RNG library version (e.g. `3.7.1`).
 
-* `flags`: human-readable breakdown of the effective flags value shared by the
-  kernel interfaces (raw value, the state of every used `JENT_*` flag bit and
-  the decoded memory-size and hash-loop fields):
+* `config/`: a subdirectory grouping the effective runtime configuration
+  shared by the kernel interfaces:
 
-		flags:                       0x00000060
-		JENT_DISABLE_MEMORY_ACCESS:  off
-		JENT_FORCE_INTERNAL_TIMER:   off
-		JENT_DISABLE_INTERNAL_TIMER: off
-		JENT_FORCE_FIPS:             on
-		JENT_NTG1:                   on
-		JENT_CACHE_ALL:              off
-		max memory size:             auto (derived from cache size)
-		hash loop count:             default
+    * `config/flags`: human-readable breakdown of the effective flags value
+      (raw value, the state of every used `JENT_*` flag bit and the decoded
+      memory-size and hash-loop fields):
 
-* `flags_raw`: the effective flags value as a plain hexadecimal number (e.g.
-  `0x00000060`), directly reusable as the `flags=` module parameter.
+			flags:                       0x00000060
+			JENT_DISABLE_MEMORY_ACCESS:  off
+			JENT_FORCE_INTERNAL_TIMER:   off
+			JENT_DISABLE_INTERNAL_TIMER: off
+			JENT_FORCE_FIPS:             on
+			JENT_NTG1:                   on
+			JENT_CACHE_ALL:              off
+			max memory size:             auto (derived from cache size)
+			hash loop count:             default
 
-* `osr`: the effective OSR as a plain number, directly reusable as the `osr=`
-  module parameter. Reports the value the collectors actually run with: an
-  `osr=` request below the library minimum (including the default `0`) is
-  raised to that minimum.
+    * `config/flags_raw`: the effective flags value as a plain hexadecimal
+      number (e.g. `0x00000060`), directly reusable as the `flags=` module
+      parameter.
 
-* `ntg1`: plain `0`/`1` indicating whether AIS 20/31 NTG.1 compliant operation
-  is in effect.
+    * `config/osr`: the effective OSR as a plain number, directly reusable as
+      the `osr=` module parameter. Reports the value the collectors actually
+      run with: an `osr=` request below the library minimum (including the
+      default `0`) is raised to that minimum.
 
-* `fips`: plain `0`/`1` indicating whether FIPS compliant operation is in
-  effect - when the `JENT_FORCE_FIPS` flag is set, when the kernel itself runs
-  in FIPS mode (`fips=1` kernel command line), or when NTG.1 mode is enabled
-  (NTG.1 implies FIPS operation).
+    * `config/ntg1`: plain `0`/`1` indicating whether AIS 20/31 NTG.1
+      compliant operation is in effect.
 
-* `kcapi`, `hwrng`, `chardev`, `testing`: plain `0`/`1` indicating whether the
-  respective optional interface (crypto API, hwrng, character device, debugfs
-  test interface) was compiled into this module build (the
+    * `config/fips`: plain `0`/`1` indicating whether FIPS compliant operation
+      is in effect - when the `JENT_FORCE_FIPS` flag is set, when the kernel
+      itself runs in FIPS mode (`fips=1` kernel command line), or when NTG.1
+      mode is enabled (NTG.1 implies FIPS operation).
+
+* `interfaces/`: a subdirectory grouping the compile-time interface
+  availability of this module build. `interfaces/kcapi`, `interfaces/hwrng`,
+  `interfaces/chardev` and `interfaces/testing` each report a plain `0`/`1`
+  indicating whether the respective optional interface (crypto API, hwrng,
+  character device, debugfs test interface) was compiled in (the
   `CONFIG_EXTERNAL_JITTERENTROPY_*` options in `Kbuild.config`).
 
 * `statistics`: module-wide statistics in JSON format. It currently reports the

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -70,6 +70,11 @@ The module offers the following load-time parameters:
   knowing the numeric value of the `JENT_FORCE_FIPS` flag bit. Equivalent to
   setting that bit in `flags`.
 
+* `cache_all`: boolean shortcut deriving the memory access region from the
+  size of all caches instead of only the L1 cache, without knowing the numeric
+  value of the `JENT_CACHE_ALL` flag bit. Equivalent to setting that bit in
+  `flags`.
+
 * `verbose`: enable verbose logging.
 
 The shortcut parameters are folded into `flags` during module initialization,

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -257,6 +257,11 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
   in FIPS mode (`fips=1` kernel command line), or when NTG.1 mode is enabled
   (NTG.1 implies FIPS operation).
 
+* `kcapi`, `hwrng`, `chardev`, `testing`: plain `0`/`1` indicating whether the
+  respective optional interface (crypto API, hwrng, character device, debugfs
+  test interface) was compiled into this module build (the
+  `CONFIG_EXTERNAL_JITTERENTROPY_*` options in `Kbuild.config`).
+
 * `statistics`: module-wide statistics in JSON format. It currently reports the
   character-device instances (one Jitter RNG entropy collector is allocated per
   `open()` of `/dev/jitterentropy`):

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -241,6 +241,12 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
 		max memory size:             auto (derived from cache size)
 		hash loop count:             default
 
+* `flags_raw`: the effective flags value as a plain hexadecimal number (e.g.
+  `0x00000060`), directly reusable as the `flags=` module parameter.
+
+* `osr`: the OSR module parameter value as a plain number (`0` selects the
+  default), directly reusable as the `osr=` module parameter.
+
 * `statistics`: module-wide statistics in JSON format. It currently reports the
   character-device instances (one Jitter RNG entropy collector is allocated per
   `open()` of `/dev/jitterentropy`):

--- a/linux_kernel/README.md
+++ b/linux_kernel/README.md
@@ -249,6 +249,14 @@ When the kernel provides `CONFIG_PROC_FS`, the module creates the directory
   `osr=` request below the library minimum (including the default `0`) is
   raised to that minimum.
 
+* `ntg1`: plain `0`/`1` indicating whether AIS 20/31 NTG.1 compliant operation
+  is in effect.
+
+* `fips`: plain `0`/`1` indicating whether FIPS compliant operation is in
+  effect - when the `JENT_FORCE_FIPS` flag is set, when the kernel itself runs
+  in FIPS mode (`fips=1` kernel command line), or when NTG.1 mode is enabled
+  (NTG.1 implies FIPS operation).
+
 * `statistics`: module-wide statistics in JSON format. It currently reports the
   character-device instances (one Jitter RNG entropy collector is allocated per
   `open()` of `/dev/jitterentropy`):

--- a/linux_kernel/jitterentropy_chardev.c
+++ b/linux_kernel/jitterentropy_chardev.c
@@ -52,7 +52,7 @@ extern int flags;
 #define JENT_CHARDEV_READ_BUF_SIZE 32
 
 /*
- * Subdirectory /proc/jitter_rng/instances holding one status file per open
+ * Subdirectory /proc/jitterentropy/instances holding one status file per open
  * character-device instance. NULL if procfs is unavailable.
  */
 static struct proc_dir_entry *jent_chardev_proc_dir;
@@ -62,13 +62,13 @@ static struct proc_dir_entry *jent_chardev_proc_dir;
 struct jent_chardev_ctx {
 	struct mutex lock;
 	struct rand_data *entropy_collector;
-	/* Per-instance status file /proc/jitter_rng/instances/<uuid>. */
+	/* Per-instance status file /proc/jitterentropy/instances/<uuid>. */
 	struct proc_dir_entry *proc;
 };
 
 /*
  * Emit the JSON status string of a single open instance, exported read-only as
- * /proc/jitter_rng/instances/<id>. Holds the instance lock (as read()/ioctl()
+ * /proc/jitterentropy/instances/<id>. Holds the instance lock (as read()/ioctl()
  * do) so the collector cannot be reallocated on health-test recovery while
  * jent_status() runs.
  */
@@ -146,8 +146,8 @@ static int jent_chardev_open(struct inode *inode, struct file *file)
 	file->private_data = ctx;
 
 	/*
-	 * Account for this instance in /proc/jitter_rng/statistics and publish
-	 * its status under /proc/jitter_rng/instances/<uuid>.
+	 * Account for this instance in /proc/jitterentropy/statistics and
+	 * publish its status under /proc/jitterentropy/instances/<uuid>.
 	 */
 	jent_proc_instance_inc();
 	jent_chardev_instance_proc_create(ctx);

--- a/linux_kernel/jitterentropy_chardev.c
+++ b/linux_kernel/jitterentropy_chardev.c
@@ -42,7 +42,7 @@
  * parameters of the same name (see jitterentropy_mod.c).
  */
 extern unsigned int osr;
-extern int flags;
+extern unsigned int flags;
 
 /*
  * Largest chunk handed to jent_read_entropy_safe() in one iteration. The

--- a/linux_kernel/jitterentropy_chardev.c
+++ b/linux_kernel/jitterentropy_chardev.c
@@ -24,6 +24,8 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/proc_fs.h>
+#include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <linux/seq_file.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>

--- a/linux_kernel/jitterentropy_chardev.c
+++ b/linux_kernel/jitterentropy_chardev.c
@@ -17,6 +17,7 @@
  */
 
 #include <linux/fs.h>
+#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/miscdevice.h>
 #include <linux/mm.h>
@@ -388,7 +389,7 @@ static struct miscdevice jent_chardev_misc = {
 	.mode	= 0444,
 };
 
-int jent_chardev_init(void)
+int __init jent_chardev_init(void)
 {
 	int ret = misc_register(&jent_chardev_misc);
 

--- a/linux_kernel/jitterentropy_chardev.h
+++ b/linux_kernel/jitterentropy_chardev.h
@@ -10,7 +10,9 @@
 
 #ifdef CONFIG_EXTERNAL_JITTERENTROPY_CHARDEV
 
-int jent_chardev_init(void);
+#include <linux/init.h>
+
+int __init jent_chardev_init(void);
 void jent_chardev_exit(void);
 
 #else /* CONFIG_EXTERNAL_JITTERENTROPY_CHARDEV */

--- a/linux_kernel/jitterentropy_hwrng.c
+++ b/linux_kernel/jitterentropy_hwrng.c
@@ -119,7 +119,7 @@ static struct hwrng jent_hwrng = {
 
 /*
  * Status of the global hwrng Jitter RNG instance, exported read-only as
- * /proc/jitter_rng/hwrng_status. Reading it emits the JSON status string
+ * /proc/jitterentropy/hwrng_status. Reading it emits the JSON status string
  * produced by jent_status() (version, health-test state, runtime environment
  * and configuration) for the single instance backing /dev/hwrng.
  */

--- a/linux_kernel/jitterentropy_hwrng.c
+++ b/linux_kernel/jitterentropy_hwrng.c
@@ -39,7 +39,7 @@
  * the same name (see jitterentropy_mod.c).
  */
 extern unsigned int osr;
-extern int flags;
+extern unsigned int flags;
 
 /*
  * Entropy quality declared to the hw_random framework, expressed as the number

--- a/linux_kernel/jitterentropy_hwrng.c
+++ b/linux_kernel/jitterentropy_hwrng.c
@@ -18,6 +18,7 @@
  */
 
 #include <linux/hw_random.h>
+#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/mm.h>
 #include <linux/module.h>
@@ -163,7 +164,7 @@ static int jent_hwrng_proc_status_show(struct seq_file *m, void *v)
 	return 0;
 }
 
-int jent_hwrng_init(void)
+int __init jent_hwrng_init(void)
 {
 	int ret;
 

--- a/linux_kernel/jitterentropy_hwrng.c
+++ b/linux_kernel/jitterentropy_hwrng.c
@@ -64,8 +64,18 @@ extern unsigned int flags;
  */
 static unsigned int hwrng_quality = 0;
 module_param(hwrng_quality, uint, S_IRUSR | S_IRGRP | S_IROTH);
+/*
+ * The promotion of quality 0 exists only since kernel 6.2, so only builds for
+ * those kernels carry the hint - on older kernels it would describe behavior
+ * the running kernel does not have.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 MODULE_PARM_DESC(hwrng_quality,
-		 "Jitter RNG hwrng entropy quality (bits per 1024 bits, 0..1024; on kernels >= 6.2 the hw_random core promotes 0 to rng_core.default_quality)");
+		 "Jitter RNG hwrng entropy quality (bits per 1024 bits, 0..1024; the hw_random core promotes 0 to rng_core.default_quality)");
+#else
+MODULE_PARM_DESC(hwrng_quality,
+		 "Jitter RNG hwrng entropy quality (bits per 1024 bits, 0..1024; 0 registers without crediting entropy to the random pool)");
+#endif
 
 /* State backing the single hwrng instance. */
 struct jent_hwrng_ctx {

--- a/linux_kernel/jitterentropy_hwrng.h
+++ b/linux_kernel/jitterentropy_hwrng.h
@@ -10,7 +10,9 @@
 
 #ifdef CONFIG_EXTERNAL_JITTERENTROPY_HWRNG
 
-int jent_hwrng_init(void);
+#include <linux/init.h>
+
+int __init jent_hwrng_init(void);
 void jent_hwrng_exit(void);
 
 #else /* CONFIG_EXTERNAL_JITTERENTROPY_HWRNG */

--- a/linux_kernel/jitterentropy_kcapi.c
+++ b/linux_kernel/jitterentropy_kcapi.c
@@ -25,7 +25,7 @@
  * same name (see jitterentropy_mod.c).
  */
 extern unsigned int osr;
-extern int flags;
+extern unsigned int flags;
 extern unsigned int verbose;
 
 /***************************************************************************

--- a/linux_kernel/jitterentropy_kcapi.c
+++ b/linux_kernel/jitterentropy_kcapi.c
@@ -6,8 +6,6 @@
  */
 
 
-#include <crypto/hash.h>
-#include <crypto/sha3.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/mm.h>
@@ -15,7 +13,6 @@
 #include <linux/ratelimit.h>
 #include <linux/slab.h>
 #include <linux/string.h>
-#include <linux/time.h>
 #include <crypto/internal/rng.h>
 
 #include "jitterentropy.h"

--- a/linux_kernel/jitterentropy_kcapi.c
+++ b/linux_kernel/jitterentropy_kcapi.c
@@ -8,6 +8,7 @@
 
 #include <crypto/hash.h>
 #include <crypto/sha3.h>
+#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/mm.h>
 #include <linux/module.h>
@@ -201,7 +202,7 @@ static struct rng_alg jent_alg = {
 	}
 };
 
-int jent_kcapi_init(void)
+int __init jent_kcapi_init(void)
 {
 	return crypto_register_rng(&jent_alg);
 }

--- a/linux_kernel/jitterentropy_kcapi.h
+++ b/linux_kernel/jitterentropy_kcapi.h
@@ -10,7 +10,9 @@
 
 #ifdef CONFIG_EXTERNAL_JITTERENTROPY_KCAPI
 
-int jent_kcapi_init(void);
+#include <linux/init.h>
+
+int __init jent_kcapi_init(void);
 void jent_kcapi_exit(void);
 
 #else /* CONFIG_EXTERNAL_JITTERENTROPY_KCAPI */

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -62,45 +62,65 @@ static int __init jent_mod_init(void)
 
 	jent_proc_init();
 
-	/*
-	 * Register the debugfs test interface only after the library
-	 * initialization above completed: the file is visible to userspace
-	 * immediately, and a read triggers library init paths that must not
-	 * run concurrently with jent_entropy_init_ex().
-	 */
-	jent_testing_init();
-
 	ret = jent_kcapi_init();
 	if (ret)
 		goto err;
 
-	ret = jent_chardev_init();
+	ret = jent_hwrng_init();
 	if (ret)
 		goto err_crypto;
 
-	ret = jent_hwrng_init();
+	/*
+	 * Register the character device after all other fallible steps:
+	 * misc_register() makes /dev/jitterentropy openable by userspace
+	 * (e.g. udev) immediately, and misc_deregister() does not wait for
+	 * open files. If a later init step failed after the device went live,
+	 * an already-open file would keep pointing into a module that init
+	 * failure frees. The hwrng registration is safe to precede it as
+	 * hwrng_unregister() drains all readers before returning.
+	 */
+	ret = jent_chardev_init();
 	if (ret)
-		goto err_chardev;
+		goto err_hwrng;
+
+	/*
+	 * Register the debugfs test interface as the very last step: like the
+	 * character device, the file is visible to userspace immediately and
+	 * debugfs_remove_recursive() does not wait for open files, so it must
+	 * not be created while a later init step could still fail (an open
+	 * file would outlive the module memory freed on init failure). Being
+	 * after jent_entropy_init_ex() also keeps its reads from racing the
+	 * library initialization. jent_testing_init() itself cannot fail, so
+	 * no unwind is needed for it.
+	 */
+	jent_testing_init();
 
 	return 0;
 
-err_chardev:
-	jent_chardev_exit();
+err_hwrng:
+	jent_hwrng_exit();
 err_crypto:
 	jent_kcapi_exit();
 err:
-	jent_testing_exit();
 	jent_proc_exit();
 	return ret;
 }
 
 static void __exit jent_mod_exit(void)
 {
-	jent_hwrng_exit();
-	jent_chardev_exit();
-	jent_proc_exit();
+	/*
+	 * Tear down in reverse order of the registrations in jent_mod_init().
+	 * The relative order of the character device, hwrng and procfs teardown
+	 * matters: both interfaces remove their status files below the shared
+	 * /proc/jitterentropy directory, so their exits must run before
+	 * jent_proc_exit() removes that directory recursively (a later
+	 * proc_remove() on an already-removed entry would act on freed memory).
+	 */
 	jent_testing_exit();
+	jent_chardev_exit();
+	jent_hwrng_exit();
 	jent_kcapi_exit();
+	jent_proc_exit();
 }
 
 module_init(jent_mod_init);

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -92,7 +92,9 @@ static int __init jent_mod_init(void)
 		return -EFAULT;
 	}
 
-	jent_proc_init();
+	ret = jent_proc_init();
+	if (ret)
+		return ret;
 
 	ret = jent_kcapi_init();
 	if (ret)
@@ -103,32 +105,38 @@ static int __init jent_mod_init(void)
 		goto err_crypto;
 
 	/*
-	 * Register the character device after all other fallible steps:
-	 * misc_register() makes /dev/jitterentropy openable by userspace
-	 * (e.g. udev) immediately, and misc_deregister() does not wait for
-	 * open files. If a later init step failed after the device went live,
-	 * an already-open file would keep pointing into a module that init
-	 * failure frees. The hwrng registration is safe to precede it as
-	 * hwrng_unregister() drains all readers before returning.
+	 * Register the debugfs test interface before the character device:
+	 * only one of the two userspace-visible interfaces can be the last
+	 * fallible init step, and unwinding the debugfs file is the safer of
+	 * the two — the debugfs proxy fails its file operations after
+	 * debugfs_remove_recursive(), and unlike /dev/jitterentropy (created
+	 * and potentially opened by udev immediately) nothing opens the test
+	 * interface automatically in the window before the unwind. Being
+	 * after jent_entropy_init_ex() also keeps its reads from racing the
+	 * library initialization.
 	 */
-	ret = jent_chardev_init();
+	ret = jent_testing_init();
 	if (ret)
 		goto err_hwrng;
 
 	/*
-	 * Register the debugfs test interface as the very last step: like the
-	 * character device, the file is visible to userspace immediately and
-	 * debugfs_remove_recursive() does not wait for open files, so it must
-	 * not be created while a later init step could still fail (an open
-	 * file would outlive the module memory freed on init failure). Being
-	 * after jent_entropy_init_ex() also keeps its reads from racing the
-	 * library initialization. jent_testing_init() itself cannot fail, so
-	 * no unwind is needed for it.
+	 * Register the character device as the very last step and after all
+	 * other fallible steps: misc_register() makes /dev/jitterentropy
+	 * openable by userspace (e.g. udev) immediately, and
+	 * misc_deregister() does not wait for open files. If a later init
+	 * step failed after the device went live, an already-open file would
+	 * keep pointing into a module that init failure frees. The hwrng
+	 * registration is safe to precede it as hwrng_unregister() drains all
+	 * readers before returning.
 	 */
-	jent_testing_init();
+	ret = jent_chardev_init();
+	if (ret)
+		goto err_testing;
 
 	return 0;
 
+err_testing:
+	jent_testing_exit();
 err_hwrng:
 	jent_hwrng_exit();
 err_crypto:
@@ -148,8 +156,8 @@ static void __exit jent_mod_exit(void)
 	 * jent_proc_exit() removes that directory recursively (a later
 	 * proc_remove() on an already-removed entry would act on freed memory).
 	 */
-	jent_testing_exit();
 	jent_chardev_exit();
+	jent_testing_exit();
 	jent_hwrng_exit();
 	jent_kcapi_exit();
 	jent_proc_exit();

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -50,6 +50,7 @@ unsigned int verbose = 0;
  */
 static bool ntg1 = false;
 static bool force_fips = false;
+static bool cache_all = false;
 
 module_param(osr, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(osr, "Jitter RNG OSR parameter");
@@ -61,6 +62,8 @@ module_param(ntg1, bool, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(ntg1, "Enable AIS 20/31 NTG.1 compliant operation (shortcut for the JENT_NTG1 bit in flags)");
 module_param(force_fips, bool, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(force_fips, "Force FIPS compliant operation (shortcut for the JENT_FORCE_FIPS bit in flags)");
+module_param(cache_all, bool, S_IRUSR | S_IRGRP | S_IROTH);
+MODULE_PARM_DESC(cache_all, "Derive the memory access region from the size of all caches instead of L1 only (shortcut for the JENT_CACHE_ALL bit in flags)");
 
 static int __init jent_mod_init(void)
 {
@@ -76,6 +79,8 @@ static int __init jent_mod_init(void)
 		flags |= JENT_NTG1;
 	if (force_fips)
 		flags |= JENT_FORCE_FIPS;
+	if (cache_all)
+		flags |= JENT_CACHE_ALL;
 
 	ret = jent_entropy_init_ex(osr, flags);
 	if (ret) {

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -42,16 +42,40 @@ unsigned int osr = 0;
 int flags = 0;
 unsigned int verbose = 0;
 
+/*
+ * Shortcut parameters for common operation modes. They are folded into the
+ * shared flags value in jent_mod_init(), so the effective configuration is
+ * visible in the flags sysfs file; the numeric flag bits do not need to be
+ * known to request the modes.
+ */
+static bool ntg1 = false;
+static bool force_fips = false;
+
 module_param(osr, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(osr, "Jitter RNG OSR parameter");
 module_param(flags, int, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(flags, "Jitter RNG flags parameter");
 module_param(verbose, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(verbose, "Jitter RNG verbose logging");
+module_param(ntg1, bool, S_IRUSR | S_IRGRP | S_IROTH);
+MODULE_PARM_DESC(ntg1, "Enable AIS 20/31 NTG.1 compliant operation (shortcut for the JENT_NTG1 bit in flags)");
+module_param(force_fips, bool, S_IRUSR | S_IRGRP | S_IROTH);
+MODULE_PARM_DESC(force_fips, "Force FIPS compliant operation (shortcut for the JENT_FORCE_FIPS bit in flags)");
 
 static int __init jent_mod_init(void)
 {
 	int ret = 0;
+
+	/*
+	 * Fold the shortcut parameters into the shared flags value before any
+	 * user of it runs: the interfaces (crypto API, hwrng, character
+	 * device) allocate their collectors from flags at open/instantiation
+	 * time, and the sysfs flags file then reports the effective value.
+	 */
+	if (ntg1)
+		flags |= JENT_NTG1;
+	if (force_fips)
+		flags |= JENT_FORCE_FIPS;
 
 	ret = jent_entropy_init_ex(osr, flags);
 	if (ret) {

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -39,7 +39,7 @@
  * jitterentropy_kcapi.c and jitterentropy_testing.c).
  */
 unsigned int osr = 0;
-int flags = 0;
+unsigned int flags = 0;
 unsigned int verbose = 0;
 
 /*
@@ -53,7 +53,7 @@ static bool force_fips = false;
 
 module_param(osr, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(osr, "Jitter RNG OSR parameter");
-module_param(flags, int, S_IRUSR | S_IRGRP | S_IROTH);
+module_param(flags, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(flags, "Jitter RNG flags parameter");
 module_param(verbose, uint, S_IRUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(verbose, "Jitter RNG verbose logging");

--- a/linux_kernel/jitterentropy_mod.c
+++ b/linux_kernel/jitterentropy_mod.c
@@ -12,9 +12,12 @@
 /*
  * MODULE_ALIAS_CRYPTO() lives in crypto/algapi.h on kernels >= 6.4 and in
  * linux/crypto.h before; crypto/algapi.h includes linux/crypto.h, so this
- * single include covers the whole supported kernel range.
+ * single include covers the whole supported kernel range. Only needed for
+ * the crypto API alias emitted at the bottom of this file.
  */
+#ifdef CONFIG_EXTERNAL_JITTERENTROPY_KCAPI
 #include <crypto/algapi.h>
+#endif
 #include <linux/fips.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -132,10 +135,14 @@ MODULE_DESCRIPTION("Non-physical True Random Number Generator based on CPU Jitte
 /*
  * The crypto API name depends on the build mode (see jent_alg.base.cra_name
  * in jitterentropy_kcapi.c). Alias the matching name so the algorithm can be
- * auto-loaded on request via the kernel crypto API.
+ * auto-loaded on request via the kernel crypto API. Only emitted when the
+ * crypto API interface is compiled in: the alias must not advertise an
+ * algorithm this build does not register.
  */
-#ifdef CONFIG_BUILTIN_JITTERENTROPY
+#ifdef CONFIG_EXTERNAL_JITTERENTROPY_KCAPI
+# ifdef CONFIG_BUILTIN_JITTERENTROPY
 MODULE_ALIAS_CRYPTO("jitterentropy_rng");
-#else
+# else
 MODULE_ALIAS_CRYPTO("jitter_rng");
-#endif
+# endif
+#endif /* CONFIG_EXTERNAL_JITTERENTROPY_KCAPI */

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -220,45 +220,55 @@ static const struct {
 	{ "fips",	jent_proc_fips_show },
 };
 
-void __init jent_proc_init(void)
+int __init jent_proc_init(void)
 {
 	struct proc_dir_entry *config_dir, *interfaces_dir;
 	unsigned int i;
+
+	/*
+	 * Without procfs there is nothing to create and jent_proc_dir stays
+	 * NULL, which the other interfaces already handle; only a failed
+	 * creation on a procfs-enabled kernel is an error.
+	 */
+	if (!IS_ENABLED(CONFIG_PROC_FS))
+		return 0;
 
 	jent_proc_dir = proc_mkdir(JENT_PROC_DIRNAME, NULL);
 	if (!jent_proc_dir) {
 		pr_warn("jitterentropy: failed to create /proc/%s\n",
 			JENT_PROC_DIRNAME);
-		return;
+		return -ENOMEM;
 	}
 
 	if (!proc_create_single("statistics", 0444, jent_proc_dir,
-				jent_proc_statistics_show))
+				jent_proc_statistics_show)) {
 		pr_warn("jitterentropy: failed to create /proc/%s/statistics\n",
 			JENT_PROC_DIRNAME);
+		goto err;
+	}
 
 	if (!proc_create_single("version", 0444, jent_proc_dir,
-				jent_proc_version_show))
+				jent_proc_version_show)) {
 		pr_warn("jitterentropy: failed to create /proc/%s/version\n",
 			JENT_PROC_DIRNAME);
+		goto err;
+	}
 
-	/*
-	 * Group the effective-configuration files below config/. A failed
-	 * directory creation is non-fatal like every other file here; the
-	 * files below it are then skipped.
-	 */
+	/* Group the effective-configuration files below config/. */
 	config_dir = proc_mkdir("config", jent_proc_dir);
 	if (!config_dir) {
 		pr_warn("jitterentropy: failed to create /proc/%s/config\n",
 			JENT_PROC_DIRNAME);
-	} else {
-		for (i = 0; i < ARRAY_SIZE(jent_proc_config_files); i++) {
-			if (!proc_create_single(jent_proc_config_files[i].name,
-						0444, config_dir,
-						jent_proc_config_files[i].show))
-				pr_warn("jitterentropy: failed to create /proc/%s/config/%s\n",
-					JENT_PROC_DIRNAME,
-					jent_proc_config_files[i].name);
+		goto err;
+	}
+	for (i = 0; i < ARRAY_SIZE(jent_proc_config_files); i++) {
+		if (!proc_create_single(jent_proc_config_files[i].name,
+					0444, config_dir,
+					jent_proc_config_files[i].show)) {
+			pr_warn("jitterentropy: failed to create /proc/%s/config/%s\n",
+				JENT_PROC_DIRNAME,
+				jent_proc_config_files[i].name);
+			goto err;
 		}
 	}
 
@@ -267,17 +277,25 @@ void __init jent_proc_init(void)
 	if (!interfaces_dir) {
 		pr_warn("jitterentropy: failed to create /proc/%s/interfaces\n",
 			JENT_PROC_DIRNAME);
-	} else {
-		for (i = 0; i < ARRAY_SIZE(jent_proc_interfaces); i++) {
-			if (!proc_create_single_data(jent_proc_interfaces[i].name,
-						     0444, interfaces_dir,
-						     jent_proc_interface_show,
-						     (void *)&jent_proc_interfaces[i].enabled))
-				pr_warn("jitterentropy: failed to create /proc/%s/interfaces/%s\n",
-					JENT_PROC_DIRNAME,
-					jent_proc_interfaces[i].name);
+		goto err;
+	}
+	for (i = 0; i < ARRAY_SIZE(jent_proc_interfaces); i++) {
+		if (!proc_create_single_data(jent_proc_interfaces[i].name,
+					     0444, interfaces_dir,
+					     jent_proc_interface_show,
+					     (void *)&jent_proc_interfaces[i].enabled)) {
+			pr_warn("jitterentropy: failed to create /proc/%s/interfaces/%s\n",
+				JENT_PROC_DIRNAME,
+				jent_proc_interfaces[i].name);
+			goto err;
 		}
 	}
+
+	return 0;
+
+err:
+	jent_proc_exit();
+	return -ENOMEM;
 }
 
 void jent_proc_exit(void)

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -40,6 +40,32 @@ static int jent_proc_flags_raw_show(struct seq_file *m, void *v)
 }
 
 /*
+ * Compile-time presence of the optional kernel interfaces, reported as plain
+ * 0/1 via /proc/jitterentropy/{kcapi,hwrng,chardev,testing} so what this
+ * module build provides can be checked without knowing its Kbuild.config.
+ */
+static const struct {
+	const char *name;
+	unsigned int enabled;
+} jent_proc_interfaces[] = {
+	{ "kcapi",	IS_ENABLED(CONFIG_EXTERNAL_JITTERENTROPY_KCAPI) },
+	{ "hwrng",	IS_ENABLED(CONFIG_EXTERNAL_JITTERENTROPY_HWRNG) },
+	{ "chardev",	IS_ENABLED(CONFIG_EXTERNAL_JITTERENTROPY_CHARDEV) },
+	{ "testing",
+	  IS_ENABLED(CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE) },
+};
+
+/* Shared show routine; m->private points at the table entry's value. */
+static int jent_proc_interface_show(struct seq_file *m, void *v)
+{
+	const unsigned int *enabled = m->private;
+
+	seq_printf(m, "%u\n", *enabled);
+
+	return 0;
+}
+
+/*
  * Quick-check mode indicators reported via /proc/jitterentropy/ntg1 and
  * /proc/jitterentropy/fips as plain 0/1. They report the modes the
  * collectors actually run with (see jent_entropy_collector_alloc_internal()):
@@ -180,6 +206,8 @@ static int jent_proc_statistics_show(struct seq_file *m, void *v)
 
 void __init jent_proc_init(void)
 {
+	unsigned int i;
+
 	jent_proc_dir = proc_mkdir(JENT_PROC_DIRNAME, NULL);
 	if (!jent_proc_dir) {
 		pr_warn("jitterentropy: failed to create /proc/%s\n",
@@ -221,6 +249,16 @@ void __init jent_proc_init(void)
 				jent_proc_fips_show))
 		pr_warn("jitterentropy: failed to create /proc/%s/fips\n",
 			JENT_PROC_DIRNAME);
+
+	for (i = 0; i < ARRAY_SIZE(jent_proc_interfaces); i++) {
+		if (!proc_create_single_data(jent_proc_interfaces[i].name,
+					     0444, jent_proc_dir,
+					     jent_proc_interface_show,
+					     (void *)&jent_proc_interfaces[i].enabled))
+			pr_warn("jitterentropy: failed to create /proc/%s/%s\n",
+				JENT_PROC_DIRNAME,
+				jent_proc_interfaces[i].name);
+	}
 }
 
 void jent_proc_exit(void)

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -14,6 +14,7 @@
 #include <linux/types.h>
 
 #include "jitterentropy.h"
+#include "jitterentropy-internal.h"	/* JENT_MIN_OSR */
 #include "jitterentropy_proc.h"
 
 struct proc_dir_entry *jent_proc_dir;
@@ -40,7 +41,13 @@ static int jent_proc_flags_raw_show(struct seq_file *m, void *v)
 
 static int jent_proc_osr_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%u\n", osr);
+	/*
+	 * Report the OSR the collectors actually run with: the library raises
+	 * any request below JENT_MIN_OSR - including the 0 select-the-default
+	 * parameter value - to that minimum (see
+	 * ensure_osr_is_at_least_minimal()).
+	 */
+	seq_printf(m, "%u\n", osr < JENT_MIN_OSR ? JENT_MIN_OSR : osr);
 
 	return 0;
 }

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -19,10 +19,31 @@
 struct proc_dir_entry *jent_proc_dir;
 
 /*
- * The effective flags value shared by the kernel interfaces, including the
- * folded-in shortcut parameters (see jitterentropy_mod.c).
+ * The effective flags and OSR values shared by the kernel interfaces,
+ * including the folded-in shortcut parameters (see jitterentropy_mod.c).
  */
 extern unsigned int flags;
+extern unsigned int osr;
+
+/*
+ * Machine-readable variants reported via /proc/jitterentropy/flags_raw and
+ * /proc/jitterentropy/osr: the plain values without any decoration, directly
+ * reusable as the flags= and osr= module parameters (kernel parameter parsing
+ * accepts the 0x prefix).
+ */
+static int jent_proc_flags_raw_show(struct seq_file *m, void *v)
+{
+	seq_printf(m, "0x%08x\n", flags);
+
+	return 0;
+}
+
+static int jent_proc_osr_show(struct seq_file *m, void *v)
+{
+	seq_printf(m, "%u\n", osr);
+
+	return 0;
+}
 
 /*
  * Human-readable breakdown of the effective flags value, reported via
@@ -148,6 +169,16 @@ void __init jent_proc_init(void)
 	if (!proc_create_single("flags", 0444, jent_proc_dir,
 				jent_proc_flags_show))
 		pr_warn("jitterentropy: failed to create /proc/%s/flags\n",
+			JENT_PROC_DIRNAME);
+
+	if (!proc_create_single("flags_raw", 0444, jent_proc_dir,
+				jent_proc_flags_raw_show))
+		pr_warn("jitterentropy: failed to create /proc/%s/flags_raw\n",
+			JENT_PROC_DIRNAME);
+
+	if (!proc_create_single("osr", 0444, jent_proc_dir,
+				jent_proc_osr_show))
+		pr_warn("jitterentropy: failed to create /proc/%s/osr\n",
 			JENT_PROC_DIRNAME);
 }
 

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -27,8 +27,9 @@ extern unsigned int flags;
 extern unsigned int osr;
 
 /*
- * Machine-readable variants reported via /proc/jitterentropy/flags_raw and
- * /proc/jitterentropy/osr: the plain values without any decoration, directly
+ * Machine-readable variants reported via /proc/jitterentropy/config/flags_raw
+ * and /proc/jitterentropy/config/osr: the plain values without any decoration,
+ * directly
  * reusable as the flags= and osr= module parameters (kernel parameter parsing
  * accepts the 0x prefix).
  */
@@ -41,7 +42,7 @@ static int jent_proc_flags_raw_show(struct seq_file *m, void *v)
 
 /*
  * Compile-time presence of the optional kernel interfaces, reported as plain
- * 0/1 via /proc/jitterentropy/{kcapi,hwrng,chardev,testing} so what this
+ * 0/1 via /proc/jitterentropy/interfaces/{kcapi,hwrng,chardev,testing} so what this
  * module build provides can be checked without knowing its Kbuild.config.
  */
 static const struct {
@@ -66,8 +67,8 @@ static int jent_proc_interface_show(struct seq_file *m, void *v)
 }
 
 /*
- * Quick-check mode indicators reported via /proc/jitterentropy/ntg1 and
- * /proc/jitterentropy/fips as plain 0/1. They report the modes the
+ * Quick-check mode indicators reported via /proc/jitterentropy/config/ntg1
+ * and /proc/jitterentropy/config/fips as plain 0/1. They report the modes the
  * collectors actually run with (see jent_entropy_collector_alloc_internal()):
  * FIPS compliant operation is in effect when the JENT_FORCE_FIPS flag is set,
  * when the kernel itself runs in FIPS mode, or when NTG.1 mode is enabled
@@ -104,7 +105,7 @@ static int jent_proc_osr_show(struct seq_file *m, void *v)
 
 /*
  * Human-readable breakdown of the effective flags value, reported via
- * /proc/jitterentropy/flags. Only the flag bits with a meaning in this
+ * /proc/jitterentropy/config/flags. Only the flag bits with a meaning in this
  * library version are listed (JENT_DISABLE_STIR and JENT_DISABLE_UNBIAS are
  * unused).
  */
@@ -204,8 +205,24 @@ static int jent_proc_statistics_show(struct seq_file *m, void *v)
 	return 0;
 }
 
+/*
+ * The effective-configuration files, grouped below
+ * /proc/jitterentropy/config/.
+ */
+static const struct {
+	const char *name;
+	int (*show)(struct seq_file *m, void *v);
+} jent_proc_config_files[] = {
+	{ "flags",	jent_proc_flags_show },
+	{ "flags_raw",	jent_proc_flags_raw_show },
+	{ "osr",	jent_proc_osr_show },
+	{ "ntg1",	jent_proc_ntg1_show },
+	{ "fips",	jent_proc_fips_show },
+};
+
 void __init jent_proc_init(void)
 {
+	struct proc_dir_entry *config_dir, *interfaces_dir;
 	unsigned int i;
 
 	jent_proc_dir = proc_mkdir(JENT_PROC_DIRNAME, NULL);
@@ -225,39 +242,41 @@ void __init jent_proc_init(void)
 		pr_warn("jitterentropy: failed to create /proc/%s/version\n",
 			JENT_PROC_DIRNAME);
 
-	if (!proc_create_single("flags", 0444, jent_proc_dir,
-				jent_proc_flags_show))
-		pr_warn("jitterentropy: failed to create /proc/%s/flags\n",
+	/*
+	 * Group the effective-configuration files below config/. A failed
+	 * directory creation is non-fatal like every other file here; the
+	 * files below it are then skipped.
+	 */
+	config_dir = proc_mkdir("config", jent_proc_dir);
+	if (!config_dir) {
+		pr_warn("jitterentropy: failed to create /proc/%s/config\n",
 			JENT_PROC_DIRNAME);
+	} else {
+		for (i = 0; i < ARRAY_SIZE(jent_proc_config_files); i++) {
+			if (!proc_create_single(jent_proc_config_files[i].name,
+						0444, config_dir,
+						jent_proc_config_files[i].show))
+				pr_warn("jitterentropy: failed to create /proc/%s/config/%s\n",
+					JENT_PROC_DIRNAME,
+					jent_proc_config_files[i].name);
+		}
+	}
 
-	if (!proc_create_single("flags_raw", 0444, jent_proc_dir,
-				jent_proc_flags_raw_show))
-		pr_warn("jitterentropy: failed to create /proc/%s/flags_raw\n",
+	/* Group the compiled-in interface indicators below interfaces/. */
+	interfaces_dir = proc_mkdir("interfaces", jent_proc_dir);
+	if (!interfaces_dir) {
+		pr_warn("jitterentropy: failed to create /proc/%s/interfaces\n",
 			JENT_PROC_DIRNAME);
-
-	if (!proc_create_single("osr", 0444, jent_proc_dir,
-				jent_proc_osr_show))
-		pr_warn("jitterentropy: failed to create /proc/%s/osr\n",
-			JENT_PROC_DIRNAME);
-
-	if (!proc_create_single("ntg1", 0444, jent_proc_dir,
-				jent_proc_ntg1_show))
-		pr_warn("jitterentropy: failed to create /proc/%s/ntg1\n",
-			JENT_PROC_DIRNAME);
-
-	if (!proc_create_single("fips", 0444, jent_proc_dir,
-				jent_proc_fips_show))
-		pr_warn("jitterentropy: failed to create /proc/%s/fips\n",
-			JENT_PROC_DIRNAME);
-
-	for (i = 0; i < ARRAY_SIZE(jent_proc_interfaces); i++) {
-		if (!proc_create_single_data(jent_proc_interfaces[i].name,
-					     0444, jent_proc_dir,
-					     jent_proc_interface_show,
-					     (void *)&jent_proc_interfaces[i].enabled))
-			pr_warn("jitterentropy: failed to create /proc/%s/%s\n",
-				JENT_PROC_DIRNAME,
-				jent_proc_interfaces[i].name);
+	} else {
+		for (i = 0; i < ARRAY_SIZE(jent_proc_interfaces); i++) {
+			if (!proc_create_single_data(jent_proc_interfaces[i].name,
+						     0444, interfaces_dir,
+						     jent_proc_interface_show,
+						     (void *)&jent_proc_interfaces[i].enabled))
+				pr_warn("jitterentropy: failed to create /proc/%s/interfaces/%s\n",
+					JENT_PROC_DIRNAME,
+					jent_proc_interfaces[i].name);
+		}
 	}
 }
 

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -18,6 +18,72 @@
 
 struct proc_dir_entry *jent_proc_dir;
 
+/*
+ * The effective flags value shared by the kernel interfaces, including the
+ * folded-in shortcut parameters (see jitterentropy_mod.c).
+ */
+extern unsigned int flags;
+
+/*
+ * Human-readable breakdown of the effective flags value, reported via
+ * /proc/jitterentropy/flags. Only the flag bits with a meaning in this
+ * library version are listed (JENT_DISABLE_STIR and JENT_DISABLE_UNBIAS are
+ * unused).
+ */
+static const struct {
+	unsigned int bit;
+	const char *label;	/* Column label including the colon. */
+} jent_proc_flags_bits[] = {
+	{ JENT_DISABLE_MEMORY_ACCESS,	"JENT_DISABLE_MEMORY_ACCESS:" },
+	{ JENT_FORCE_INTERNAL_TIMER,	"JENT_FORCE_INTERNAL_TIMER:" },
+	{ JENT_DISABLE_INTERNAL_TIMER,	"JENT_DISABLE_INTERNAL_TIMER:" },
+	{ JENT_FORCE_FIPS,		"JENT_FORCE_FIPS:" },
+	{ JENT_NTG1,			"JENT_NTG1:" },
+	{ JENT_CACHE_ALL,		"JENT_CACHE_ALL:" },
+};
+
+static int jent_proc_flags_show(struct seq_file *m, void *v)
+{
+	unsigned int memsize = JENT_FLAGS_TO_MAX_MEMSIZE(flags);
+	unsigned int hashloop = JENT_FLAGS_TO_HASHLOOP(flags);
+	unsigned int i;
+
+	seq_printf(m, "%-29s0x%08x\n", "flags:", flags);
+
+	for (i = 0; i < ARRAY_SIZE(jent_proc_flags_bits); i++)
+		seq_printf(m, "%-29s%s\n", jent_proc_flags_bits[i].label,
+			   flags & jent_proc_flags_bits[i].bit ? "on" : "off");
+
+	/*
+	 * The memory size field encodes 1 kB << (field - 1); field 0 selects
+	 * the automatic cache-size-derived default (see jent_memsize()).
+	 */
+	if (!memsize)
+		seq_printf(m, "%-29sauto (derived from cache size)\n",
+			   "max memory size:");
+	else if (memsize <= 10)
+		seq_printf(m, "%-29s%u kB\n", "max memory size:",
+			   1U << (memsize - 1));
+	else if (memsize <= JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_MAX))
+		seq_printf(m, "%-29s%u MB\n", "max memory size:",
+			   1U << (memsize - 11));
+	else
+		seq_printf(m, "%-29sinvalid (%u)\n", "max memory size:",
+			   memsize);
+
+	/*
+	 * The hash loop field encodes 1 << field iterations; field 0 selects
+	 * the built-in default (see jent_hashloop_cnt()).
+	 */
+	if (!hashloop)
+		seq_printf(m, "%-29sdefault\n", "hash loop count:");
+	else
+		seq_printf(m, "%-29s%u\n", "hash loop count:",
+			   1U << hashloop);
+
+	return 0;
+}
+
 /* Library version reported via /proc/jitterentropy/version. */
 static int jent_proc_version_show(struct seq_file *m, void *v)
 {
@@ -77,6 +143,11 @@ void __init jent_proc_init(void)
 	if (!proc_create_single("version", 0444, jent_proc_dir,
 				jent_proc_version_show))
 		pr_warn("jitterentropy: failed to create /proc/%s/version\n",
+			JENT_PROC_DIRNAME);
+
+	if (!proc_create_single("flags", 0444, jent_proc_dir,
+				jent_proc_flags_show))
+		pr_warn("jitterentropy: failed to create /proc/%s/flags\n",
 			JENT_PROC_DIRNAME);
 }
 

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -39,6 +39,30 @@ static int jent_proc_flags_raw_show(struct seq_file *m, void *v)
 	return 0;
 }
 
+/*
+ * Quick-check mode indicators reported via /proc/jitterentropy/ntg1 and
+ * /proc/jitterentropy/fips as plain 0/1. They report the modes the
+ * collectors actually run with (see jent_entropy_collector_alloc_internal()):
+ * FIPS compliant operation is in effect when the JENT_FORCE_FIPS flag is set,
+ * when the kernel itself runs in FIPS mode, or when NTG.1 mode is enabled
+ * (NTG.1 implies FIPS operation).
+ */
+static int jent_proc_ntg1_show(struct seq_file *m, void *v)
+{
+	seq_printf(m, "%u\n", !!(flags & JENT_NTG1));
+
+	return 0;
+}
+
+static int jent_proc_fips_show(struct seq_file *m, void *v)
+{
+	seq_printf(m, "%u\n",
+		   !!((flags & (JENT_FORCE_FIPS | JENT_NTG1)) ||
+		      jent_fips_enabled()));
+
+	return 0;
+}
+
 static int jent_proc_osr_show(struct seq_file *m, void *v)
 {
 	/*
@@ -186,6 +210,16 @@ void __init jent_proc_init(void)
 	if (!proc_create_single("osr", 0444, jent_proc_dir,
 				jent_proc_osr_show))
 		pr_warn("jitterentropy: failed to create /proc/%s/osr\n",
+			JENT_PROC_DIRNAME);
+
+	if (!proc_create_single("ntg1", 0444, jent_proc_dir,
+				jent_proc_ntg1_show))
+		pr_warn("jitterentropy: failed to create /proc/%s/ntg1\n",
+			JENT_PROC_DIRNAME);
+
+	if (!proc_create_single("fips", 0444, jent_proc_dir,
+				jent_proc_fips_show))
+		pr_warn("jitterentropy: failed to create /proc/%s/fips\n",
 			JENT_PROC_DIRNAME);
 }
 

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -7,6 +7,7 @@
  */
 
 #include <linux/atomic.h>
+#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
@@ -59,7 +60,7 @@ static int jent_proc_statistics_show(struct seq_file *m, void *v)
 	return 0;
 }
 
-void jent_proc_init(void)
+void __init jent_proc_init(void)
 {
 	jent_proc_dir = proc_mkdir(JENT_PROC_DIRNAME, NULL);
 	if (!jent_proc_dir) {

--- a/linux_kernel/jitterentropy_proc.c
+++ b/linux_kernel/jitterentropy_proc.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Shared /proc/jitter_rng directory and statistics file for the Jitter RNG
+ * Shared /proc/jitterentropy directory and statistics file for the Jitter RNG
  * kernel interfaces.
  *
  * Copyright (C) 2026, Stephan Mueller <smueller@chronox.de>
@@ -18,7 +18,7 @@
 
 struct proc_dir_entry *jent_proc_dir;
 
-/* Library version reported via /proc/jitter_rng/version. */
+/* Library version reported via /proc/jitterentropy/version. */
 static int jent_proc_version_show(struct seq_file *m, void *v)
 {
 	seq_printf(m, "%u.%u.%u\n", JENT_MAJVERSION, JENT_MINVERSION,
@@ -27,7 +27,7 @@ static int jent_proc_version_show(struct seq_file *m, void *v)
 	return 0;
 }
 
-/* Statistics reported via /proc/jitter_rng/statistics. */
+/* Statistics reported via /proc/jitterentropy/statistics. */
 static atomic_t jent_open_instances = ATOMIC_INIT(0);
 static atomic64_t jent_cumulative_opens = ATOMIC64_INIT(0);
 

--- a/linux_kernel/jitterentropy_proc.h
+++ b/linux_kernel/jitterentropy_proc.h
@@ -25,8 +25,13 @@
  */
 extern struct proc_dir_entry *jent_proc_dir;
 
-/* Create/remove /proc/jitterentropy and the statistics file. Both are non-fatal. */
-void __init jent_proc_init(void);
+/*
+ * Create/remove /proc/jitterentropy and the files below it. A creation
+ * failure on a procfs-enabled kernel is returned as -ENOMEM after removing
+ * anything already created; with CONFIG_PROC_FS off the init succeeds and
+ * jent_proc_dir stays NULL.
+ */
+int __init jent_proc_init(void);
 void jent_proc_exit(void);
 
 /*

--- a/linux_kernel/jitterentropy_proc.h
+++ b/linux_kernel/jitterentropy_proc.h
@@ -12,6 +12,7 @@
 #ifndef _JITTERENTROPY_PROC_H
 #define _JITTERENTROPY_PROC_H
 
+#include <linux/init.h>
 #include <linux/proc_fs.h>
 
 /* Name of the shared /proc directory. */
@@ -25,7 +26,7 @@
 extern struct proc_dir_entry *jent_proc_dir;
 
 /* Create/remove /proc/jitterentropy and the statistics file. Both are non-fatal. */
-void jent_proc_init(void);
+void __init jent_proc_init(void);
 void jent_proc_exit(void);
 
 /*

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -21,6 +21,7 @@
 
 #include <linux/debugfs.h>
 #include <linux/fs.h>
+#include <linux/init.h>
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
@@ -447,7 +448,7 @@ static const struct file_operations jent_raw_hires_fops = {
 
 /******************************* Initialization *******************************/
 
-void jent_testing_init(void)
+void __init jent_testing_init(void)
 {
 	jent_raw_debugfs_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
 

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -17,6 +17,9 @@
  * interface-only JENT_IOCLOOPCNT ioctl, overriding the loop count applied to
  * the raw noise measurements of that instance.
  *
+ * On a locked-down kernel the interface is not created, and opens of an
+ * already-created file are refused once lockdown is raised at runtime.
+ *
  * Copyright (C) 2023 - 2026, Stephan Mueller <smueller@chronox.de>
  */
 
@@ -28,6 +31,7 @@
 #include <linux/mutex.h>
 #include <linux/sched.h>
 #include <linux/sched/signal.h>
+#include <linux/security.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/uaccess.h>
@@ -50,6 +54,21 @@ static DEFINE_MUTEX(jent_testing_read_lock);
 #define JENT_TEST_MEMACCLOOP (1<<16)
 
 static struct dentry *jent_raw_debugfs_root = NULL;
+
+/*
+ * The raw noise measurements expose the timing behavior of the kernel and are
+ * a pure test vehicle, so the interface has no business on a locked-down
+ * kernel: do not create it when the kernel is already locked down at module
+ * load, and refuse opens if lockdown was raised afterwards (lockdown can be
+ * tightened at runtime, e.g. via /sys/kernel/security/lockdown, but never
+ * relaxed). LOCKDOWN_DEBUGFS is the reason the debugfs core itself uses to
+ * gate debugfs files, and it is part of the integrity level, so the interface
+ * disappears for both lockdown=integrity and lockdown=confidentiality.
+ */
+static bool jent_testing_locked_down(void)
+{
+	return security_locked_down(LOCKDOWN_DEBUGFS) != 0;
+}
 
 /*
  * The tester can define the OSR as well as the flags used to perform the
@@ -158,6 +177,16 @@ static int jent_testing_open(struct inode *inode, struct file *file)
 	struct jent_testing_ctx *ctx;
 	unsigned int osr;
 	unsigned int flags;
+
+	/*
+	 * The file only exists if the kernel was not locked down at module
+	 * load; re-check here to also cover lockdown raised at runtime after
+	 * the file was created. The debugfs proxy performs the same check on
+	 * open for fops carrying an ioctl handler, but do not rely on that
+	 * implementation detail.
+	 */
+	if (jent_testing_locked_down())
+		return -EPERM;
 
 	ctx = kvzalloc(sizeof(*ctx), GFP_KERNEL);
 	if (!ctx)
@@ -483,6 +512,11 @@ static const struct file_operations jent_raw_hires_fops = {
 
 void __init jent_testing_init(void)
 {
+	if (jent_testing_locked_down()) {
+		pr_info("jitterentropy: kernel is locked down, not exposing the raw entropy test interface\n");
+		return;
+	}
+
 	jent_raw_debugfs_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
 
 	/*

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -485,14 +485,18 @@ void __init jent_testing_init(void)
 {
 	jent_raw_debugfs_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
 
-	debugfs_create_file_unsafe("jent_raw_hires", 0400,
-				   jent_raw_debugfs_root, NULL,
-				   &jent_raw_hires_fops);
+	/*
+	 * Use the proxied variant: the fops do not implement the
+	 * debugfs_file_get()/debugfs_file_put() protocol that the _unsafe
+	 * variant requires, so only the proxy protects a reader against a
+	 * concurrent debugfs_remove_recursive() from jent_testing_exit().
+	 */
+	debugfs_create_file("jent_raw_hires", 0400,
+			    jent_raw_debugfs_root, NULL,
+			    &jent_raw_hires_fops);
 }
-EXPORT_SYMBOL(jent_testing_init);
 
 void jent_testing_exit(void)
 {
 	debugfs_remove_recursive(jent_raw_debugfs_root);
 }
-EXPORT_SYMBOL(jent_testing_exit);

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -27,6 +27,7 @@
 #include <linux/mutex.h>
 #include <linux/sched.h>
 #include <linux/sched/signal.h>
+#include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/uaccess.h>
 

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -66,15 +66,15 @@ static struct dentry *jent_raw_debugfs_root = NULL;
  * 5. Go back to step 3 and attempt testing with yet other parameters.
  */
 static unsigned int testing_osr = 0;
-static int testing_flags = 0;
+static unsigned int testing_flags = 0;
 
 module_param(testing_osr, uint, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(testing_osr, "Jitter RNG testing OSR parameter");
-module_param(testing_flags, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+module_param(testing_flags, uint, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(testing_flags, "Jitter RNG testing flags parameter");
 
 static unsigned int logged_osr = 0xffffffff;
-static int logged_flags = 0xffffffff;
+static unsigned int logged_flags = 0xffffffff;
 
 /*
  * Verbose logging switch, configurable via the module parameter of the same
@@ -157,7 +157,7 @@ static int jent_testing_open(struct inode *inode, struct file *file)
 {
 	struct jent_testing_ctx *ctx;
 	unsigned int osr;
-	int flags;
+	unsigned int flags;
 
 	ctx = kvzalloc(sizeof(*ctx), GFP_KERNEL);
 	if (!ctx)

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -155,17 +155,12 @@ struct jent_testing_ctx {
 static int jent_testing_open(struct inode *inode, struct file *file)
 {
 	struct jent_testing_ctx *ctx;
+	unsigned int osr;
+	int flags;
 
 	ctx = kvzalloc(sizeof(*ctx), GFP_KERNEL);
 	if (!ctx)
 		return -ENOMEM;
-
-	if (testing_flags & (JENT_TEST_HASHLOOP))
-		ctx->measure_jitter = jent_measure_jitter_ntg1_sha3;
-	else if (testing_flags & (JENT_TEST_MEMACCLOOP))
-		ctx->measure_jitter = jent_measure_jitter_ntg1_memaccess;
-	else
-		ctx->measure_jitter = jent_measure_jitter;
 
 	/* Serialize the jent_testing_log() bookkeeping. */
 	if (mutex_lock_interruptible(&jent_testing_read_lock)) {
@@ -174,13 +169,29 @@ static int jent_testing_open(struct inode *inode, struct file *file)
 	}
 
 	/*
+	 * Snapshot the runtime-writable module parameters once: a concurrent
+	 * sysfs write between separate reads could otherwise pair a
+	 * measurement routine with a collector allocated from different
+	 * flags.
+	 */
+	flags = testing_flags;
+	osr = testing_osr;
+
+	if (flags & (JENT_TEST_HASHLOOP))
+		ctx->measure_jitter = jent_measure_jitter_ntg1_sha3;
+	else if (flags & (JENT_TEST_MEMACCLOOP))
+		ctx->measure_jitter = jent_measure_jitter_ntg1_memaccess;
+	else
+		ctx->measure_jitter = jent_measure_jitter;
+
+	/*
 	 * Allocate the collector without the startup entropy collection and
 	 * its health-test reset ladder (mirroring the userspace recording
 	 * tools): the startup could silently escalate OSR, memory size and
 	 * hash loop count, but the recorded raw data must correspond exactly
 	 * to the requested testing_osr/testing_flags.
 	 */
-	ctx->ec = jent_entropy_collector_alloc_raw(testing_osr, testing_flags);
+	ctx->ec = jent_entropy_collector_alloc_raw(osr, flags);
 	if (!ctx->ec) {
 		mutex_unlock(&jent_testing_read_lock);
 		/*

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -510,14 +510,34 @@ static const struct file_operations jent_raw_hires_fops = {
 
 /******************************* Initialization *******************************/
 
-void __init jent_testing_init(void)
+int __init jent_testing_init(void)
 {
+	struct dentry *raw_hires;
+	int ret;
+
+	/*
+	 * Without debugfs there is nothing to create and every debugfs call
+	 * would return -ENODEV; the test interface is a pure debugging aid,
+	 * so its absence must not fail the module load.
+	 */
+	if (!IS_ENABLED(CONFIG_DEBUG_FS)) {
+		pr_info("jitterentropy: debugfs not available, not exposing the raw entropy test interface\n");
+		return 0;
+	}
+
 	if (jent_testing_locked_down()) {
 		pr_info("jitterentropy: kernel is locked down, not exposing the raw entropy test interface\n");
-		return;
+		return 0;
 	}
 
 	jent_raw_debugfs_root = debugfs_create_dir(KBUILD_MODNAME, NULL);
+	if (IS_ERR(jent_raw_debugfs_root)) {
+		ret = PTR_ERR(jent_raw_debugfs_root);
+		pr_warn("jitterentropy: failed to create debugfs directory %s: %d\n",
+			KBUILD_MODNAME, ret);
+		jent_raw_debugfs_root = NULL;
+		return ret;
+	}
 
 	/*
 	 * Use the proxied variant: the fops do not implement the
@@ -525,9 +545,19 @@ void __init jent_testing_init(void)
 	 * variant requires, so only the proxy protects a reader against a
 	 * concurrent debugfs_remove_recursive() from jent_testing_exit().
 	 */
-	debugfs_create_file("jent_raw_hires", 0400,
-			    jent_raw_debugfs_root, NULL,
-			    &jent_raw_hires_fops);
+	raw_hires = debugfs_create_file("jent_raw_hires", 0400,
+					jent_raw_debugfs_root, NULL,
+					&jent_raw_hires_fops);
+	if (IS_ERR(raw_hires)) {
+		ret = PTR_ERR(raw_hires);
+		pr_warn("jitterentropy: failed to create debugfs file jent_raw_hires: %d\n",
+			ret);
+		debugfs_remove_recursive(jent_raw_debugfs_root);
+		jent_raw_debugfs_root = NULL;
+		return ret;
+	}
+
+	return 0;
 }
 
 void jent_testing_exit(void)

--- a/linux_kernel/jitterentropy_testing.c
+++ b/linux_kernel/jitterentropy_testing.c
@@ -6,8 +6,9 @@
  * RNG: each open allocates a dedicated Jitter RNG instance, each read drives
  * its measure_jitter operation and returns one u64 per measurement holding
  * the time delta as consumed by the health tests and the entropy pool (i.e.
- * including the division by the common timer GCD). This mirrors the user
- * space recording logic in
+ * including the division by the common timer GCD). Read sizes must be a
+ * multiple of the u64 sample size; any other size is rejected with -EINVAL.
+ * This mirrors the user space recording logic in
  * tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c.
  *
  * The file also implements the JENT_IOCSTATUS ioctl known from the character
@@ -235,7 +236,7 @@ static ssize_t jent_testing_extract_user(struct file *file, char __user *buf,
 					 size_t nbytes, loff_t *ppos)
 {
 	struct jent_testing_ctx *ctx = file->private_data;
-	struct rand_data *ec = ctx->ec;
+	struct rand_data *ec;
 	u64 *tmp = NULL;
 	u64 loop_cnt;
 	ssize_t ret = 0;
@@ -243,11 +244,31 @@ static ssize_t jent_testing_extract_user(struct file *file, char __user *buf,
 
 	unsigned int (*measure_jitter)(struct rand_data *ec,
 				       uint64_t loop_cnt,
-				       uint64_t *ret_current_delta) =
-		ctx->measure_jitter;
+				       uint64_t *ret_current_delta);
+
+	/* Defense in depth, matching the ioctl handler: open() sets this. */
+	if (!ctx)
+		return -EFAULT;
+
+	ec = ctx->ec;
+	measure_jitter = ctx->measure_jitter;
 
 	if (!nbytes)
 		return 0;
+
+	/*
+	 * The interface delivers whole u64 time stamp samples only: reject
+	 * requests that are not a multiple of the sample size. A request
+	 * smaller than one sample would fall through the loop below and
+	 * return 0, which reads as EOF on an endless stream (e.g. dd with
+	 * bs < 8 would record nothing and report success); a trailing
+	 * partial sample would be silently dropped as a short read. This
+	 * also catches a recording tool built for the u32 sample format of
+	 * the vanilla kernel test interface loudly instead of letting it
+	 * record garbled data.
+	 */
+	if (nbytes % sizeof(u64))
+		return -EINVAL;
 
 	/* Only one extract session may run at a time. */
 	if (mutex_lock_interruptible(&jent_testing_read_lock))

--- a/linux_kernel/jitterentropy_testing.h
+++ b/linux_kernel/jitterentropy_testing.h
@@ -11,10 +11,15 @@
 #ifdef CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE
 #include <linux/init.h>
 
-void __init jent_testing_init(void);
+/*
+ * Create/remove the debugfs test interface. A creation failure is returned
+ * as an error after removing anything already created; a kernel without
+ * debugfs or with lockdown active skips the interface and succeeds.
+ */
+int __init jent_testing_init(void);
 void jent_testing_exit(void);
 #else /* CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE */
-static inline void jent_testing_init(void) { }
+static inline int jent_testing_init(void) { return 0; }
 static inline void jent_testing_exit(void) { }
 #endif /* CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE */
 

--- a/linux_kernel/jitterentropy_testing.h
+++ b/linux_kernel/jitterentropy_testing.h
@@ -9,7 +9,9 @@
 #define _JITTERENTROPY_TESTING_H
 
 #ifdef CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE
-void jent_testing_init(void);
+#include <linux/init.h>
+
+void __init jent_testing_init(void);
 void jent_testing_exit(void);
 #else /* CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE */
 static inline void jent_testing_init(void) { }

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -516,6 +516,18 @@ ssize_t jent_read_entropy_safe(struct rand_data **ec, char *data, size_t len)
 uint32_t jent_memsize(unsigned int flags)
 {
 	uint32_t memsize = JENT_FLAGS_TO_MAX_MEMSIZE(flags);
+	static const uint32_t max_field =
+		JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_MAX);
+
+	/*
+	 * Flags of collectors instantiated with JENT_DISABLE_MEMORY_ACCESS are
+	 * never normalized by jent_update_memsize(), so an out-of-range
+	 * caller-provided size field can reach this point (e.g. via
+	 * jent_status()). Clamp it: the shift below would otherwise exceed the
+	 * uint32_t width, which is undefined behavior.
+	 */
+	if (memsize > max_field)
+		memsize = max_field;
 
 	if (memsize == 0) {
 		memsize = JENT_DEFAULT_MEMORY_BITS;

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -561,6 +561,14 @@ static struct rand_data
 	uint32_t memsize = 0;
 
 	/*
+	 * Enforce the invariants of the compile-time tunable OSR bounds: the
+	 * health-test lookup tables are indexed with osr - 1, and an empty
+	 * [JENT_MIN_OSR, JENT_MAX_OSR] range would make every allocation fail.
+	 */
+	BUILD_BUG_ON(JENT_MIN_OSR < 1);
+	BUILD_BUG_ON(JENT_MIN_OSR > JENT_MAX_OSR);
+
+	/*
 	 * Requesting disabling and forcing of internal timer
 	 * makes no sense.
 	 */

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -577,17 +577,6 @@ static struct rand_data
 		return NULL;
 
 	/*
-	 * The FIPS / NTG.1 startup samples the memory-access noise source as
-	 * an independent stage (startup_state jent_startup_memory). Without
-	 * the memory region every startup sample is stuck, so the allocation
-	 * could only fail after burning through the entire health-test reset
-	 * ladder. Reject the contradictory combination immediately.
-	 */
-	if ((flags & JENT_DISABLE_MEMORY_ACCESS) &&
-	    ((flags & (JENT_NTG1 | JENT_FORCE_FIPS)) || jent_fips_enabled()))
-		return NULL;
-
-	/*
 	 * Ensure over sampling rate is not too low.
 	 */
 	osr = ensure_osr_is_at_least_minimal(osr);
@@ -721,8 +710,28 @@ err:
 static struct rand_data *_jent_entropy_collector_alloc(unsigned int osr,
 						       unsigned int flags)
 {
-	struct rand_data *ec = jent_entropy_collector_alloc_internal(osr,
-								     flags);
+	struct rand_data *ec;
+
+	/*
+	 * The FIPS / NTG.1 startup samples the memory-access noise source as
+	 * an independent stage (startup_state jent_startup_memory). Without
+	 * the memory region every startup sample is stuck, so the allocation
+	 * could only fail after burning through the entire health-test reset
+	 * ladder below. Reject the contradictory combination immediately.
+	 *
+	 * This check must not live in jent_entropy_collector_alloc_internal():
+	 * the test-only collectors (jent_time_entropy_init(), the kernel raw
+	 * test interface, the raw-entropy recording tools) are allocated there
+	 * directly and never run the startup ladder, and jent_time_entropy_init()
+	 * always ORs in JENT_FORCE_FIPS for its test instance - rejecting the
+	 * combination there would make jent_entropy_init_ex() fail for every
+	 * caller using JENT_DISABLE_MEMORY_ACCESS.
+	 */
+	if ((flags & JENT_DISABLE_MEMORY_ACCESS) &&
+	    ((flags & (JENT_NTG1 | JENT_FORCE_FIPS)) || jent_fips_enabled()))
+		return NULL;
+
+	ec = jent_entropy_collector_alloc_internal(osr, flags);
 
 	if (!ec)
 		return ec;

--- a/src/jitterentropy-gcd.c
+++ b/src/jitterentropy-gcd.c
@@ -45,7 +45,7 @@ static inline uint64_t jent_gcd64(uint64_t a, uint64_t b)
 	while (b != 0) {
 		uint64_t r;
 
-		r = a % b;
+		r = jent_umod64(a, b);
 
 		a = b;
 		b = r;

--- a/src/jitterentropy-health.c
+++ b/src/jitterentropy-health.c
@@ -573,6 +573,7 @@ static void jent_rct_mem_insert(struct rand_data *ec, unsigned int stuck)
 		 * wasted.
 		 */
 		if (!ec->in_recovery) {
+			enum jent_startup_state saved_state = ec->startup_state;
 			unsigned int i;
 
 			/*
@@ -581,8 +582,24 @@ static void jent_rct_mem_insert(struct rand_data *ec, unsigned int stuck)
 			 */
 			ec->rct_mem_count = 0;
 			ec->in_recovery = 1;
+
+			/*
+			 * The recovery loop may fire while an outer
+			 * jent_random_data() invocation is still inside a
+			 * FIPS/NTG.1 startup stage. Park the state machine in
+			 * the completed state for the recursive calls: they
+			 * would otherwise re-run the startup stages and
+			 * advance startup_state underneath the outer
+			 * invocation, whose subsequent stale-state decrement
+			 * would push startup_state below
+			 * jent_startup_completed - and the startup loop in
+			 * _jent_entropy_collector_alloc() would then never
+			 * terminate.
+			 */
+			ec->startup_state = jent_startup_completed;
 			for (i = 0; i < JENT_RCT_MEM_RECOVERY_LOOP_CNT; i++)
 				jent_random_data(ec);
+			ec->startup_state = saved_state;
 			ec->in_recovery = 0;
 
 			/*

--- a/src/jitterentropy-health.c
+++ b/src/jitterentropy-health.c
@@ -645,13 +645,18 @@ static void jent_rct_init(struct rand_data *ec, unsigned short safety)
 void jent_rct_duplicate(struct rand_data *new_ec)
 {
 	/*
-	 * RCT re-initialization to intermittent error: As during a reset,
-	 * the OSR is updated and the OSR is at the same time the cutoff for
-	 * the RCT, we re-initialize the new RCT to the intermittent error
-	 * value based on the new OSR.
+	 * RCT re-initialization to intermittent error: prime the new RCT with
+	 * the intermittent cutoff established by jent_rct_init() for the new
+	 * collector, so a continuing streak of stuck values escalates to the
+	 * permanent error instead of restarting from zero.
+	 *
+	 * Use the collector's rct_cutoff member instead of recomputing it via
+	 * JENT_HEALTH_RCT_INTERMITTENT_CUTOFF: in NTG.1 mode the cutoffs carry
+	 * the 8-fold safety divisor, and the undivided value would already
+	 * exceed rct_cutoff_permanent, turning the first stuck measurement
+	 * after the reallocation into a spurious permanent failure.
 	 */
-	new_ec->rct_count =
-		(unsigned int)(JENT_HEALTH_RCT_INTERMITTENT_CUTOFF(new_ec->osr));
+	new_ec->rct_count = (unsigned int)new_ec->rct_cutoff;
 }
 
 /**

--- a/src/jitterentropy-health.c
+++ b/src/jitterentropy-health.c
@@ -607,7 +607,18 @@ static void jent_rct_mem_insert(struct rand_data *ec, unsigned int stuck)
 
 void jent_rct_mem_duplicate(struct rand_data *new_ec, struct rand_data *old_ec)
 {
-	/* RCT with memory re-initialization to intermittent error */
+	/*
+	 * RCT with memory re-initialization to intermittent error.
+	 *
+	 * NOTE: this priming is currently ineffective. Every output block
+	 * starts with jent_random_data_one() setting rct_mem_ctr = 0, and the
+	 * first jent_rct_mem_insert() of a window then clears rct_mem_count
+	 * before any cutoff comparison sees it - so, unlike the RCT/APT/lag
+	 * duplication, no escalation state actually survives the reset. Making
+	 * it effective would change the health-test semantics (the window-
+	 * start reset in jent_rct_mem_insert() would need to spare a primed
+	 * value once); left as-is pending a maintainer decision.
+	 */
 	new_ec->rct_mem_count = old_ec->rct_mem_cutoff;
 }
 

--- a/src/jitterentropy-health.c
+++ b/src/jitterentropy-health.c
@@ -634,7 +634,7 @@ void jent_rct_mem_duplicate(struct rand_data *new_ec, struct rand_data *old_ec)
 	 * duplication, no escalation state actually survives the reset. Making
 	 * it effective would change the health-test semantics (the window-
 	 * start reset in jent_rct_mem_insert() would need to spare a primed
-	 * value once); left as-is pending a maintainer decision.
+	 * value once).
 	 */
 	new_ec->rct_mem_count = old_ec->rct_mem_cutoff;
 }

--- a/src/jitterentropy-internal.h
+++ b/src/jitterentropy-internal.h
@@ -74,11 +74,17 @@ extern "C" {
 
 #ifdef LINUX_KERNEL
 
-#define UINT32_MAX	(4294967295U)
-#if __LP64__
-# define UINT64_C(c)   c ## UL
-#else
-# define UINT64_C(c)   c ## ULL
+#ifndef UINT32_MAX
+# define UINT32_MAX	(4294967295U)
+#endif
+#ifndef UINT64_C
+/* #ifdef, not #if: kernel builds run with -Wundef and 32-bit targets do not
+ * define __LP64__ at all. */
+# ifdef __LP64__
+#  define UINT64_C(c)   c ## UL
+# else
+#  define UINT64_C(c)   c ## ULL
+# endif
 #endif
 
 /*

--- a/src/jitterentropy-internal.h
+++ b/src/jitterentropy-internal.h
@@ -426,10 +426,10 @@ struct rand_data
 	 * jent_health_failure_reset() so the totals span the instance's whole
 	 * lifetime.
 	 *
-	 * read_invocations counts caller read requests: every jent_read_entropy()
-	 * call increments it, and jent_read_entropy_safe() decrements it once per
-	 * health-test reinitialization so that a single request still maps to one
-	 * invocation regardless of how many internal retries it takes.
+	 * read_invocations counts caller read requests: jent_read_entropy()
+	 * increments it only on success, so a jent_read_entropy_safe() request
+	 * maps to one invocation regardless of how many internal health-test
+	 * retries it takes (failed attempts never count).
 	 * bytes_output counts the random bytes actually delivered to callers.
 	 */
 	uint64_t read_invocations;

--- a/src/jitterentropy-internal.h
+++ b/src/jitterentropy-internal.h
@@ -58,6 +58,16 @@
 #include "arch/jitterentropy-arch-sched.h"
 #include "arch/jitterentropy-arch-uuid.h"
 
+#ifdef LINUX_KERNEL
+/*
+ * Kernel div64 primitives backing jent_udiv64()/jent_umod64() below. The
+ * header is deliberately lightweight (types, math, the arch div64
+ * primitives), so it is safe for the -O0 entropy-collection core including
+ * this file.
+ */
+#include <linux/math64.h>	/* div64_u64(), div64_u64_rem() */
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -95,6 +105,28 @@ extern "C" {
 struct rand_data *jent_entropy_collector_alloc_raw(unsigned int osr,
 						   unsigned int flags);
 
+/*
+ * 64-bit division / modulo with a 64-bit divisor.
+ *
+ * The plain C operators on 64-bit operands are lowered to libgcc helper
+ * calls (__udivdi3, __aeabi_uldivmod, ...) on 32-bit kernels, and the kernel
+ * does not provide those helpers; route the operations through the kernel's
+ * div64 primitives instead. On 64-bit kernels both primitives are inline
+ * plain divisions, so code generation there is identical to the operators.
+ */
+static inline uint64_t jent_udiv64(uint64_t dividend, uint64_t divisor)
+{
+	return div64_u64(dividend, divisor);
+}
+
+static inline uint64_t jent_umod64(uint64_t dividend, uint64_t divisor)
+{
+	uint64_t rem;
+
+	div64_u64_rem(dividend, divisor, &rem);
+	return rem;
+}
+
 #else /* LINUX_KERNEL */
 
 #if __has_attribute(__fallthrough__)
@@ -106,6 +138,21 @@ struct rand_data *jent_entropy_collector_alloc_raw(unsigned int osr,
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/*
+ * 64-bit division / modulo with a 64-bit divisor; see the kernel branch
+ * above for the rationale. Userspace links against libgcc (or an
+ * equivalent), so the plain operators are used directly.
+ */
+static inline uint64_t jent_udiv64(uint64_t dividend, uint64_t divisor)
+{
+	return dividend / divisor;
+}
+
+static inline uint64_t jent_umod64(uint64_t dividend, uint64_t divisor)
+{
+	return dividend % divisor;
+}
 
 #endif /* LINUX_KERNEL */
 

--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -558,6 +558,7 @@ static void jent_random_data_one(
 				       uint64_t *ret_current_delta))
 {
 	unsigned int safety_factor = 0, ctr = 0;
+	uint64_t nosr;
 
 	if (ec->is_fips_enabled)
 		safety_factor = ENTROPY_SAFETY_FACTOR;
@@ -565,15 +566,23 @@ static void jent_random_data_one(
 	/* RCT with memory: start a new iteration loop */
 	ec->rct_mem_ctr = 0;
 
-	/* Obtain number of loop iterations */
-	ec->rct_mem_nosr = (unsigned short)
-		JENT_ADJUSTED_MEASURE_JITTER_LOOP_CTR(ec->osr, safety_factor);
-
-	/* Safety measure against wrapping */
-	if (ec->rct_mem_nosr < DATA_SIZE_BITS) {
+	/*
+	 * Obtain number of loop iterations.
+	 *
+	 * Safety measure against wrapping: compute in 64 bits and verify the
+	 * count fits the unsigned short window counters and covers at least
+	 * one output block. With the default JENT_MAX_OSR of 20 this cannot
+	 * trigger, but JENT_MAX_OSR is a compile-time tunable and a truncated
+	 * count would silently shrink the RCT-with-memory window below what
+	 * the cutoff tables assume, disabling the health test.
+	 */
+	nosr = JENT_ADJUSTED_MEASURE_JITTER_LOOP_CTR((uint64_t)ec->osr,
+						     safety_factor);
+	if (nosr > USHRT_MAX || nosr < DATA_SIZE_BITS) {
 		ec->health_failure |= JENT_RCT_MEM_FAILURE_PERMANENT;
 		return;
 	}
+	ec->rct_mem_nosr = (unsigned short)nosr;
 
 	/* Entropy collection loop */
 	while (!jent_health_failure(ec)) {

--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -600,7 +600,14 @@ void jent_random_data(struct rand_data *ec)
 	switch (ec->startup_state) {
 	case jent_startup_memory:
 		jent_random_data_one(ec, jent_measure_jitter_ntg1_memaccess);
-		ec->startup_state--;
+		/*
+		 * Assign the successor state explicitly instead of
+		 * decrementing: a decrement based on the state observed
+		 * before jent_random_data_one() could move the state out of
+		 * the valid enum range if a reentrant path (e.g. the RCT-mem
+		 * recovery loop) advanced it in the meantime.
+		 */
+		ec->startup_state = jent_startup_sha3;
 
 		/*
 		 * Initialize the health tests as we fall through to
@@ -613,7 +620,7 @@ void jent_random_data(struct rand_data *ec)
 		fallthrough;
 	case jent_startup_sha3:
 		jent_random_data_one(ec, jent_measure_jitter_ntg1_sha3);
-		ec->startup_state--;
+		ec->startup_state = jent_startup_completed;
 
 		/*
 		 * Initialize the health tests as we fall through to

--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -258,8 +258,9 @@ static void jent_memaccess_pseudorandom(struct rand_data *ec, uint64_t loop_cnt,
 	 */
 	if (current_delta) {
 		jent_get_nstime_internal(ec, &time_now_end);
-		tmp_delta += jent_delta(time_now_start, time_now_end) /
-					ec->jent_common_timer_gcd;
+		tmp_delta += jent_udiv64(jent_delta(time_now_start,
+						    time_now_end),
+					 ec->jent_common_timer_gcd);
 		*current_delta = tmp_delta;
 	}
 }
@@ -333,8 +334,9 @@ static void jent_memaccess_deterministic(struct rand_data *ec,
 
 	if (current_delta) {
 		jent_get_nstime_internal(ec, &time_now_end);
-		tmp_delta += jent_delta(time_now_start, time_now_end) /
-					ec->jent_common_timer_gcd;
+		tmp_delta += jent_udiv64(jent_delta(time_now_start,
+						    time_now_end),
+					 ec->jent_common_timer_gcd);
 		*current_delta = tmp_delta;
 	}
 }
@@ -449,8 +451,8 @@ unsigned int jent_measure_jitter_ntg1_sha3(struct rand_data *ec,
 	 * invocation to measure the timing variations
 	 */
 	jent_get_nstime_internal(ec, &time_now);
-	current_delta = jent_delta(ec->prev_time, time_now) /
-				   ec->jent_common_timer_gcd;
+	current_delta = jent_udiv64(jent_delta(ec->prev_time, time_now),
+				    ec->jent_common_timer_gcd);
 
 	/*
 	 * Check whether we have a stuck measurement - and apply the health
@@ -509,8 +511,8 @@ unsigned int jent_measure_jitter(struct rand_data *ec,
 	 * invocation to measure the timing variations
 	 */
 	jent_get_nstime_internal(ec, &time_now);
-	current_delta = jent_delta(ec->prev_time, time_now) /
-				   ec->jent_common_timer_gcd;
+	current_delta = jent_udiv64(jent_delta(ec->prev_time, time_now),
+				    ec->jent_common_timer_gcd);
 	ec->prev_time = time_now;
 
 	/* Check whether we have a stuck measurement. */
@@ -544,7 +546,7 @@ unsigned int jent_measure_jitter(struct rand_data *ec,
  * Therefore, round up the jitter loop counter to the nearest multiple of three.
  */
 #define JENT_ROUNDUP_TO_THREE(x)                                               \
-	( (((x) + 2) / 3) * 3 )
+	(jent_udiv64((x) + 2, 3) * 3)
 #define JENT_ADJUSTED_MEASURE_JITTER_LOOP_CTR(_osr, _safety_factor)            \
 	JENT_ROUNDUP_TO_THREE(                                                 \
 		JENT_MEASURE_JITTER_LOOP_CTR(_osr, _safety_factor))

--- a/src/jitterentropy-sha3.c
+++ b/src/jitterentropy-sha3.c
@@ -63,7 +63,7 @@ static inline uint64_t rol64(uint64_t x, unsigned int n)
 
 /*********************************** Keccak ***********************************/
 /* state[x + y*5] */
-#define A(x, y) (x + 5 * y)
+#define A(x, y) ((x) + 5 * (y))
 
 static inline void jent_keccakp_theta(uint64_t s[25])
 {
@@ -120,7 +120,7 @@ static inline void jent_keccakp_rho(uint64_t s[25])
 	/* Step 1 */
 	/* s[A(0, 0)] = s[A(0, 0)]; */
 
-#define RHO_ROL(t)	(((t + 1) * (t + 2) / 2) % 64)
+#define RHO_ROL(t)	((((t) + 1) * ((t) + 2) / 2) % 64)
 	/* Step 3 */
 	s[A(1, 0)] = rol64(s[A(1, 0)], RHO_ROL(0));
 	s[A(0, 2)] = rol64(s[A(0, 2)], RHO_ROL(1));

--- a/src/jitterentropy-status.c
+++ b/src/jitterentropy-status.c
@@ -21,7 +21,17 @@
 #include "jitterentropy-base.h"
 #include "jitterentropy-internal.h"
 
-#ifndef LINUX_KERNEL
+#ifdef LINUX_KERNEL
+/*
+ * Do not rely on transitive includes for the string helpers: snprintf() and
+ * strlen()/memcpy() live in <linux/kernel.h> (which pulls in the sprintf
+ * declarations across the supported kernel range) and <linux/string.h>. This
+ * file is not part of the -O0 entropy core, so the heavier headers are safe
+ * here.
+ */
+#include <linux/kernel.h>
+#include <linux/string.h>
+#else
 #include <stdio.h>
 #endif
 
@@ -48,7 +58,7 @@ int jent_status(const struct rand_data *ec, char *buf, size_t buflen)
 	/* needed as plain snprintf to make jent_add_to_status len calculation usable */
 	snprintf(buf, buflen, "{\n");
 
-	jent_add_to_status("\t\"version\": \"%u.%u.%u\"",
+	jent_add_to_status("\t\"version\": \"%d.%d.%d\"",
 			   JENT_MAJVERSION, JENT_MINVERSION, JENT_PATCHLEVEL)
 
 	if (!ec) {

--- a/tests/gcd/gcd.c
+++ b/tests/gcd/gcd.c
@@ -58,11 +58,16 @@ int main(int argc, char *argv[])
 	(void)argc;
 	(void)argv;
 
+	if (!gcd)
+		return 4;
+
 	for (i = 0; i < ELEM; i++)
 		jent_gcd_add_value(gcd, i * EXP_GCD, i);
 
-	if (jent_gcd_analyze(gcd, ELEM, osr))
+	if (jent_gcd_analyze(gcd, ELEM, osr)) {
+		jent_gcd_fini(gcd, ELEM);
 		return 1;
+	}
 
 	jent_gcd_fini(gcd, ELEM);
 

--- a/tests/raw-entropy/extractlsb.c
+++ b/tests/raw-entropy/extractlsb.c
@@ -190,6 +190,12 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	if (bitcount(mask) == 0) {
+		fprintf(stderr,
+			"Mask selects no bits - the output would be all-zero. Check the mask value\n");
+		return 1;
+	}
+
 	f = fopen(argv[1], "r");
 	if (!f) {
 		fprintf(stderr, "File %s cannot be opened for read: %s\n",
@@ -226,7 +232,20 @@ int main(int argc, char *argv[])
 			goto err;
 		}
 
-		sample = strtoull(res, NULL, 10);
+		/*
+		 * Reject lines that are not a plain non-negative decimal
+		 * number (blank lines, headers, stray text, negative values):
+		 * they would silently parse as 0 (or wrap around) and inject a
+		 * bogus symbol into the SP800-90B input data.
+		 */
+		errno = 0;
+		endptr = NULL;
+		sample = strtoull(res, &endptr, 10);
+		if (errno || endptr == res || *res == '-' ||
+		    (*endptr != '\0' && *endptr != '\n' && *endptr != '\r')) {
+			fprintf(stderr, "Invalid sample line [%s]\n", res);
+			goto err;
+		}
 		unchanged0s |= sample;
 		unchanged1s &= sample;
 

--- a/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
@@ -154,6 +154,8 @@ static int getrawentropy(const struct opts *opts)
 	size_t requested = opts->samples * DATASIZE;
 	lrngval_t leftover = 0;
 	uint8_t leftover_present = 0;
+	/* Bytes of a partial record carried over from the previous read(). */
+	size_t fill = 0;
 	uint8_t *buffer_p, buffer[BUFFER_SIZE];
 	ssize_t ret;
 	int fd = -1;
@@ -225,7 +227,15 @@ static int getrawentropy(const struct opts *opts)
 
 		buffer_p = buffer;
 
-		ret = read(fd, buffer_p, gather);
+		/*
+		 * Append to any partial record carried over from the previous
+		 * iteration: a read() delivering a byte count that is not a
+		 * record multiple (a pipe, or --debugfs-file pointing at an
+		 * odd-sized regular file) would otherwise drop the trailing
+		 * bytes and misalign - and thereby garble - every subsequently
+		 * decoded value.
+		 */
+		ret = read(fd, buffer + fill, gather - fill);
 		if (ret < 0) {
 			ret = -errno;
 			goto out;
@@ -243,7 +253,9 @@ static int getrawentropy(const struct opts *opts)
 			goto out;
 		}
 
-		for (i = 0; i < ret / (DATASIZE); i++) {
+		fill += (size_t)ret;
+
+		for (i = 0; i < fill / (DATASIZE); i++) {
 			lrngval_t val;
 
 			memcpy(&val, buffer_p, DATASIZE);
@@ -277,6 +289,10 @@ static int getrawentropy(const struct opts *opts)
 			if (requested == 0)
 				break;
 		}
+
+		/* Carry a trailing partial record to the next iteration. */
+		fill -= (size_t)(buffer_p - buffer);
+		memmove(buffer, buffer_p, fill);
 	}
 
 	ret = 0;

--- a/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
@@ -79,6 +79,25 @@ struct opts {
 	const char *sysfs_dir;
 };
 
+/*
+ * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
+ * a typo (or a follow-up option consumed as value due to the prefix matching
+ * below) into 0 and the tool would silently record with a configuration
+ * different from what the operator requested.
+ */
+static int parse_ulong(const char *str, unsigned long *val)
+{
+	char *endptr;
+
+	errno = 0;
+	*val = strtoul(str, &endptr, 10);
+	if (endptr == str || *endptr != '\0' || errno != 0) {
+		printf("Invalid numeric value \"%s\"\n", str);
+		return -EINVAL;
+	}
+	return 0;
+}
+
 static int write_config(const struct opts *opts, const char *file,
 			unsigned int val)
 {
@@ -305,7 +324,11 @@ int main(int argc, char * argv[])
 	opts.status = 0;
 	opts.loopcnt = 0;
 
-	if (argc < 4) {
+	/*
+	 * Every option has a default, so any single option (e.g. --samples N
+	 * or --status) is a valid invocation.
+	 */
+	if (argc < 2) {
 		printf("%s --samples <NUMSAMPLES> | --debugfs-file <FILE> [ --param-dir <DIR> | --timestamps | --ntg1|--force-fips|--disable-memory-access|--disable-internal-timer|--force-internal-timer|--osr <OSR>|--loopcnt <NUM>|--max-mem <NUM>|--hashloop|--memaccess|--all-caches|--hloopcnt <NUM>|--status]\n", argv[0]);
 		return 1;
 	}
@@ -322,12 +345,16 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			/*
 			 * Bound the sample count so that the byte total
-			 * (samples + 1) * DATASIZE cannot overflow size_t.
+			 * (samples + 1) * DATASIZE cannot overflow size_t. A
+			 * zero count would record an empty data file with exit
+			 * status 0.
 			 */
-			if (val >= UINT_MAX || val + 1 > SIZE_MAX / DATASIZE)
+			if (!val || val >= UINT_MAX ||
+			    val + 1 > SIZE_MAX / DATASIZE)
 				return 1;
 			opts.samples = (size_t)val;
 		} else if (!strncmp(argv[1], "--debugfs-file", 14) ||
@@ -379,8 +406,7 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
-			if (val >= UINT_MAX)
+			if (parse_ulong(argv[1], &val) || val >= UINT_MAX)
 				return 1;
 			opts.osr = (unsigned int)val;
 		} else if (!strncmp(argv[1], "--loopcnt", 9)) {
@@ -398,8 +424,7 @@ int main(int argc, char * argv[])
 			 * jitterentropy-hashtime (also enforced by the
 			 * JENT_IOCLOOPCNT ioctl).
 			 */
-			val = strtoul(argv[1], NULL, 10);
-			if (val >= UINT_MAX)
+			if (parse_ulong(argv[1], &val) || val >= UINT_MAX)
 				return 1;
 			opts.loopcnt = val;
 		} else if (!strncmp(argv[1], "--max-mem", 9)) {
@@ -412,7 +437,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				/* Allow to set no option */
@@ -491,7 +517,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				opts.flags |= JENT_HASHLOOP_1;

--- a/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
+++ b/tests/raw-entropy/recording_runtime_kernelspace/getrawentropy.c
@@ -127,8 +127,17 @@ static int write_config(const struct opts *opts, const char *file,
 	}
 
 out:
-	if (config)
-		fclose(config);
+	/*
+	 * The value leaves the stdio buffer only at fclose() time (it is far
+	 * smaller than the buffer), so a kernel rejecting it (e.g. EINVAL)
+	 * surfaces only here. Without this check the recording would silently
+	 * run with a different osr/flags configuration than requested.
+	 */
+	if (config && fclose(config) != 0 && !ret) {
+		printf("Configuration parameters writing to %s failed: %s\n",
+		       file, strerror(errno));
+		ret = -EINVAL;
+	}
 	return ret;
 }
 
@@ -275,6 +284,16 @@ static int getrawentropy(const struct opts *opts)
 out:
 	if (fd >= 0)
 		close(fd);
+
+	/*
+	 * The samples were written through stdout's buffer; a write error on
+	 * the redirect target (e.g. ENOSPC) may surface only at flush time.
+	 * Report it so a truncated data file cannot pass as a success.
+	 */
+	if (!ret && (fflush(stdout) != 0 || ferror(stdout))) {
+		fprintf(stderr, "Failed to write output\n");
+		ret = -EIO;
+	}
 
 	return (int)ret;
 }

--- a/tests/raw-entropy/recording_userspace/Makefile.osr
+++ b/tests/raw-entropy/recording_userspace/Makefile.osr
@@ -23,9 +23,17 @@ JENT_DIR := jitterentropy
 JENT_SRCS := $(wildcard $(JENT_DIR)/src/*.c) $(wildcard $(JENT_DIR)/arch/*.c)
 
 NAME := jitterentropy-osr
+
+# Compile all objects into a local directory. Emitting them next to the
+# library sources (through the jitterentropy symlink) would leave objects
+# built with this tool's flags inside src/ and arch/, which the library's
+# own Makefile then silently picks up via VPATH - e.g. linking a
+# libjitterentropy without JENT_CONF_ENABLE_INTERNAL_TIMER support.
+OBJDIR := obj-osr
 C_SRCS := $(JENT_SRCS) jitterentropy-osr.c
-C_OBJS := ${C_SRCS:.c=.o}
-OBJS := $(C_OBJS)
+OBJS := $(addprefix $(OBJDIR)/,$(notdir $(C_SRCS:.c=.o)))
+
+vpath %.c $(JENT_DIR)/src $(JENT_DIR)/arch
 
 INCLUDE_DIRS := $(JENT_DIR) $(JENT_DIR)/src
 LIBRARY_DIRS :=
@@ -42,8 +50,14 @@ all: $(NAME)
 $(NAME): $(OBJS)
 	$(CC) $(OBJS) -o $(NAME) $(LDFLAGS)
 
+$(OBJDIR)/%.o: %.c | $(OBJDIR)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+$(OBJDIR):
+	mkdir -p $(OBJDIR)
+
 clean:
 	@- $(RM) $(NAME)
-	@- $(RM) $(OBJS)
+	@- $(RM) -r $(OBJDIR)
 
 distclean: clean

--- a/tests/raw-entropy/recording_userspace/Makefile.rng
+++ b/tests/raw-entropy/recording_userspace/Makefile.rng
@@ -25,9 +25,17 @@ JENT_DIR := jitterentropy
 JENT_SRCS := $(wildcard $(JENT_DIR)/src/*.c) $(wildcard $(JENT_DIR)/arch/*.c)
 
 NAME := jitterentropy-rng
+
+# Compile all objects into a local directory. Emitting them next to the
+# library sources (through the jitterentropy symlink) would leave objects
+# built with this tool's flags inside src/ and arch/, which the library's
+# own Makefile then silently picks up via VPATH - e.g. linking a
+# libjitterentropy without JENT_CONF_ENABLE_INTERNAL_TIMER support.
+OBJDIR := obj-rng
 C_SRCS := $(JENT_SRCS) jitterentropy-rng.c
-C_OBJS := ${C_SRCS:.c=.o}
-OBJS := $(C_OBJS)
+OBJS := $(addprefix $(OBJDIR)/,$(notdir $(C_SRCS:.c=.o)))
+
+vpath %.c $(JENT_DIR)/src $(JENT_DIR)/arch
 
 INCLUDE_DIRS := $(JENT_DIR) $(JENT_DIR)/src
 LIBRARY_DIRS :=
@@ -44,8 +52,14 @@ all: $(NAME)
 $(NAME): $(OBJS)
 	$(CC) $(OBJS) -o $(NAME) $(LDFLAGS)
 
+$(OBJDIR)/%.o: %.c | $(OBJDIR)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+$(OBJDIR):
+	mkdir -p $(OBJDIR)
+
 clean:
 	@- $(RM) $(NAME)
-	@- $(RM) $(OBJS)
+	@- $(RM) -r $(OBJDIR)
 
 distclean: clean

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -21,6 +21,7 @@
 #define _GNU_SOURCE
 #endif
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -55,6 +56,24 @@
 #ifndef REPORT_COUNTER_TICKS
 #define REPORT_COUNTER_TICKS 1
 #endif
+
+/*
+ * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
+ * a typo (or a follow-up option consumed as value) into 0 and the tool would
+ * silently record with a configuration different from what was requested.
+ */
+static int parse_ulong(const char *str, unsigned long *val)
+{
+	char *endptr;
+
+	errno = 0;
+	*val = strtoul(str, &endptr, 10);
+	if (endptr == str || *endptr != '\0' || errno != 0) {
+		printf("Invalid numeric value \"%s\"\n", str);
+		return 1;
+	}
+	return 0;
+}
 
 enum jent_es {
 	jent_common,		/* Common entropy source */
@@ -256,17 +275,33 @@ int main(int argc, char * argv[])
 		return 1;
 	}
 
-	rounds = strtoul(argv[1], NULL, 10);
-	if (rounds >= UINT_MAX)
-		return 1;
-	argc--;
-	argv++;
+	{
+		char *endp;
 
-	repeats = strtoul(argv[1], NULL, 10);
-	if (repeats >= UINT_MAX)
-		return 1;
-	argc--;
-	argv++;
+		/*
+		 * Reject non-numeric input and zero: rounds feeds
+		 * calloc(rounds, ...), and calloc(0, ...) may legally return
+		 * NULL, which would be reported as an allocation failure (or
+		 * silently record empty data files).
+		 */
+		rounds = strtoul(argv[1], &endp, 10);
+		if (endp == argv[1] || *endp != '\0' ||
+		    rounds == 0 || rounds >= UINT_MAX) {
+			fprintf(stderr, "Invalid rounds value %s\n", argv[1]);
+			return 1;
+		}
+		argc--;
+		argv++;
+
+		repeats = strtoul(argv[1], &endp, 10);
+		if (endp == argv[1] || *endp != '\0' ||
+		    repeats == 0 || repeats >= UINT_MAX) {
+			fprintf(stderr, "Invalid repeats value %s\n", argv[1]);
+			return 1;
+		}
+		argc--;
+		argv++;
+	}
 
 	file = argv[1];
 	argc--;
@@ -299,8 +334,7 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
-			if (val >= UINT_MAX)
+			if (parse_ulong(argv[1], &val) || val >= UINT_MAX)
 				return 1;
 			osr = (unsigned int)val;
 		} else if (!strncmp(argv[1], "--loopcnt", 9)) {
@@ -313,8 +347,7 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
-			if (val >= UINT_MAX)
+			if (parse_ulong(argv[1], &val) || val >= UINT_MAX)
 				return 1;
 			loopcnt = (unsigned int)val;
 		} else if (!strncmp(argv[1], "--max-mem", 9)) {
@@ -327,7 +360,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				/* Allow to set no option */
@@ -406,7 +440,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				flags |= JENT_HASHLOOP_1;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -206,12 +206,25 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 		measure_jitter(ec, loopcnt, &duration[size]);
 	}
 
+	/*
+	 * Treat output errors as fatal for the tool: a silently truncated
+	 * sample file would be analyzed by the SP800-90B validation pipeline
+	 * as if it were complete.
+	 */
 #ifdef JENT_TEST_BINARY_OUTPUT
 	recordsWritten = fwrite(duration, sizeof(uint64_t), rounds, out);
-	if(recordsWritten != rounds) fprintf(stderr, "Can't output data.\n");
-	#else
-	for (size = 0; size < rounds; size++)
-		fprintf(out, "%" PRIu64 "\n", duration[size]);
+	if (recordsWritten != rounds) {
+		fprintf(stderr, "Can't output data.\n");
+		ret = 1;
+	}
+#else
+	for (size = 0; size < rounds; size++) {
+		if (fprintf(out, "%" PRIu64 "\n", duration[size]) < 0) {
+			fprintf(stderr, "Can't output data.\n");
+			ret = 1;
+			break;
+		}
+	}
 #endif
 
 	if ((health_test_result = jent_health_failure(ec))) {
@@ -225,8 +238,11 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 out:
 	free(duration);
 
-	if (out)
-		fclose(out);
+	/* An fclose() error means buffered sample data was lost. */
+	if (out && fclose(out) != 0) {
+		fprintf(stderr, "Can't close output file.\n");
+		ret = 1;
+	}
 
 	if (ec) {
 		/* checks internally if timer was used, maybe NOOP */
@@ -483,11 +499,24 @@ int main(int argc, char * argv[])
 	}
 
 	for (i = 1; i <= repeats; i++) {
+		int len;
+
 #if defined(JENT_TEST_BINARY_OUTPUT)
-		snprintf(pathname, sizeof(pathname), "%s-%.4lu-u64.bin", file, i);
+		len = snprintf(pathname, sizeof(pathname), "%s-%.4lu-u64.bin",
+			       file, i);
 #else
-		snprintf(pathname, sizeof(pathname), "%s-%.4lu.data", file, i);
+		len = snprintf(pathname, sizeof(pathname), "%s-%.4lu.data",
+			       file, i);
 #endif
+		/*
+		 * A truncated path would drop the repeat-number suffix and make
+		 * every repeat overwrite the same file, silently collapsing the
+		 * SP800-90B restart matrix to a single repeat.
+		 */
+		if (len < 0 || (size_t)len >= sizeof(pathname)) {
+			fprintf(stderr, "Output file path too long\n");
+			return 1;
+		}
 
 		ret = jent_one_test(pathname, rounds, flags, osr, jent_es,
 				    loopcnt, REPORT_COUNTER_TICKS, status);

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -20,6 +20,7 @@
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <stdio.h>
@@ -29,6 +30,24 @@
 #include <float.h>
 #include <assert.h>
 #include <time.h>
+
+/*
+ * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
+ * a typo (or a follow-up option consumed as value) into 0 and the tool would
+ * silently measure with a configuration different from what was requested.
+ */
+static int parse_ulong(const char *str, unsigned long *val)
+{
+	char *endptr;
+
+	errno = 0;
+	*val = strtoul(str, &endptr, 10);
+	if (endptr == str || *endptr != '\0' || errno != 0) {
+		fprintf(stderr, "Invalid numeric value \"%s\"\n", str);
+		return 1;
+	}
+	return 0;
+}
 
 /* We use a linear interpolation to estimate where the value is going to be.
  * The way these variable are named, this is technically the inverse function
@@ -118,14 +137,20 @@ int main(int argc, char * argv[])
 		return 1;
 	}
 
-	rounds = strtoul(argv[1], NULL, 10);
-	if ((rounds >= UINT_MAX) || (rounds == 0))
+	if (parse_ulong(argv[1], &rounds) || rounds >= UINT_MAX || rounds == 0)
 		return 1;
 	argc--;
 	argv++;
 
+	/*
+	 * Reject NaN, infinities and values whose nanosecond representation
+	 * does not fit uint64_t: converting such a double to uint64_t below is
+	 * undefined behavior and would yield a garbage time bound.
+	 */
 	timeBoundIn = strtod(argv[1], &endtimeparam);
-	if ((timeBoundIn <= 0.0) || (*endtimeparam != '\0'))
+	if (!isfinite(timeBoundIn) || (timeBoundIn <= 0.0) ||
+	    (timeBoundIn > 1.8e10) || (endtimeparam == argv[1]) ||
+	    (*endtimeparam != '\0'))
 		return 1;
 
 	/* The time upper bound, expressed as an integer number of nanoseconds. */
@@ -156,7 +181,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				/* Allow to set no option */
@@ -235,7 +261,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				flags |= JENT_HASHLOOP_1;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -67,7 +67,14 @@ double linearInverse(double y, double x1, double y1, double x2, double y2) {
 	return (y-y1)*((x2-x1)/(y2-y1)) + x1;
 }
 
-/* Returns the number of nanoseconds per output for the selected flags and osr. */
+/*
+ * Returns the number of nanoseconds per output for the selected flags and osr.
+ *
+ * A failed measurement terminates the program: any numeric return value would
+ * be indistinguishable from a legitimate (fast) timing and would corrupt the
+ * search invariants of the caller (e.g. drive the doubling search into an
+ * endless loop).
+ */
 uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 {
 	struct rand_data *ec_nostir;
@@ -77,27 +84,27 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 
 	ret = jent_entropy_init_ex(osr, flags);
 	if (ret) {
-		if (osr > JENT_MAX_OSR) {
+		if (osr > JENT_MAX_OSR)
 			fprintf(stderr,
 				"The initialization failed with error code %d due to selected OSR %u too high (max %u)\n",
 				ret, osr, JENT_MAX_OSR);
-			return 1;
-		}
-		fprintf(stderr, "The initialization failed with error code %d\n", ret);
-		return 1;
+		else
+			fprintf(stderr,
+				"The initialization failed with error code %d\n",
+				ret);
+		exit(1);
 	}
 
 	ec_nostir = jent_entropy_collector_alloc(osr, flags);
 
 	if (!ec_nostir) {
 		fprintf(stderr, "Jitter RNG handle cannot be allocated\n");
-		return 1;
+		exit(1);
 	}
 
 	if (timespec_get(&start, TIME_UTC) == 0) {
 		fprintf(stderr, "Unable to get start time\n");
-		jent_entropy_collector_free(ec_nostir);
-		return 1;
+		exit(1);
 	}
 
 	for (unsigned long size = 0; size < rounds; size++) {
@@ -105,15 +112,13 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 
 		if (0 > jent_read_entropy_safe(&ec_nostir, tmp, sizeof(tmp))) {
 			fprintf(stderr, "FIPS 140-2 continuous test failed\n");
-			jent_entropy_collector_free(ec_nostir);
-			return 1;
+			exit(1);
 		}
 	}
 
 	if (timespec_get(&finish, TIME_UTC) == 0) {
 		fprintf(stderr, "Unable to get finish time\n");
-		jent_entropy_collector_free(ec_nostir);
-		return 1;
+		exit(1);
 	}
 	runtime = ((uint64_t)finish.tv_sec * UINT64_C(1000000000) + (uint64_t)finish.tv_nsec) - ((uint64_t)start.tv_sec * UINT64_C(1000000000) + (uint64_t)start.tv_nsec);
 

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -102,7 +102,12 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 		exit(1);
 	}
 
-	if (timespec_get(&start, TIME_UTC) == 0) {
+	/*
+	 * Use a monotonic clock: the measured interval feeds the search
+	 * invariants, and a wall-clock step (NTP, DST, manual adjustment)
+	 * during a measurement would corrupt or even negate the runtime.
+	 */
+	if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
 		fprintf(stderr, "Unable to get start time\n");
 		exit(1);
 	}
@@ -116,7 +121,7 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 		}
 	}
 
-	if (timespec_get(&finish, TIME_UTC) == 0) {
+	if (clock_gettime(CLOCK_MONOTONIC, &finish) != 0) {
 		fprintf(stderr, "Unable to get finish time\n");
 		exit(1);
 	}
@@ -408,7 +413,7 @@ int main(int argc, char * argv[])
 
 	/*
 	 * Now secondLinearGuess > firstLinearGuess and the times are usually
-	 * ordered the same way - but they are wall-clock measurements, so an
+	 * ordered the same way - but they are elapsed-time measurements, so an
 	 * inversion from timing noise is possible. Do not assert on measured
 	 * data: the bracketing logic below only compares the times against
 	 * timeBound and remains correct either way.
@@ -496,7 +501,7 @@ int main(int argc, char * argv[])
 
 		fprintf(stderr, "Trying osr=%u. ", curosr);
 		/*
-		 * curTime is a wall-clock measurement; timing noise can place it
+		 * curTime is an elapsed-time measurement; timing noise can place it
 		 * outside (minTime, maxTime), so it must not be asserted to lie
 		 * within. The bracket update below relies only on the comparison
 		 * with timeBound and keeps the search invariants intact.

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -323,6 +323,16 @@ int main(int argc, char * argv[])
 	 * the time cost per osr, and so this produces a likely underestimate.
 	 */
 	firstLinearGuess = (unsigned int)(timeBound / (1U + minTime / minBound));
+	/*
+	 * Keep the guess within the OSR range the library accepts: values beyond
+	 * JENT_MAX_OSR cannot be measured (initialization rejects them), and a
+	 * guess at or below minBound would degenerate the interpolation below
+	 * (identical x coordinates).
+	 */
+	if (firstLinearGuess <= minBound)
+		firstLinearGuess = minBound + 1;
+	if (firstLinearGuess > JENT_MAX_OSR)
+		firstLinearGuess = JENT_MAX_OSR;
 	fprintf(stderr, "The initial linear estimate is osr=%u\n", firstLinearGuess);
 	firstLinearTime = jent_output_time(rounds, firstLinearGuess, flags);
 
@@ -330,13 +340,51 @@ int main(int argc, char * argv[])
 	 * perform a full linear interpolation.
 	 * We are presently looking for an overestimate, so let's round up here.
 	 */
-	secondLinearGuess = (unsigned int)ceil(linearInverse((double)timeBound, (double)minBound, (double)minTime, (double)firstLinearGuess, (double)firstLinearTime));
+	if (firstLinearTime == minTime) {
+		/*
+		 * Two identical timings carry no slope information (and would
+		 * trip the divide-by-zero guard in linearInverse()); fall back
+		 * to the neighboring value.
+		 */
+		secondLinearGuess = firstLinearGuess + 1;
+	} else {
+		double secondGuessD = ceil(linearInverse((double)timeBound,
+					   (double)minBound, (double)minTime,
+					   (double)firstLinearGuess,
+					   (double)firstLinearTime));
+
+		/*
+		 * Clamp into the valid OSR range before converting: with noisy
+		 * timings the interpolation can produce a negative value, and
+		 * casting a negative double to unsigned int is undefined
+		 * behavior. The comparison is written so a NaN also falls into
+		 * the clamp.
+		 *
+		 * The lower clamp is minBound + 1, not JENT_MIN_OSR: a guess
+		 * equal to minBound would - after the exchange below - allow
+		 * the bracket to collapse to maxBound == minBound when the
+		 * re-measurement of that osr lands above timeBound due to
+		 * timing noise, tripping the assert(maxBound > minBound).
+		 */
+		if (!(secondGuessD >= (double)(minBound + 1)))
+			secondGuessD = (double)(minBound + 1);
+		if (secondGuessD > (double)JENT_MAX_OSR)
+			secondGuessD = (double)JENT_MAX_OSR;
+		secondLinearGuess = (unsigned int)secondGuessD;
+	}
 	fprintf(stderr, "Linear interpolation suggests a cutoff of %u\n", secondLinearGuess);
 
+	if (secondLinearGuess > JENT_MAX_OSR)
+		secondLinearGuess = JENT_MAX_OSR;
+
 	/* These estimates were done in two related ways, but they could have produced the same value.
-	 * Looking at the timing of two identical guesses isn't helpful, so adjust the result in this case.*/
+	 * Looking at the timing of two identical guesses isn't helpful, so adjust the result in this case.
+	 * Stay within the measurable OSR range while keeping the two guesses distinct. */
 	if(secondLinearGuess == firstLinearGuess) {
-		secondLinearGuess++;
+		if (secondLinearGuess < JENT_MAX_OSR)
+			secondLinearGuess++;
+		else
+			secondLinearGuess--;
 	}
 	secondLinearTime = jent_output_time(rounds, secondLinearGuess, flags);
 
@@ -358,8 +406,20 @@ int main(int argc, char * argv[])
 		secondLinearTime = tmpTime;
 	}
 
-	/* Now secondLinearGuess > firstLinearGuess, and the time values should have a similar relationship. */
-	assert(secondLinearTime > firstLinearTime);
+	/*
+	 * Now secondLinearGuess > firstLinearGuess and the times are usually
+	 * ordered the same way - but they are wall-clock measurements, so an
+	 * inversion from timing noise is possible. Do not assert on measured
+	 * data: the bracketing logic below only compares the times against
+	 * timeBound and remains correct either way.
+	 */
+	if (secondLinearTime <= firstLinearTime)
+		fprintf(stderr,
+			"Warning: non-monotone timings measured (osr %u: %llu ns, osr %u: %llu ns)\n",
+			firstLinearGuess,
+			(unsigned long long)firstLinearTime,
+			secondLinearGuess,
+			(unsigned long long)secondLinearTime);
 
 	/* Use the linear interpolation guesses as bounds where possible. */
 	if(firstLinearTime > timeBound) {
@@ -383,17 +443,33 @@ int main(int argc, char * argv[])
 		minTime = secondLinearTime;
 	}
 
-	/* If we don't yet have a maxBound, find one. This will also adjust minBound up as the search goes.*/
+	/* If we don't yet have a maxBound, find one. This will also adjust minBound up as the search goes.
+	 * The search is capped at JENT_MAX_OSR: larger values cannot be measured
+	 * (the library rejects them), and without the cap the former doubling
+	 * loop could never terminate once the target time exceeded the cost of
+	 * every valid OSR. */
 	if(maxBound == 0) {
-		maxBound = minBound*2;
-		fprintf(stderr, "Trying to find a maximum: %u", maxBound);
-		/* Locate the maxBound */
-		while((maxTime = jent_output_time(rounds, maxBound, flags)) <= timeBound) {
+		fprintf(stderr, "Trying to find a maximum:");
+		for (;;) {
+			if (minBound >= JENT_MAX_OSR) {
+				/*
+				 * Even the largest valid OSR meets the time
+				 * bound - it is the answer.
+				 */
+				fprintf(stderr,
+					".\nAll valid OSR values meet the target time.\n");
+				printf("%u\n", JENT_MAX_OSR);
+				return 0;
+			}
+			maxBound = minBound * 2;
+			if (maxBound > JENT_MAX_OSR)
+				maxBound = JENT_MAX_OSR;
+			fprintf(stderr, " %u", maxBound);
+			maxTime = jent_output_time(rounds, maxBound, flags);
+			if (maxTime > timeBound)
+				break;
 			minBound = maxBound;
 			minTime = maxTime;
-			maxBound = maxBound * 2;
-			fprintf(stderr, " %u", maxBound);
-			assert(maxBound > minBound);
 		}
 		fprintf(stderr, ".\nMaximum found: osr upper bound is < %u.\n", maxBound);
 	}
@@ -419,9 +495,13 @@ int main(int argc, char * argv[])
 		assert(curosr < maxBound);
 
 		fprintf(stderr, "Trying osr=%u. ", curosr);
+		/*
+		 * curTime is a wall-clock measurement; timing noise can place it
+		 * outside (minTime, maxTime), so it must not be asserted to lie
+		 * within. The bracket update below relies only on the comparison
+		 * with timeBound and keeps the search invariants intact.
+		 */
 		curTime = jent_output_time(rounds, curosr, flags);
-		assert(curTime > minTime);
-		assert(curTime < maxTime);
 
 		if(curTime <= timeBound) {
 			fprintf(stderr, "Timing is less than or equal to the target time. ");

--- a/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
@@ -19,10 +19,29 @@
 
 #include "jitterentropy.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
+
+/*
+ * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
+ * a typo (or a follow-up option consumed as value) into 0 and the tool would
+ * silently record with a configuration different from what was requested.
+ */
+static int parse_ulong(const char *str, unsigned long *val)
+{
+	char *endptr;
+
+	errno = 0;
+	*val = strtoul(str, &endptr, 10);
+	if (endptr == str || *endptr != '\0' || errno != 0) {
+		printf("Invalid numeric value \"%s\"\n", str);
+		return 1;
+	}
+	return 0;
+}
 
 int main(int argc, char * argv[])
 {
@@ -39,9 +58,16 @@ int main(int argc, char * argv[])
 		return 1;
 	}
 
-	rounds = strtoull(argv[1], NULL, 10);
-	if (rounds >= ULLONG_MAX)
-		return 1;
+	{
+		char *endp;
+
+		/* Reject non-numeric input instead of treating it as 0. */
+		rounds = strtoull(argv[1], &endp, 10);
+		if (endp == argv[1] || *endp != '\0' || rounds >= ULLONG_MAX) {
+			fprintf(stderr, "Invalid rounds value %s\n", argv[1]);
+			return 1;
+		}
+	}
 	argc--;
 	argv++;
 
@@ -68,8 +94,7 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
-			if (val >= UINT_MAX)
+			if (parse_ulong(argv[1], &val) || val >= UINT_MAX)
 				return 1;
 			osr = (unsigned int)val;
 		} else if (!strncmp(argv[1], "--max-mem", 9)) {
@@ -82,7 +107,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				/* Allow to set no option */
@@ -161,7 +187,8 @@ int main(int argc, char * argv[])
 				return 1;
 			}
 
-			val = strtoul(argv[1], NULL, 10);
+			if (parse_ulong(argv[1], &val))
+				return 1;
 			switch (val) {
 			case 0:
 				flags |= JENT_HASHLOOP_1;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
@@ -257,13 +257,39 @@ int main(int argc, char * argv[])
 			ret = 1;
 			goto out;
 		}
+		/*
+		 * Treat output errors as fatal: consumers pipe this data into
+		 * files for analysis, and a silently truncated stream with
+		 * exit code 0 would be processed as if complete.
+		 */
 		if (hex) {
 			for (i = 0; i < sizeof(tmp); ++i) {
-				fprintf(stdout, "%02X", (unsigned int)tmp[i]);
+				if (fprintf(stdout, "%02X",
+					    (unsigned int)tmp[i]) < 0) {
+					fprintf(stderr, "Can't output data\n");
+					ret = 1;
+					goto out;
+				}
 			}
 		} else {
-			fwrite(&tmp, sizeof(tmp), 1, stdout);
+			if (fwrite(&tmp, sizeof(tmp), 1, stdout) != 1) {
+				fprintf(stderr, "Can't output data\n");
+				ret = 1;
+				goto out;
+			}
 		}
+	}
+
+	/*
+	 * Most of the output above only fills the stdio buffer; the final
+	 * chunk would be flushed inside exit(), where a write failure (e.g.
+	 * ENOSPC) is silently discarded. Flush explicitly so a truncated
+	 * stream cannot terminate with exit code 0.
+	 */
+	if (fflush(stdout) != 0) {
+		fprintf(stderr, "Can't output data\n");
+		ret = 1;
+		goto out;
 	}
 
 	ret = 0;


### PR DESCRIPTION
Hi Stephan,

I did a final scrub on the kernel module with Claude.

Changes found/done on the way:
- fix module build for i686/32 Bit
- restructure proc output, also show flags and ntg1/fips status to be easily checkable
- enable secure memory in kernel code path
- add shortcut module parameters for ntg1 and fips
- testing: only return multiples of 64 bit timestamps

BR
Markus