### PR TITLE
Fixes from testing with different platforms

### DIFF
--- a/.github/scripts/vm-build-and-test.sh
+++ b/.github/scripts/vm-build-and-test.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# Build and test on a platform with no hosted GitHub runner. Driven by the
+# freebsd/openbsd/netbsd/dragonflybsd/solaris/haiku jobs in
+# .github/workflows/ci.yml, which reach their platform through a VM, and by the
+# cygwin and linux-distro jobs, which are not VMs - a Cygwin installation and
+# RHEL/SLES/Arch containers - but want exactly the same build matrix.
+#
+# Booting the VM dominates the runtime of those jobs, so everything the Linux
+# and macOS jobs spread across a matrix is done here in a single boot: both
+# CMake link configurations plus the Makefile build.
+#
+# Strictly POSIX sh. /bin/sh is the Almquist shell on FreeBSD, NetBSD and
+# DragonFly, pdksh on OpenBSD, ksh93 on Solaris and bash on Haiku and Cygwin;
+# not all of them are bash, and the workflow-level "shell: bash" default in
+# ci.yml applies to the runner, not to the guest.
+#
+# MAKE is overridden by the jobs whose GNU make is not called gmake - Haiku and
+# Cygwin ship it as plain make - and CC by those where the default choice would
+# be wrong.
+
+set -e
+
+os=$(uname -s)
+
+# The Makefile is GNU make syntax (ifeq, $(filter ...), $(shell ...)). No guest
+# here has that as /usr/bin/make - the BSDs ship BSD make and Solaris ships the
+# SunOS one - so every job installs GNU make and it is invoked by its own name.
+: "${MAKE:=gmake}"
+
+# hw.ncpu is a BSD sysctl and does not exist on Solaris; _NPROCESSORS_ONLN is
+# the POSIX spelling and is what answers there. Neither is universal, so both
+# are tried and the result is sanity-checked rather than trusted: an empty or
+# non-numeric answer would silently become "make -j" with no argument, which is
+# unlimited parallelism and enough to wedge a small guest.
+ncpu=$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)
+case "$ncpu" in
+''|*[!0-9]*) ncpu=$(sysctl -n hw.ncpu 2>/dev/null || true) ;;
+esac
+case "$ncpu" in
+''|*[!0-9]*) ncpu=2 ;;
+esac
+
+# cc(1) is not a given, and where it exists it is not always the one wanted: on
+# Solaris /usr/bin/cc can be the Oracle Studio compiler, which the GCC-specific
+# Makefile cannot be driven by, so that job passes CC in rather than relying on
+# this search. Exported so that CMake, the Makefile and the smoke-test link
+# below all agree on one compiler - the Makefile's "CC ?=" does not override
+# make's built-in default, but an environment value does.
+if [ -z "${CC:-}" ]; then
+	for c in cc gcc clang; do
+		if command -v "$c" > /dev/null 2>&1; then CC=$c; break; fi
+	done
+fi
+if [ -z "${CC:-}" ]; then
+	echo "no C compiler found (looked for cc, gcc, clang)" >&2
+	exit 1
+fi
+export CC
+
+echo "==> $(uname -a)"
+echo "==> cc: $($CC --version 2>&1 | head -n 1)"
+echo "==> using CC=$CC MAKE=$MAKE ncpu=$ncpu"
+
+# ---------------------------------------------------------------------------
+# CMake, static and shared
+# ---------------------------------------------------------------------------
+for shared in OFF ON; do
+	build="build-shared-$shared"
+	echo "==> CMake build (BUILD_SHARED_LIBS=$shared)"
+
+	rm -rf "$build"
+	cmake -S . -B "$build" -DBUILD_SHARED_LIBS="$shared"
+	cmake --build "$build" -j "$ncpu"
+
+	# A shared build leaves the library in the top-level build directory,
+	# which is not on the guests' default search path.
+	LD_LIBRARY_PATH="$PWD/$build:$LD_LIBRARY_PATH"
+	export LD_LIBRARY_PATH
+
+	# Cygwin builds a DLL rather than a shared object and resolves it the
+	# way Windows does, through PATH; LD_LIBRARY_PATH means nothing there
+	# and the shared run would fail to start for want of the library. The
+	# directory holds only the library, so prepending it shadows nothing.
+	PATH="$PWD/$build:$PATH"
+	export PATH
+
+	"$build/tests/gcd/gcd"
+
+	rng="$build/tests/raw-entropy/recording_userspace/jitterentropy-rng"
+	for opt in "" --all-caches --force-internal-timer; do
+		echo "==> jitterentropy-rng 256 $opt"
+		# Unquoted on purpose: the empty case must expand to no argument.
+		"$rng" 256 $opt > /dev/null
+	done
+
+	# --force-fips and --ntg1 are the two modes that require the collector
+	# memory to be locked into RAM (they imply JENT_FORCE_SECURE_MEM), so
+	# they are what reaches the mlock path in arch/jitterentropy-arch-memory.c and the
+	# limit raising the tool does for them beforehand
+	# (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h).
+	#
+	# They are not gated on. Both can fail on properties of the guest rather
+	# than on a defect: a memory lock limit smaller than the collector needs,
+	# or a startup whose health tests do not converge on the block size
+	# derived from this CPU's caches - which is a real possibility on the
+	# emulated CPUs these guests run on. The failure is printed rather than
+	# swallowed; note that "set -e" does not apply to a command whose status
+	# is consumed by ||.
+	for opt in --force-fips --ntg1; do
+		echo "==> jitterentropy-rng 256 $opt"
+		"$rng" 256 $opt > /dev/null ||
+			echo "::warning::jitterentropy-rng $opt failed in $os"
+	done
+done
+
+# ---------------------------------------------------------------------------
+# Makefile
+#
+# A second, independent build system with its own UNAME_S-keyed flag and
+# link-library selection. Those branches are reached from nowhere else, and the
+# guests here are what reach them: the BSD case drops -lrt (the POSIX clocks
+# live in libc there, and OpenBSD ships no librt at all) while keeping
+# -Wl,-z,relro,-z,now, and SunOS does the opposite - it is one of the two
+# platforms that still needs -lrt, and its link editor takes neither -z form.
+# ---------------------------------------------------------------------------
+echo "==> Makefile build ($MAKE)"
+"$MAKE" -j "$ncpu"
+
+cat > smoke.c <<'EOF'
+#include <stdio.h>
+#include "jitterentropy.h"
+
+static int collect(unsigned int flags, const char *what)
+{
+	char buf[64];
+	struct rand_data *ec = jent_entropy_collector_alloc(0, flags);
+
+	if (!ec) { printf("alloc failed (%s)\n", what); return 1; }
+	if (jent_read_entropy(ec, buf, sizeof(buf)) != (ssize_t)sizeof(buf)) {
+		printf("short read (%s)\n", what);
+		jent_entropy_collector_free(ec);
+		return 1;
+	}
+	jent_entropy_collector_free(ec);
+	printf("ok (%s)\n", what);
+	return 0;
+}
+
+int main(void) {
+	int rc = jent_entropy_init();
+	if (rc) { printf("jent_entropy_init: %d\n", rc); return 1; }
+	if (collect(0, "default")) return 1;
+	/*
+	 * The internal timer has to be forced: where the counter read works,
+	 * which is everywhere this runs, the automatic selection never falls
+	 * back to it, so the thread back-end would be linked in and never
+	 * started. That back-end is what the Makefile's own -pthread selection
+	 * exists for, and this is the only thing the Makefile build runs.
+	 */
+	if (collect(JENT_FORCE_INTERNAL_TIMER, "internal timer")) return 1;
+	return 0;
+}
+EOF
+
+# Mirrors the Makefile's own LIBRARIES selection, because this links the same
+# static archive by hand. -pthread rather than -lpthread: on FreeBSD it is the
+# only spelling that selects libthr, and every compiler here accepts it.
+case "$os" in
+SunOS) smoke_libs="-pthread -lrt" ;;
+*)     smoke_libs="-pthread" ;;
+esac
+
+# The archive's objects are stack-protector instrumented even though smoke.c
+# itself is not compiled with the flag, so their __stack_chk_fail and
+# __stack_chk_guard have to resolve here too - and on Solaris the driver only
+# links the runtime that defines them when the flag is on the link line. Same
+# probe as the Makefile's SSP_USABLE, for the same reason it is a probe and not
+# a name check: Solaris needs this and illumos does not, and both say SunOS.
+#
+# Where the probe fails the build dropped the flag as well, so the archive
+# carries no instrumented frames and there is nothing here left to resolve.
+if printf 'int main(int c,char**v){char b[64];(void)v;b[0]=(char)c;return b[0];}' \
+	| $CC -fstack-protector-strong -x c - -o /dev/null > /dev/null 2>&1; then
+	smoke_libs="$smoke_libs -fstack-protector-strong"
+fi
+
+# Unquoted on purpose: smoke_libs must split into separate arguments.
+# shellcheck disable=SC2086
+$CC -std=c11 -I. smoke.c libjitterentropy.a $smoke_libs -o smoke
+./smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,1536 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Every job scripts in bash, including the Windows ones, so that the build and
+# run steps stay identical across the matrix rather than being rewritten in
+# PowerShell. Git for Windows provides bash on the Windows runners.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # ubuntu-24.04-arm rather than a hypothetical "ubuntu-latest-arm": GitHub
+  # publishes no -arm alias for ubuntu-latest, only version-pinned arm labels.
+  #
+  # The arm64 entry is not a duplicate of the x86 one. It is the only job that
+  # compiles the aarch64 cntvct_el0 timer read against Linux, and the only
+  # aarch64 target anywhere in this workflow that pairs it with glibc and with
+  # the sysfs cache-size discovery in arch/jitterentropy-arch-cache.c. macOS on
+  # Apple Silicon reaches the same timer instruction but through an entirely
+  # different libc and a sysctl cache backend, so neither stands in for the
+  # other.
+  linux:
+    name: Linux / ${{ matrix.os }} / ${{ matrix.cc }} / shared=${{ matrix.shared }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        cc: [ gcc, clang ]
+        shared: [ 'ON', 'OFF' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      # The memory lock limits are printed before the runs below: the raise the
+      # recording tools do can only take the soft limit up to the hard one, so
+      # on a runner whose hard RLIMIT_MEMLOCK is smaller than the collector
+      # needs this line is what says why the compliance modes could not lock
+      # their memory.
+      - name: Run tests
+        run: |
+          echo "RLIMIT_MEMLOCK soft=$(ulimit -Sl) hard=$(ulimit -Hl)"
+          ./build/tests/gcd/gcd
+          export LD_LIBRARY_PATH="$PWD/build:$LD_LIBRARY_PATH"
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # 32-bit exercises code paths no other job reaches: the JENT_MAX_AUTO_MEMSIZE
+  # cap on the cache-derived working set, and the narrower size_t/long the cache
+  # and memory backends compute with.
+  linux-32bit:
+    name: Linux / gcc -m32
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install 32-bit toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_C_FLAGS=-m32 \
+            -DCMAKE_EXE_LINKER_FLAGS=-m32 \
+            -DCMAKE_SHARED_LINKER_FLAGS=-m32
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      - name: Run tests
+        run: |
+          file build/tests/gcd/gcd | grep -q '32-bit' || { echo "not a 32-bit build"; exit 1; }
+          ./build/tests/gcd/gcd
+          for opt in "--all-caches" "--force-internal-timer"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # Every other Linux job here links against glibc, but the library leans on a
+  # good deal of what the two libcs disagree about: the
+  # pthread_setaffinity_np()/CPU_SET pinning in arch/jitterentropy-arch-sched.c,
+  # the mlock/getrlimit handling in arch/jitterentropy-arch-memory.c, and
+  # clock_gettime(), which musl keeps in libc where glibc split it into librt.
+  # musl is also stricter about which header declares what, so an include glibc
+  # happens to supply transitively breaks here first.
+  #
+  # Distro musl and Nix musl are not the same test. This job is Debian's
+  # musl-gcc wrapper over the stock gcc against musl 1.2.x headers, which is how
+  # Alpine and the container world build the library; the nix-musl job below is
+  # a different musl, a different gcc and a full pkgsMusl dependency tree. The
+  # cheap one runs here, on a plain runner, where the failure is easy to read.
+  #
+  # Both linkages are built. Static is not a variation for its own sake: it is
+  # the configuration musl is usually chosen for, and it is where the library's
+  # use of pthreads and clock_gettime() has to hold up with no dynamic loader
+  # underneath - the case glibc warns about for NSS and that nothing else here
+  # covers.
+  linux-musl:
+    name: Linux / musl-gcc / ${{ matrix.link }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        link: [ dynamic, static ]
+        include:
+          - link: dynamic
+            flags: ''
+            # What `file` must report for this linkage, checked below.
+            expect: ld-musl
+          - link: static
+            flags: '-static'
+            expect: statically linked
+    steps:
+      - uses: actions/checkout@v4
+
+      # binutils for `strings`, which the libc check below reads the binary
+      # with.
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools binutils
+
+      # musl-gcc is a wrapper script, not a compiler binary, so the compiler ABI
+      # check CMake runs at configure time is what proves it is usable at all.
+      #
+      # The -idirafter pair is what makes the whole tree build rather than just
+      # the library. musl-gcc's specs replace the system include path with
+      # musl's own, which carries no Linux UAPI headers, so the two tools that
+      # speak to the kernel module - jitterentropy-chardev-status and
+      # getrawentropy, both reaching <linux/ioctl.h> through
+      # linux_kernel/jitterentropy_uapi.h - fail to compile. CMakeLists.txt
+      # gates those two on Linux with no way to opt out, which musl on Linux
+      # still is. Searched *after* musl's own directories, so musl keeps
+      # precedence for everything it defines and only linux/* and asm/*, which
+      # it does not ship, resolve out of Debian's linux-libc-dev.
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_C_COMPILER=musl-gcc \
+            -DCMAKE_C_FLAGS="${{ matrix.flags }} -idirafter /usr/include -idirafter /usr/include/x86_64-linux-gnu" \
+            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.flags }}"
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      - name: Run tests
+        run: |
+          bin=build/tests/gcd/gcd
+          file "$bin"
+
+          # Confirm this really is musl before trusting anything the tests say:
+          # a wrapper that silently fell back to the host compiler would produce
+          # a glibc binary and the job would pass as a duplicate of the plain
+          # Linux one. glibc stamps GLIBC_* symbol versions into everything it
+          # links, static builds included, and musl stamps nothing - so the
+          # absence of them is the one check that holds for both linkages. A
+          # static musl binary carries no positive marker to test instead; it is
+          # an ordinary SysV ELF with no libc name anywhere in it.
+          if strings "$bin" | grep -q GLIBC; then
+            echo "::error::GLIBC symbol versions present, this is not musl"
+            exit 1
+          fi
+
+          # And that the linkage is the one this matrix entry asked for; -static
+          # silently ignored would otherwise duplicate the dynamic entry. For
+          # the dynamic entry this doubles as the positive musl test, the
+          # interpreter being ld-musl rather than ld-linux.
+          file "$bin" | grep -q "${{ matrix.expect }}" || {
+            echo "::error::expected a ${{ matrix.link }} binary (${{ matrix.expect }})"
+            exit 1
+          }
+
+          ./build/tests/gcd/gcd
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # The distributions the hosted runners are not: every enterprise Linux
+  # generation still under support - RHEL 7 through 10, SLES 15 SP7 and 16.1 -
+  # and, at the other end, Arch. Between them they span eighteen years of
+  # toolchain, gcc 4.8.5 / glibc 2.17 through gcc 16 / glibc 2.44, and they are
+  # here to hold *both* bounds. The Ubuntu jobs above sit in the middle and say
+  # only that the library builds against something current; the long-lived
+  # appliance and HSM firmware it tends to end up inside is built against
+  # something considerably older, and the compiler that will reject it next is
+  # newer.
+  #
+  # The entries are not interchangeable, and the interesting one is RHEL 7. It is
+  # the only environment anywhere in this workflow where glibc's own version
+  # floors are visible at all - every other Linux job runs a glibc new enough
+  # that the following two are invisible, and each was a hard compile failure
+  # until this job existed:
+  #
+  #   - <sys/random.h> and the getrandom() wrapper are glibc 2.25, and the UUID
+  #     backend included the header unconditionally on Linux
+  #     (arch/jitterentropy-arch-uuid.c). Below that it takes the /dev/urandom
+  #     path it already falls back to at runtime - which is the right answer here
+  #     anyway, the getrandom() syscall being Linux 3.17 and RHEL 7's kernel
+  #     3.10.
+  #   - MAP_ANONYMOUS is __USE_MISC-guarded, so the Makefile's strict -std=c11
+  #     hides it. Current glibc defines it unconditionally regardless, which is
+  #     why arch/jitterentropy-arch-memory.c got away with setting no
+  #     feature-test macro; on 2.17 neither spelling exists.
+  #
+  # Arch is the mirror image of RHEL 7 and the reason this job is not only about
+  # old toolchains. It is a rolling release carrying gcc and glibc within days of
+  # upstream, which makes it the earliest warning available that a new compiler
+  # has started rejecting something: today it builds this library with gcc 16 and
+  # glibc 2.44, a full compiler generation ahead of the newest enterprise entry
+  # and two ahead of the Ubuntu runners. It is also the only job whose CMake is
+  # 4.x, which is what keeps CMakeLists.txt's 3.20 floor honest - CMake 4 dropped
+  # compatibility with anything below 3.5 and will keep raising that.
+  #
+  # The rest are compiler coverage. Between them the entries compile the library
+  # with gcc 4.8.5, 7.5, 8.5, 11.5, 14, 15 and 16 - seven diagnostic generations,
+  # where the two Ubuntu jobs supply one. gcc 14 is the first to reject implicit
+  # declarations outright rather than warn, and SLES 15 is the only thing here on
+  # gcc 7: an enterprise distribution can hold a compiler generation for a
+  # decade, and the gap between RHEL 7's 4.8 and RHEL 8's 8.5 is otherwise not
+  # covered by anything.
+  #
+  # None of these has a hosted runner, and unlike the BSDs none needs a VM - a
+  # container is the same libc and the same compiler. It is started with docker
+  # run from the job rather than through the workflow's "container:" key because
+  # actions/checkout is a Node 20 action and Node 20 requires glibc 2.28: it
+  # cannot execute inside the RHEL 7 image at all. So the checkout happens on the
+  # runner and the tree is mounted in, uniformly for every entry rather than only
+  # where it is forced.
+  #
+  # Each distribution's own image is used rather than a rebuild: Red Hat's UBI,
+  # SUSE's BCI and Arch's own are all published by the project itself, and the
+  # first two carry a repository subset that serves the handful of packages
+  # installed here without a subscription. centos:7 would instead need every
+  # build to first rewrite its yum configuration to point at vault.centos.org,
+  # the mirrors having been retired.
+  linux-distro:
+    name: ${{ matrix.name }} / cmake + make
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # RHEL 7.9 is pinned because it is the last RHEL 7 minor release: a
+          # fixed target rather than a moving "latest". The other UBI entries
+          # are still receiving minor releases and deliberately track them - a
+          # new compiler landing in RHEL 9 is a thing this job should notice,
+          # not something to pin away.
+          - name: RHEL 7
+            image: registry.access.redhat.com/ubi7/ubi:7.9
+            # RHEL 7 has no CMake meeting the project's floor: its own is
+            # 2.8.12 and is not even in the UBI repository subset, and EPEL 7's
+            # cmake3 stopped at 3.17.5, below the 3.20 CMakeLists.txt requires.
+            # Kitware's Linux x86_64 binaries are still built against glibc
+            # 2.17, and installing one is what a RHEL 7 user building a current
+            # CMake project actually does. Every other entry ships one that is
+            # new enough (3.26 to 3.31) and uses it.
+            cmake: kitware
+          - name: RHEL 8
+            image: registry.access.redhat.com/ubi8/ubi:latest
+            cmake: distro
+          - name: RHEL 9
+            image: registry.access.redhat.com/ubi9/ubi:latest
+            cmake: distro
+          - name: RHEL 10
+            image: registry.access.redhat.com/ubi10/ubi:latest
+            cmake: distro
+          # BCI publishes no floating major tag - there is no bci-base:15 or
+          # :16, only <major>.<minor> and a "latest" that currently means the
+          # newest SLE 15 service pack - so unlike UBI these have to be named
+          # exactly and bumped by hand when a service pack lands. One per
+          # generation is enough: 15 SP6 and SP7 carry an identical toolchain,
+          # as do 16.0 and 16.1.
+          - name: SLES 15 SP7
+            image: registry.suse.com/bci/bci-base:15.7
+            cmake: distro
+          - name: SLES 16.1
+            image: registry.suse.com/bci/bci-base:16.1
+            cmake: distro
+          # Arch publishes the same image to Docker Hub and to quay.io. The
+          # latter is used because Docker Hub rate-limits anonymous pulls per
+          # source IP, and a GitHub runner shares its IP with every other job on
+          # the same host - a limit this workflow has no way to raise and would
+          # hit at random.
+          - name: Arch Linux
+            image: quay.io/archlinux/archlinux:latest
+            cmake: distro
+    env:
+      # Only used by the kitware entry. Any version whose Linux x86_64 binary
+      # still runs on glibc 2.17 - Kitware has kept that baseline, and the day it
+      # moves, the RHEL 7 leg is where it shows.
+      CMAKE_VERSION: 3.31.9
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a ${{ matrix.name }} container
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src \
+            -e CMAKE_SOURCE="${{ matrix.cmake }}" \
+            -e CMAKE_VERSION="$CMAKE_VERSION" \
+            "${{ matrix.image }}" \
+            bash -euxo pipefail -c '
+              # RHEL 7 predates dnf and has only yum; RHEL 8 and later keep yum
+              # as a symlink onto dnf; SLES uses zypper and Arch pacman. Probing
+              # in this order picks each distribution native tool rather than a
+              # compatibility shim.
+              #
+              # pacman needs -Sy to fetch the package databases first: the image
+              # ships with none, and the Arch mirrors carry only the current
+              # version of each package, so a database older than the image is
+              # already stale. --needed skips anything the image happens to
+              # carry rather than reinstalling it.
+              if command -v dnf > /dev/null; then
+                install="dnf -y install"
+              elif command -v zypper > /dev/null; then
+                install="zypper --non-interactive install"
+              elif command -v pacman > /dev/null; then
+                install="pacman -Sy --noconfirm --needed"
+              else
+                install="yum -y install"
+              fi
+              $install gcc make
+
+              if [ "$CMAKE_SOURCE" = distro ]; then
+                $install cmake
+              else
+                # tar is not in the RHEL 7 base image and the tarball needs it.
+                $install tar
+                url=https://github.com/Kitware/CMake/releases/download
+                curl -fsSL \
+                  "$url/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz" \
+                  -o /tmp/cmake.tar.gz
+                mkdir -p /opt/cmake
+                tar -xzf /tmp/cmake.tar.gz -C /opt/cmake --strip-components=1
+                export PATH=/opt/cmake/bin:$PATH
+              fi
+
+              # GNU make is plain make here, not gmake as on the BSD guests the
+              # script is otherwise driven from.
+              MAKE=make sh .github/scripts/vm-build-and-test.sh
+            '
+
+  # The out-of-tree kernel module is a third build system (Kbuild) compiling the
+  # same core against a completely different environment: no libc, LINUX_KERNEL
+  # defined, and its own backends for memory, cache discovery and the timer.
+  # Nothing else in this workflow compiles that configuration.
+  #
+  # The module is only built, never loaded - the runner kernel is not the one
+  # the headers describe, and loading is not what tends to break. The interface
+  # options are each exercised because they are what the #ifdefs key on.
+  # Built on both architectures. The arm64 half is the only place anything
+  # compiles the CONFIG_ARM64 branch of arch/jitterentropy-arch-cache.c - the
+  # CLIDR/CCSIDR cache-ID register reads behind read_sysreg(), and the isb()
+  # from <asm/barrier.h>. The nix kernel matrix is x86_64 throughout and the
+  # userspace arm64 job takes the sysfs backend instead, so without this that
+  # code is compiled by nothing in the project.
+  linux-kmod:
+    name: Linux / kernel module / ${{ matrix.os }} / ${{ matrix.config }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        # A real dimension so that it multiplies with os; the include entries
+        # below match on it to attach each config's flags to both
+        # architectures, rather than adding standalone combinations.
+        config: [ default, test-interface, minimal ]
+        include:
+          # Kbuild.config as shipped: crypto API, chardev and hwrng on.
+          - config: default
+            flags: ''
+          # Adds the raw-entropy test interface, which pulls in
+          # jitterentropy_testing.c.
+          - config: test-interface
+            flags: CONFIG_EXTERNAL_JITTERENTROPY_TESTINTERFACE=y
+          # Every optional interface off, so the module core has to stand alone.
+          - config: minimal
+            flags: >-
+              CONFIG_EXTERNAL_JITTERENTROPY_KCAPI=n
+              CONFIG_EXTERNAL_JITTERENTROPY_CHARDEV=n
+              CONFIG_EXTERNAL_JITTERENTROPY_HWRNG=n
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kernel headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-headers-generic
+
+      - name: Build
+        run: |
+          # The prepared headers tree is used directly rather than
+          # /lib/modules/$(uname -r)/build: the runner's kernel is an Azure
+          # build whose headers package is not installable, and an out-of-tree
+          # module only needs a configured tree to compile against.
+          KDIR=$(ls -d /usr/src/linux-headers-*-generic | sort -V | tail -n 1)
+          echo "Building against $KDIR"
+          make -C "$KDIR" M="$PWD/linux_kernel" ${{ matrix.flags }} \
+            modules -j "$(nproc)"
+
+      - name: Show the result
+        run: |
+          ls -l linux_kernel/jitter_rng.ko
+          modinfo linux_kernel/jitter_rng.ko
+
+  # The linux-kmod job above varies the interface options but builds against a
+  # single kernel - whichever linux-headers-generic Ubuntu currently ships. The
+  # module's other axis of breakage is the kernel API itself, which moves under
+  # it continuously: an exported symbol that changes signature, a header that
+  # splits, a helper that becomes a macro.
+  #
+  # flake.nix already describes that axis. kernelSetsFor enumerates every
+  # numbered kernel package set nixpkgs exposes plus linux_testing, and
+  # modulesFor builds jitter_rng.ko against each, so the set tracks nixpkgs
+  # rather than a list here that would silently go stale. The attribute names
+  # are read back out of the flake and turned into one job per kernel: they
+  # build independently, a kernel that fails names itself, and no single job
+  # has to sit through every kernel in sequence.
+  #
+  # vmTestsFor derives a NixOS VM test from the same kernelSetsFor list, so
+  # every module attribute has a check attribute next to it - vm-linux_6_6
+  # beside jitterentropy-module-linux_6_6, vm beside jitterentropy-module. The
+  # two names are paired here so that the build job can boot the VM for the
+  # kernel it has just built for, which is what turns "the module compiles"
+  # into "the module loads, registers its interfaces and produces entropy".
+  #
+  # The same evaluation also yields the cross-compilation smoke builds, so the
+  # matrix for those is read out of the flake here rather than restated in this
+  # file. crossTargets is a hand-written list - unlike the kernel sets it does
+  # not track nixpkgs - but deriving the matrix from it still keeps a target
+  # added to the flake from being silently left unbuilt by CI.
+  nix-list:
+    name: Nix / enumerate outputs
+    runs-on: ubuntu-latest
+    outputs:
+      pairs: ${{ steps.list.outputs.pairs }}
+      cross: ${{ steps.cross.outputs.attrs }}
+      consumers: ${{ steps.consumers.outputs.attrs }}
+      crypto: ${{ steps.crypto.outputs.attrs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # attrNames forces only the attribute set's spine, not the derivations
+      # behind it, so this stays an evaluation rather than an instantiation of
+      # every ISO and cross target that packages.x86_64-linux also carries.
+      #
+      # jitterentropy-module-i686 is excluded by name: it builds against
+      # pkgsi686Linux.linuxPackages_latest.kernel, and nixpkgs publishes no
+      # binary cache for a 32-bit x86 kernel, so the job would compile a whole
+      # kernel from source before it got to the module. The 32-bit code paths
+      # it covers are reached more cheaply elsewhere in this workflow - the
+      # linux-32bit job for userspace, and the cross-i686 entry of the nix-cross
+      # matrix - and it stays available for anyone building the flake locally.
+      - name: List the kernel module outputs and their VM tests
+        id: list
+        run: |
+          modules=$(nix eval --json .#packages.x86_64-linux --apply \
+            'ps: builtins.filter
+                   (n: builtins.match "jitterentropy-module.*" n != null
+                       && n != "jitterentropy-module-i686")
+                   (builtins.attrNames ps)')
+          vms=$(nix eval --json .#checks.x86_64-linux --apply \
+            'cs: builtins.attrNames cs')
+
+          # jitterentropy-module -> vm, jitterentropy-module-<k> -> vm-<k>,
+          # keeping only the pairs the flake actually exposes as a check.
+          pairs=$(jq -cn --argjson modules "$modules" --argjson vms "$vms" '
+            $modules
+            | map({ attr: ., vm: sub("^jitterentropy-module"; "vm") })
+            | map(select([.vm] | inside($vms)))')
+
+          # Both sets come out of kernelSetsFor, so a module without a check
+          # means the two have been allowed to drift apart in flake.nix. Say
+          # which one rather than quietly building it without booting it.
+          missing=$(jq -rn --argjson modules "$modules" --argjson pairs "$pairs" \
+            '($modules - ($pairs | map(.attr))) | join(" ")')
+          if [ -n "$missing" ]; then
+            echo "::error::no VM test in .#checks.x86_64-linux for: $missing"
+            exit 1
+          fi
+
+          jq -r '.[] | "\(.attr) -> \(.vm)"' <<<"$pairs"
+          echo "pairs=$pairs" >> "$GITHUB_OUTPUT"
+
+      - name: List the cross-compilation outputs
+        id: cross
+        run: |
+          cross=$(nix eval --json .#packages.x86_64-linux --apply \
+            'ps: builtins.filter
+                   (n: builtins.match "cross-.*" n != null)
+                   (builtins.attrNames ps)')
+
+          # An empty matrix is not an error to GitHub - it skips the job - so
+          # the case where the filter stops matching would otherwise look like
+          # a green run with no cross builds in it.
+          if [ "$(jq 'length' <<<"$cross")" -eq 0 ]; then
+            echo "::error::no cross-* outputs in .#packages.x86_64-linux"
+            exit 1
+          fi
+
+          jq -r '.[]' <<<"$cross"
+          echo "attrs=$cross" >> "$GITHUB_OUTPUT"
+
+      # Same treatment for the downstream consumer builds, and for the same
+      # reason: consumersFor is hand-written, so reading the matrix out of the
+      # flake keeps a consumer added there from going unbuilt here.
+      - name: List the downstream consumer outputs
+        id: consumers
+        run: |
+          consumers=$(nix eval --json .#packages.x86_64-linux --apply \
+            'ps: builtins.filter
+                   (n: builtins.match "consumer-.*" n != null)
+                   (builtins.attrNames ps)')
+
+          if [ "$(jq 'length' <<<"$consumers")" -eq 0 ]; then
+            echo "::error::no consumer-* outputs in .#packages.x86_64-linux"
+            exit 1
+          fi
+
+          jq -r '.[]' <<<"$consumers"
+          echo "attrs=$consumers" >> "$GITHUB_OUTPUT"
+
+      # And for the external crypto backends, so that a backend added to
+      # cryptoFor is built here without the workflow having to be edited too.
+      - name: List the external crypto backend outputs
+        id: crypto
+        run: |
+          crypto=$(nix eval --json .#packages.x86_64-linux --apply \
+            'ps: builtins.filter
+                   (n: builtins.match "crypto-.*" n != null)
+                   (builtins.attrNames ps)')
+
+          if [ "$(jq 'length' <<<"$crypto")" -eq 0 ]; then
+            echo "::error::no crypto-* outputs in .#packages.x86_64-linux"
+            exit 1
+          fi
+
+          jq -r '.[]' <<<"$crypto"
+          echo "attrs=$crypto" >> "$GITHUB_OUTPUT"
+
+  nix-kmod:
+    name: Nix / ${{ matrix.attr }}
+    runs-on: ubuntu-latest
+    needs: nix-list
+    # A kernel whose dev output is not in the binary cache has to be built from
+    # source, which is far longer than this job is worth; bound it rather than
+    # letting it run to the six-hour default. The VM test that follows the
+    # build reuses that same kernel, so it does not widen the worst case by
+    # anything like a second kernel build.
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      # One entry per {attr, vm} pair from the enumerate job: the module
+      # attribute to build and the NixOS VM test to boot for that same kernel.
+      matrix:
+        include: ${{ fromJSON(needs.nix-list.outputs.pairs) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            # runNixOSTest marks its derivation as needing the kvm and
+            # nixos-test system features. Nix only advertises kvm when
+            # /dev/kvm was present as the daemon started, so state both
+            # explicitly rather than depending on the runner image.
+            system-features = nixos-test benchmark big-parallel kvm
+
+      - name: Build
+        run: nix build --no-link --print-build-logs ".#${{ matrix.attr }}"
+
+      - name: Show the result
+        run: |
+          ko=$(find "$(nix path-info ".#${{ matrix.attr }}")" -name '*.ko')
+          ls -l "$ko"
+          nix shell nixpkgs#kmod -c modinfo "$ko"
+
+      # GitHub's Ubuntu runners carry /dev/kvm but leave it accessible only to
+      # root, and the build runs as an unprivileged nix daemon user. QEMU would
+      # fall back to TCG emulation (accel=kvm:tcg), which boots the guest but
+      # takes many times longer - long enough to matter across this matrix.
+      - name: Enable KVM for the unprivileged builder
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Boots a NixOS guest on this kernel with jitter_rng loaded and runs the
+      # assertions in flake.nix: the character device, the kernel crypto API
+      # instance, the hwrng registration, the debugfs raw entropy interface,
+      # the JENT_IOC* ioctls and the O_NONBLOCK behaviour. The guest module is
+      # the same source built with withTestInterface = true, so this recompiles
+      # jitter_rng.ko but not the kernel the build step already fetched.
+      - name: Boot the VM integration test
+        run: |
+          nix build --no-link --print-build-logs \
+            ".#checks.x86_64-linux.${{ matrix.vm }}"
+
+  # Every job above runs on an architecture GitHub hosts a runner for: x86-64
+  # and aarch64, Linux, macOS and Windows. Everything else the library claims to
+  # support - s390x, POWER, RISC-V, LoongArch, 32-bit ARM, 32-bit Windows - is
+  # reached by nothing, and those are exactly the targets whose jent_get_nstime()
+  # and cache backends are selected by preprocessor conditions, so a break there
+  # is invisible until someone builds for the platform.
+  #
+  # crossTargets in flake.nix compiles and links the library and its tools for
+  # each of them; this builds every one, one job per target so that a target
+  # that fails names itself. They are not run - the point is the compile and the
+  # link, which is where this class of breakage shows up (a missing declaration,
+  # an unavailable header, an unlinked import library, inline asm that does not
+  # assemble).
+  nix-cross:
+    name: Nix / ${{ matrix.attr }}
+    runs-on: ubuntu-latest
+    needs: nix-list
+    # The toolchains come out of the binary cache; a target whose cache entry
+    # has gone would build a cross GCC from source instead, which is far longer
+    # than a smoke build is worth.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        attr: ${{ fromJSON(needs.nix-list.outputs.cross) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # --print-out-paths so the step below inspects what this build produced
+      # rather than re-evaluating the flake to ask where it would have gone.
+      # --print-build-logs writes to stderr, leaving the path alone on stdout.
+      - name: Build
+        id: build
+        run: |
+          out=$(nix build --no-link --print-build-logs --print-out-paths \
+            ".#${{ matrix.attr }}")
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      # A cross build that quietly produced host binaries would still succeed,
+      # so name the machine of everything it installed rather than trusting the
+      # exit status. The tools land in bin/ and the library in lib/, whatever
+      # the target's extensions are.
+      - name: Show the result
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          find "$OUT" -type f \( -path '*/bin/*' -o -name '*.a' -o -name '*.so*' \
+            -o -name '*.dll' \) -print0 |
+            xargs -0 --no-run-if-empty nix shell nixpkgs#file -c file
+
+  # Every other job here builds this repository and runs this repository's own
+  # tools, which cannot see the ways an installed library breaks the programs
+  # that link it: a declaration dropped from the installed header, a symbol that
+  # stops being exported, a link dependency that never reaches the .pc file.
+  # Those show up in the consumer's build, not in ours.
+  #
+  # consumersFor in flake.nix builds the two consumers that matter - rng-tools,
+  # whose rngd feeds the kernel from a jitter entropy source, and ESDM, whose
+  # es_jent entropy source is this library - as nixpkgs packages them, with only
+  # their jitterentropy input swapped for this working tree. Each is built
+  # twice, with the internal timer on and off, because that option changes which
+  # symbols the library exports and rng-tools configures against the ones it
+  # finds (see the comment on consumersFor).
+  #
+  # This is a compile-and-link check: the flake turns both consumers' check
+  # phases off, and nothing built here is executed. Whether the library produces
+  # entropy is what the tool runs and the VM tests in the other jobs answer.
+  nix-consumers:
+    name: Nix / ${{ matrix.attr }}
+    runs-on: ubuntu-latest
+    needs: nix-list
+    # Both consumers pull a sizeable dependency tree (openssl, opensc and
+    # rtl-sdr for rng-tools, botan and protobuf-c for ESDM); bound the job in
+    # case one of them misses the binary cache rather than letting it run to the
+    # six-hour default.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        attr: ${{ fromJSON(needs.nix-list.outputs.consumers) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build
+        id: build
+        run: |
+          out=$(nix build --no-link --print-build-logs --print-out-paths \
+            ".#${{ matrix.attr }}")
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      # The library is built as a static archive, so a consumer that links it
+      # keeps no store reference to it and a successful build on its own does
+      # not say the swap took effect - a consumer configured without jitter
+      # entropy support would link just as cleanly. The symbol table of what it
+      # installed is what shows the archive was linked in, and reading it runs
+      # nothing.
+      - name: Show the result
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          # Dispatched on the attribute rather than on which files exist, so
+          # that a consumer added to the flake arrives here as an error instead
+          # of quietly taking another consumer's check and failing on a missing
+          # file.
+          case "${{ matrix.attr }}" in
+          consumer-rng-tools*) file=bin/rngd; nmflags="" ;;
+          consumer-esdm*) file=lib/libesdm.so; nmflags="-D" ;;
+          *)
+            echo "::error::no result check defined for ${{ matrix.attr }}"
+            exit 1
+            ;;
+          esac
+
+          # rngd links the archive into the executable, ESDM into libesdm.so;
+          # the shared library exports only its dynamic symbols, hence -D there.
+          syms=$(nix shell nixpkgs#binutils -c \
+            nm $nmflags --defined-only "$OUT/$file")
+          grep -E ' [TtWw] jent_' <<<"$syms" | head -20
+          grep -qE ' [TtWw] jent_entropy_init$' <<<"$syms" || {
+            echo "::error::no jitterentropy symbols in $file"
+            exit 1
+          }
+
+  # The external crypto backends: EXTERNAL_CRYPTO=OPENSSL, AWSLC and LIBGCRYPT.
+  # Every other job in this workflow builds the library with its own secure
+  # memory allocator and its own FIPS-mode query, so the branches these select -
+  # the libgcrypt secmem pool, OpenSSL's secure heap and AWS-LC's
+  # wiped-but-unlocked OPENSSL_malloc() in arch/jitterentropy-arch-memory.c, and
+  # each library's own FIPS-mode query in arch/jitterentropy-arch-fips.c - are
+  # compiled by nothing at all otherwise. They are also what the AMALGAMATED
+  # test program in tests/raw-entropy/recording_userspace/CMakeLists.txt had to
+  # be taught about: it absorbs those sources and links neither the library nor
+  # its dependencies.
+  #
+  # Nix rather than apt: AWS-LC is not packaged by Ubuntu, and pinning all three
+  # through the flake keeps the versions the same from run to run.
+  #
+  # The two pool-based backends allocate the collector out of an arena that is
+  # created once per process and can then not be resized. The library does not
+  # size it - the recording tools do, from the memory size the collector is
+  # asked for, in
+  # tests/raw-entropy/recording_userspace/jitterentropy-memlock.h - which is
+  # what lets a run here ask for a block larger than the 2 MiB the library used
+  # to reserve for itself, as --all-caches and the NTG.1 startup growth do.
+  nix-crypto:
+    name: Nix / ${{ matrix.attr }}
+    runs-on: ubuntu-latest
+    needs: nix-list
+    # openssl, aws-lc and libgcrypt all come out of the binary cache; bound the
+    # job in case one of them misses it rather than letting it run to the
+    # six-hour default.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        attr: ${{ fromJSON(needs.nix-list.outputs.crypto) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build
+        id: build
+        run: |
+          out=$(nix build --no-link --print-build-logs --print-out-paths \
+            ".#${{ matrix.attr }}")
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      # A build in which EXTERNAL_CRYPTO quietly did not take effect would look
+      # exactly like a successful one - the library falls back to its own
+      # implementations for everything - so the linkage is what says the backend
+      # is actually in use.
+      - name: Show the result
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          case "${{ matrix.attr }}" in
+          crypto-openssl|crypto-awslc) needed=libcrypto ;;
+          crypto-libgcrypt)            needed=libgcrypt ;;
+          *)
+            echo "::error::no result check defined for ${{ matrix.attr }}"
+            exit 1
+            ;;
+          esac
+
+          # The amalgamated tool is the one that carries the dependency
+          # directly; the others reach it through libjitterentropy.so.
+          for bin in bin/jitterentropy-hashtime lib/libjitterentropy.so; do
+            echo "==> $bin"
+            nix shell nixpkgs#binutils -c readelf -d "$OUT/$bin" |
+              grep NEEDED
+          done
+
+          nix shell nixpkgs#binutils -c readelf -d \
+            "$OUT/bin/jitterentropy-hashtime" |
+            grep -q "NEEDED.*$needed" || {
+              echo "::error::$needed is not linked into jitterentropy-hashtime"
+              exit 1
+            }
+
+      - name: Run tests
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          "$OUT/bin/gcd"
+          for opt in "" "--force-internal-timer" "--all-caches"; do
+            "$OUT/bin/jitterentropy-rng" 256 $opt > /dev/null
+          done
+
+          # The compliance modes are run but not gated on, as everywhere else:
+          # they are the modes whose startup health tests may not converge on a
+          # given machine. Both demand secure memory, which on these backends
+          # means the collector has to come out of the arena the tool created -
+          # so a run that does converge also says the arena was sized for it.
+          for opt in "--force-fips" "--ntg1"; do
+            "$OUT/bin/jitterentropy-rng" 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed"
+          done
+
+  # Address and undefined behaviour sanitizers (the ENABLE_SANITIZERS option of
+  # CMakeLists.txt). The library is compiled at -O0 and does its own memory
+  # management - mmap with PROT_NONE guard pages around the collector state,
+  # pointer arithmetic back to the mapping base on free, a memory access loop
+  # walking a masked offset into that region - which is exactly the class of
+  # code where an off-by-one is silently harmless in an ordinary build and
+  # caught here.
+  #
+  # Both compilers: their sanitizer runtimes do not diagnose the same set, and
+  # UBSan in particular differs between the two on what it instruments by
+  # default.
+  #
+  # halt_on_error makes UBSan fail the job rather than print a report and carry
+  # on with exit code 0 - without it a diagnosed error is only visible to
+  # someone reading the log of a green run.
+  sanitizers:
+    name: Linux / ${{ matrix.cc }} / sanitizers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [ gcc, clang ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+            -DENABLE_SANITIZERS=ON
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: |
+          bin=./build/tests/raw-entropy/recording_userspace
+
+          # The compliance modes are not gated on here either (see the Linux
+          # job), but a tolerated exit status must not swallow a sanitizer
+          # finding - which is the whole point of this job and would otherwise
+          # be indistinguishable from a health test that did not converge. The
+          # two are told apart by what the runtime writes to stderr; everything
+          # else the tools print there (the status JSON, the health test
+          # message) is kept in the log either way.
+          run_tolerated() {
+            log="$RUNNER_TEMP/sanitizer-run.log"
+
+            if "$@" > /dev/null 2> "$log"; then
+              return 0
+            fi
+
+            cat "$log"
+            if grep -qE 'Sanitizer|runtime error:' "$log"; then
+              echo "::error::sanitizer report from: $*"
+              exit 1
+            fi
+            echo "::warning::failed without a sanitizer finding: $*"
+          }
+
+          ./build/tests/gcd/gcd
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            "$bin/jitterentropy-rng" 256 $opt > /dev/null
+          done
+
+          for opt in "--force-fips" "--ntg1"; do
+            run_tolerated "$bin/jitterentropy-rng" 256 $opt
+          done
+
+          # The recording tool as well, and not as a duplicate of the above: it
+          # is the AMALGAMATED build, which compiles the library sources into
+          # the program itself, and it is the only thing here that drives the
+          # raw noise collection (jent_measure_jitter and the memory access
+          # loop) directly rather than through jent_read_entropy().
+          run_tolerated "$bin/jitterentropy-hashtime" \
+            1000 2 "$RUNNER_TEMP/hashtime" --force-fips
+
+  # The Nix half of the musl coverage, and static only: .#musl-static is built
+  # through pkgsStatic, so it is not just the library that is musl-linked and
+  # statically linked but every dependency under it, against a musl and a gcc
+  # pinned by the flake rather than whatever Ubuntu ships this month. A
+  # regression that needs a newer or older musl than Debian's shows up here and
+  # not in linux-musl.
+  #
+  # Dynamic musl is deliberately not built here. linux-musl already covers it,
+  # and repeating it through pkgsMusl would exercise the same code paths a
+  # second time; the fully static tree is the configuration that has no
+  # counterpart elsewhere in this workflow.
+  #
+  # pkgsStatic is a native package set, so unlike the cross targets these
+  # binaries run on the runner and the job executes them instead of only
+  # linking them.
+  nix-musl:
+    name: Nix / musl-static
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build
+        id: build
+        run: |
+          out=$(nix build --no-link --print-build-logs --print-out-paths \
+            .#musl-static)
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          # file and strings come from the flake's nixpkgs rather than the
+          # runner image, so this reads the same either way.
+          nix shell nixpkgs#file nixpkgs#binutils -c sh -c '
+            set -e
+            file "$1"
+
+            # Same reasoning as linux-musl: glibc stamps GLIBC_* symbol
+            # versions into everything it links, static builds included, and
+            # musl stamps nothing, so their absence is what separates the two.
+            # A static musl binary carries no positive marker to test instead -
+            # it is an ordinary SysV ELF with no libc name anywhere in it.
+            if strings "$1" | grep -q GLIBC; then
+              echo "::error::GLIBC symbol versions present, this is not musl"
+              exit 1
+            fi
+
+            file "$1" | grep -q "statically linked" || {
+              echo "::error::expected a statically linked binary"; exit 1
+            }
+          ' sh "$OUT/bin/gcd"
+
+          "$OUT/bin/gcd"
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            "$OUT/bin/jitterentropy-rng" 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            "$OUT/bin/jitterentropy-rng" 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # Android is a fourth build system: ndk-build reading arch/android/Android.mk,
+  # against bionic rather than glibc, with the NDK's own clang. Nothing else
+  # here compiles that file, so a variable renamed in it or a source directory
+  # that stops being picked up by its wildcard would go unnoticed.
+  #
+  # Two ABIs are built (see androidFor in flake.nix): arm64-v8a for the
+  # cntvct_el0 timer read as bionic reaches it, and x86_64 for the emulator
+  # configuration. The NDK is unfree, which the flake accepts for this output
+  # alone - no runner-side nixpkgs config is needed.
+  nix-android:
+    name: Nix / android
+    runs-on: ubuntu-latest
+    # Dominated by the ~1 GiB NDK download, which is a fixed-output derivation
+    # fetched from Google rather than substituted from the binary cache.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build
+        id: build
+        run: |
+          out=$(nix build --no-link --print-build-logs --print-out-paths .#android)
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      # ndk-build treats an ABI it has nothing to do for as success rather than
+      # as an error, so both are named explicitly here: dropping one out of
+      # APP_ABI would otherwise leave a green job that built half of what it
+      # says it does.
+      - name: Show the result
+        env:
+          OUT: ${{ steps.build.outputs.out }}
+        run: |
+          find "$OUT/lib" -name '*.so' -print0 |
+            xargs -0 --no-run-if-empty nix shell nixpkgs#file -c file
+          for abi in arm64-v8a x86_64; do
+            test -f "$OUT/lib/$abi/libjitterentropy.so" || {
+              echo "::error::no libjitterentropy.so for ABI $abi"
+              exit 1
+            }
+          done
+
+  # The Makefile is a second, independent build system with its own flag and
+  # link-library selection (see its UNAME_S branches), so it needs its own
+  # coverage rather than being assumed equivalent to CMakeLists.txt.
+  makefile:
+    name: Makefile / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make -j 4
+
+      - name: Link and run against the built library
+        run: |
+          cat > smoke.c <<'EOF'
+          #include <stdio.h>
+          #include "jitterentropy.h"
+
+          static int collect(unsigned int flags, const char *what)
+          {
+                  char buf[64];
+                  struct rand_data *ec = jent_entropy_collector_alloc(0, flags);
+
+                  if (!ec) { printf("alloc failed (%s)\n", what); return 1; }
+                  if (jent_read_entropy(ec, buf, sizeof(buf)) != (ssize_t)sizeof(buf)) {
+                          printf("short read (%s)\n", what);
+                          jent_entropy_collector_free(ec);
+                          return 1;
+                  }
+                  jent_entropy_collector_free(ec);
+                  printf("ok (%s)\n", what);
+                  return 0;
+          }
+
+          int main(void) {
+                  int rc = jent_entropy_init();
+                  if (rc) { printf("jent_entropy_init: %d\n", rc); return 1; }
+                  if (collect(0, "default")) return 1;
+                  /*
+                   * Forced: where the counter read works, which is everywhere
+                   * this runs, the automatic selection never falls back to the
+                   * internal timer, so the thread back-end the Makefile links
+                   * -pthread for would never be started. This is the only thing
+                   * the Makefile build runs.
+                   */
+                  if (collect(JENT_FORCE_INTERNAL_TIMER, "internal timer")) return 1;
+                  return 0;
+          }
+          EOF
+          # librt only exists on Linux; macOS carries the POSIX clocks in libSystem.
+          case "${{ runner.os }}" in
+            Linux) LIBS="-pthread -lrt" ;;
+            *)     LIBS="-pthread" ;;
+          esac
+          cc -std=c11 -I. smoke.c libjitterentropy.a $LIBS -o smoke
+          ./smoke
+
+  # Both macOS architectures: they select different jent_get_nstime() back-ends
+  # (cntvct_el0 on Apple Silicon, rdtsc on Intel) and different cache sysctls
+  # (the hw.perflevel0.* names exist only on Apple Silicon).
+  macos:
+    name: macOS / ${{ matrix.os }} / shared=${{ matrix.shared }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest, macos-15-intel ]
+        shared: [ 'ON', 'OFF' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+
+      - name: Build
+        run: cmake --build build -j "$(sysctl -n hw.ncpu)"
+
+      - name: Run tests
+        run: |
+          ./build/tests/gcd/gcd
+          export DYLD_LIBRARY_PATH="$PWD/build:$DYLD_LIBRARY_PATH"
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # These systems have no hosted GitHub runner, so they are exercised in a QEMU
+  # guest started by the vmactions actions on an Ubuntu runner. They are worth
+  # the boot cost because each one reaches code no other job compiles:
+  #
+  #   - FreeBSD: the cpuset_setaffinity() CPU pinning back-end, and the CMake
+  #     branch that deliberately does not link pthread (libthr comes in through
+  #     -pthread instead).
+  #   - NetBSD: the pthread_setaffinity_np()/cpuset_create() pinning back-end,
+  #     and the only non-Linux, non-Windows job here whose cc is GCC.
+  #   - OpenBSD: the no-affinity-API path, which has to report -ENOTSUP rather
+  #     than fail, plus a libc with no librt at all - the case the Makefile's
+  #     LIBRARIES branch and the jent_get_nstime() clock selection exist for.
+  #   - DragonFly: named in the Makefile's -z relro branch and in the arc4random
+  #     UUID backend, but reached by neither until now.
+  #   - Solaris: the only SunOS target, and the only one that is neither Linux,
+  #     Windows, Apple nor BSD. It is the sole job reaching the SunOS arm of the
+  #     Makefile - the one that still needs -lrt and must not be given -z relro
+  #     - and the only one compiling the CMAKE_SYSTEM_NAME STREQUAL "SunOS"
+  #     branch of CMakeLists.txt. Per the comment in
+  #     arch/jitterentropy-arch-memory.c it is also one of the platforms the
+  #     POSIX mlock backend was widened to cover on the strength of the option
+  #     macros alone, with nothing ever compiling it.
+  #
+  # The guests are shared between the CMake and Makefile builds by
+  # .github/scripts/vm-build-and-test.sh: one boot dominates the job, so both
+  # build systems and both link configurations run inside it rather than being
+  # spread over a matrix as they are on Linux and macOS.
+  #
+  # The release is left unpinned so the action's default (its most recently
+  # tested image) is used; pinning here only guarantees the job breaks once that
+  # image is retired. Solaris is the exception and says why at the job.
+  freebsd:
+    name: FreeBSD / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y cmake gmake
+          run: |
+            sh .github/scripts/vm-build-and-test.sh
+
+  openbsd:
+    name: OpenBSD / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in an OpenBSD VM
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg_add -I cmake gmake
+          run: |
+            sh .github/scripts/vm-build-and-test.sh
+
+  netbsd:
+    name: NetBSD / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a NetBSD VM
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            /usr/sbin/pkg_add cmake gmake
+          run: |
+            sh .github/scripts/vm-build-and-test.sh
+
+  dragonflybsd:
+    name: DragonFly BSD / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a DragonFly BSD VM
+        uses: vmactions/dragonflybsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y cmake gmake
+          run: |
+            sh .github/scripts/vm-build-and-test.sh
+
+  # Solaris is the SunOS half of the list above. Two things differ from the BSD
+  # jobs and both are deliberate.
+  #
+  # The release is pinned, against the rule stated above, because the stock
+  # 11.4 image carries no C compiler and the action publishes ready-made
+  # variants rather than leaving one to be installed: 11.4-gcc is 11.4 with the
+  # default gcc/g++ already in it. Installing a compiler through pkg(1) instead
+  # would cost a large download on every run to arrive at the same place.
+  #
+  # Packages come from Oracle's IPS repository rather than the OpenCSW pkgutil
+  # the action's own example uses. CMakeLists.txt asks for CMake 3.20 and the
+  # 11.4 IPS repository carries 3.2x, whereas OpenCSW targets Solaris 10 and
+  # makes no such promise. developer/build/gnu-make is what puts gmake on PATH,
+  # which the shared script needs because the Makefile is GNU make syntax and
+  # /usr/bin/make here is the SunOS one.
+  #
+  # CC is set rather than left to the script's cc/gcc/clang search: on Solaris
+  # /usr/bin/cc can be the Oracle Studio compiler, and while CMakeLists.txt has
+  # a SUNPRO branch, the Makefile is GCC-specific - it parses `cc -dumpversion`
+  # and passes GCC warning flags - so the Makefile half of the script would fail
+  # on a guest where cc resolved to Studio.
+  solaris:
+    name: Solaris / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a Solaris VM
+        uses: vmactions/solaris-vm@v1
+        with:
+          release: "11.4-gcc"
+          usesh: true
+          copyback: false
+          prepare: |
+            # pkg(1) exits 4 for "nothing to do", which is what an image that
+            # already carries one of these reports; only a real failure should
+            # stop the job, so 4 is accepted and everything else is not.
+            pkg install developer/build/cmake developer/build/gnu-make || [ $? -eq 4 ]
+          run: |
+            CC=gcc sh .github/scripts/vm-build-and-test.sh
+
+  # Haiku and Cygwin are the last two platforms arch/ names but nothing here
+  # compiles. Both appear by name in the same preprocessor conditions -
+  # jitterentropy-arch-sched.c, -ncpu.c and -uuid.c all test
+  # defined(__HAIKU__) || defined(__CYGWIN__) - so both were added to those
+  # branches on the strength of the documentation alone, exactly the situation
+  # the Solaris job was added for and immediately found a real break in.
+  #
+  # Each also builds the internal timer against a pthreads implementation of its
+  # own - Haiku's in libroot, Cygwin's in the Cygwin DLL - which is the only
+  # coverage the thread back-end gets outside glibc, musl, the BSDs and Apple.
+  #
+  # MAKE=make on both: the shared script defaults to gmake for the BSDs and
+  # Solaris, but Haiku and Cygwin ship GNU make under its plain name and have
+  # no gmake at all.
+  haiku:
+    name: Haiku / cmake + make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and test in a Haiku VM
+        uses: vmactions/haiku-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkgman install -y cmake make
+          run: |
+            MAKE=make sh .github/scripts/vm-build-and-test.sh
+
+  # Cygwin is the one entry here that is not a VM: it runs on the hosted Windows
+  # runner, so it needs no guest, but it is not a variation of the MSVC or MinGW
+  # jobs either. Those two are Windows targets; Cygwin is a POSIX target that
+  # happens to sit on Windows. CMake does not set WIN32 for it, so the whole
+  # ELF-ish branch of CMakeLists.txt applies - the -z now,-z relro hardening,
+  # -fPIC, the pthread selection - and arch/jitterentropy-arch-cache.c says in
+  # so many words that Cygwin is handled outside its Windows branch.
+  cygwin:
+    name: Cygwin / cmake + make
+    runs-on: windows-latest
+    steps:
+      # Before the checkout, so the shell scripts arrive with LF endings.
+      # Cygwin's sh reads a CRLF script as having a stray \r on every line and
+      # fails on the first one.
+      - name: Keep line endings as committed
+        run: git config --global core.autocrlf input
+
+      - uses: actions/checkout@v4
+
+      - uses: cygwin/cygwin-install-action@v6
+        with:
+          # gcc-core rather than gcc: the C compiler alone, no C++ or the rest
+          # of the collection this build never invokes.
+          packages: |
+            cmake
+            gcc-core
+            make
+            binutils
+
+      # The workflow-level "shell: bash" default resolves to Cygwin's bash here
+      # rather than the runner's Git bash: the action prepends Cygwin's bin to
+      # PATH, and GitHub looks the interpreter up there. That is what makes the
+      # POSIX script below run against the Cygwin toolchain at all.
+      - name: Build and test
+        run: MAKE=make sh .github/scripts/vm-build-and-test.sh
+
+  # MSVC is the reference Windows toolchain. The shared configuration is built
+  # as well because it is the only one that exercises the dllexport/dllimport
+  # split in jitterentropy.h.
+  #
+  # windows-11-arm is not a duplicate of the x64 entry: it is the only target in
+  # this workflow that reaches the QueryPerformanceCounter timer back-end and
+  # the __yield() pause intrinsic, both of which exist solely for Windows on ARM.
+  #
+  # --force-internal-timer is what actually starts the Win32 thread back-end in
+  # arch/jitterentropy-arch-thread.c: the __stdcall trampoline,
+  # _beginthreadex() and the WaitForSingleObject()/CloseHandle() join, none of
+  # which any other job here runs. Forced rather than left to the automatic
+  # selection, which on a machine with a working counter never reaches it:
+  # jent_entropy_init() only falls back to the internal timer when the plain
+  # path fails, so without the flag these jobs would compile that back-end and
+  # never run it.
+  windows-msvc:
+    name: Windows / MSVC / ${{ matrix.os }} / shared=${{ matrix.shared }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, windows-11-arm ]
+        shared: [ 'ON', 'OFF' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+
+      # The Visual Studio generator is multi-config, so the configuration is
+      # named at build time and the binaries land in a per-config subdirectory.
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Run tests
+        run: |
+          # A shared build leaves the import library beside the executables but
+          # the DLL in the top-level config directory; Windows resolves it from
+          # PATH.
+          export PATH="$PWD/build/Release:$PATH"
+          ./build/tests/gcd/Release/gcd.exe
+          rng=./build/tests/raw-entropy/recording_userspace/Release/jitterentropy-rng.exe
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            "$rng" 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            "$rng" 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
+  # MinGW is a distinct Windows target rather than a variation of MSVC: it is
+  # the GCC side of the Win32 thread back-end (__stdcall on a GCC front end,
+  # _beginthreadex() out of the mingw-w64 CRT rather than the UCRT), and it has
+  # to be told to link bcrypt explicitly because the #pragma comment(lib, ...)
+  # in arch/jitterentropy-arch-uuid.c is MSVC-only.
+  #
+  # Only 64-bit environments are built. MSYS2 retired MINGW32: package builds
+  # were dropped progressively from 2023 and the community 32-bit repository
+  # stopped being updated in November 2025, so a mingw-w64-i686-* install no
+  # longer resolves. 32-bit Windows is compiled instead by the cross-mingw32
+  # entry of the nix-cross matrix, which needs no MSYS2 repository at all.
+  windows-mingw:
+    name: Windows / MinGW-w64 / ${{ matrix.msystem }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - msystem: MINGW64
+            prefix: mingw-w64-x86_64
+          - msystem: UCRT64
+            prefix: mingw-w64-ucrt-x86_64
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            ${{ matrix.prefix }}-gcc
+            ${{ matrix.prefix }}-cmake
+            ${{ matrix.prefix }}-ninja
+
+      - name: Configure
+        run: cmake -S . -B build -G Ninja
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests
+        run: |
+          ./build/tests/gcd/gcd.exe
+          rng=./build/tests/raw-entropy/recording_userspace/jitterentropy-rng.exe
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            "$rng" 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            "$rng" 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,11 @@ endif()
 
 if(WIN32)
     if(MSVC)
-        list(APPEND JITTER_C_FLAGS  /Od /W4 /DYNAMICBASE)
+        # _CRT_SECURE_NO_WARNINGS: MSVC deprecates the standard C library in
+        # favour of its own _s variants (C4996 on fopen, strtok, ...). The
+        # code has to stay portable, so the "insecure" spellings are the
+        # intended ones and the advice is noise.
+        list(APPEND JITTER_C_FLAGS  /Od /W4 /D_CRT_SECURE_NO_WARNINGS)
     else()
         list(APPEND JITTER_C_FLAGS  -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -Wcast-align
         -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -O0 -fwrapv -Wconversion)
@@ -71,8 +75,52 @@ if(WIN32)
 else()
     list(APPEND JITTER_C_FLAGS  -fvisibility=hidden -Wcast-align -Wmissing-field-initializers -Wshadow -Wswitch-enum -Wextra -Wall -pedantic -O0 -Wconversion)
 
-    if(NOT APPLE)
-        if(SUNPRO)
+    # This library reports failure the POSIX way, as a negated errno - see
+    # "Returns 0 on success or a negative errno on failure" in jitterentropy.h
+    # and the ~30 "return -EXXX" sites behind it. That convention assumes errno
+    # constants are positive, which on Haiku they are not: its <errno.h> maps
+    # them onto Haiku's own B_* error codes, which are large negative numbers
+    # based at B_GENERAL_ERROR_BASE == INT_MIN.
+    #
+    # Negating those inverts the contract. ENOENT is B_ENTRY_NOT_FOUND, so
+    # -ENOENT comes out as +2147459069 and every "if (ret < 0)" reads that
+    # failure as success - silently, because nothing diagnoses it. Only ENOMEM
+    # is noticed at all, and only because it is exactly INT_MIN, where negation
+    # overflows and GCC says so ("integer overflow in expression
+    # '-2147483648'"); it stays negative by accident and so keeps working.
+    #
+    # B_USE_POSITIVE_POSIX_ERRORS is Haiku's own switch for exactly this: it
+    # turns B_TO_POSIX_ERROR() into a negation so that the POSIX names take
+    # their usual positive values, and then -EXXX means what it means
+    # everywhere else. Preferred over rewriting the return sites because it
+    # leaves every other platform untouched and keeps one convention in the
+    # source. It has to reach the compiler before any system header, hence a
+    # command-line define rather than one in a header of ours.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
+        list(APPEND JITTER_C_FLAGS -DB_USE_POSITIVE_POSIX_ERRORS)
+    endif()
+
+    # -z relro is a GNU ld / lld spelling. The Solaris link editor rejects it
+    # outright - "ld: fatal: option -z has illegal argument 'relro'" - while
+    # accepting -z now, so Solaris and illumos get the immediate-binding half
+    # of the hardening and not the read-only-relocation half.
+    #
+    # Keyed on the target system rather than on the compiler. The constraint
+    # belongs to the linker, and on those systems GCC drives the same Solaris
+    # ld that the SunPro compiler does, so testing SUNPRO alone silently missed
+    # every GCC build - which is what broke the OpenIndiana job. Apple is
+    # excluded for the same class of reason: ld64 understands neither form.
+    #
+    # The Makefile reaches the same conclusion through its UNAME_S filter,
+    # which lists the platforms that get these flags rather than the ones that
+    # do not.
+    #
+    # Cygwin is excluded outright: its ld targets PE/COFF like MinGW's and
+    # rejects the option at the first hurdle - "ld: unrecognized option '-z'" -
+    # even though CMake does not set WIN32 for it and everything else in this
+    # branch applies.
+    if(NOT APPLE AND NOT CYGWIN)
+        if(SUNPRO OR CMAKE_SYSTEM_NAME STREQUAL "SunOS")
             list(APPEND JITTER_LINKER_FLAGS -Wl,-z,now)
         else()
             list(APPEND JITTER_LINKER_FLAGS -Wl,-z,now,-z,relro)
@@ -96,15 +144,106 @@ else()
     endif()
 endif()
 
+set(JITTER_SSP_LINK_FLAGS "")
 if(STACK_PROTECTOR)
+    set(JITTER_SSP_FLAG "")
     if(GCC)
         if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.9.0")
-            list(APPEND JITTER_C_FLAGS -fstack-protector-strong)
+            set(JITTER_SSP_FLAG -fstack-protector-strong)
         else()
-            list(APPEND JITTER_C_FLAGS -fstack-protector-all)
+            set(JITTER_SSP_FLAG -fstack-protector-all)
         endif()
     elseif(CLANG)
-        list(APPEND JITTER_C_FLAGS -fstack-protector-strong)
+        set(JITTER_SSP_FLAG -fstack-protector-strong)
+    endif()
+
+    if(JITTER_SSP_FLAG)
+        # -fstack-protector* emits references to __stack_chk_fail and
+        # __stack_chk_guard, and something has to define them. Most C libraries
+        # do (glibc since 2.4, the BSDs, Apple, bionic, musl, Cygwin), so the
+        # flag costs nothing extra at link time and every platform built until
+        # now hid the question. Solaris' libc defines neither and the runtime
+        # has to come from GCC's own libssp instead - without it the link dies
+        # with "ld: fatal: symbol referencing errors". Haiku has neither the
+        # symbols nor a usable libssp, so there the flag cannot be honoured at
+        # all.
+        #
+        # The flag therefore belongs on the *link* command as well as the
+        # compile one. That is how the compiler driver is told to bring the
+        # runtime in: GCC on Solaris links libssp from its own spec when it
+        # sees -fstack-protector* while driving the link, and adds nothing when
+        # it does not. Naming -lssp here instead would hardcode one platform's
+        # spelling of a decision the driver already knows how to make.
+        #
+        # This was originally a compile-only flag, which is exactly why Solaris
+        # failed: the objects came out instrumented and the link that consumed
+        # them never mentioned the flag, so nothing pulled the runtime in and
+        # every executable died on undefined __stack_chk_fail/__stack_chk_guard.
+        #
+        # A probe rather than a check on CMAKE_SYSTEM_NAME: illumos added both
+        # symbols to its libc (illumos issue #5788) and needs no help, yet it
+        # reports SunOS exactly as Solaris does, so the system name cannot tell
+        # the two apart. The constraint belongs to the toolchain, so the
+        # toolchain is what gets asked - the same reasoning as the floor()/-lm
+        # probe in tests/raw-entropy/recording_userspace/CMakeLists.txt.
+        #
+        # check_c_source_compiles() compiles and links in a single driver
+        # invocation with the flag on it, which is precisely the arrangement
+        # used below, so what the probe answers is what the build will do.
+        #
+        # The probe needs a function the flag actually instruments:
+        # -fstack-protector-strong only guards frames with a local array, so an
+        # empty main() would link on any platform and prove nothing.
+        include(CheckCSourceCompiles)
+        set(JITTER_SSP_PROBE "
+            int main(int argc, char **argv) {
+                char buf[64];
+                (void)argv;
+                buf[0] = (char)argc;
+                return buf[0];
+            }")
+        set(CMAKE_REQUIRED_FLAGS "${JITTER_SSP_FLAG}")
+        check_c_source_compiles("${JITTER_SSP_PROBE}" JITTER_SSP_USABLE)
+        unset(CMAKE_REQUIRED_FLAGS)
+
+        # Emitted only where the runtime behind it exists. It is hardening, not
+        # functionality, and STACK_PROTECTOR is on by default, so a toolchain
+        # that cannot supply the runtime must not be left unable to build the
+        # library at all - which is what a hard error here would mean for
+        # Haiku, whose libroot carries neither symbol and which ships no
+        # libssp to fall back on. Dropped with a warning instead, because a
+        # security option that quietly turns itself off is worse than one that
+        # goes missing loudly.
+        if(JITTER_SSP_USABLE)
+            list(APPEND JITTER_C_FLAGS ${JITTER_SSP_FLAG})
+
+            # Every target compiled with the flag needs it on its own link
+            # command, not just the library. Attaching it to the library target
+            # alone is enough for a static build, where CMake replays a
+            # static library's PRIVATE link items into its consumers, but a
+            # shared library propagates nothing - so the test programs, which
+            # compile their own instrumented frames with JITTER_C_FLAGS, lost
+            # it exactly there. Solaris then failed them on
+            # "__stack_chk_fail ... symbol belongs to implicit dependency
+            # libssp.so.0": reaching libssp through libjitterentropy.so is not
+            # something its link editor will resolve a direct reference
+            # against.
+            #
+            # add_link_options() applies to every target created after it,
+            # including those in the tests/ subdirectories, and mirrors what
+            # ENABLE_SANITIZERS does above for -fsanitize, which needs to be on
+            # both command lines for the same reason.
+            add_link_options(${JITTER_SSP_FLAG})
+
+            # Kept for the .pc file only; the link itself is handled above.
+            set(JITTER_SSP_LINK_FLAGS ${JITTER_SSP_FLAG})
+        else()
+            message(WARNING
+                "Building WITHOUT ${JITTER_SSP_FLAG}: this toolchain cannot "
+                "resolve __stack_chk_fail/__stack_chk_guard even with the flag "
+                "on the link line, so it would break every link. Configure "
+                "with -DSTACK_PROTECTOR=off to silence this.")
+        endif()
     endif()
 endif()
 
@@ -122,11 +261,65 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR})
 target_compile_options(${PROJECT_NAME} PRIVATE ${JITTER_C_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${JITTER_LINKER_FLAGS})
-install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/arch
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    FILES_MATCHING PATTERN "*.h"
-)
+
+# The same treatment bcrypt gets below, for the same reason. A static consumer
+# links this archive's stack-protected frames into its own program and so has to
+# resolve __stack_chk_fail/__stack_chk_guard itself; the exported CMake target
+# carries that as $<LINK_ONLY:ssp>, but nothing propagates it into the .pc file.
+# A shared build resolves them inside the library and needs nothing here.
+if(JITTER_SSP_LINK_FLAGS AND NOT BUILD_SHARED_LIBS)
+    set(JITTER_PC_LIBS_PRIVATE "${JITTER_PC_LIBS_PRIVATE} ${JITTER_SSP_LINK_FLAGS}")
+endif()
+
+if(WIN32)
+    # arch/jitterentropy-arch-uuid.c calls BCryptGenRandom(). MSVC picks the
+    # import library up from the #pragma comment(lib, ...) in that file, but
+    # that pragma is MSVC-only: a MinGW build has to be told here, and without
+    # it every link failed on the undefined symbol. jent_uuid_generate() is
+    # called from jent_entropy_collector_alloc_internal(), so no configuration
+    # avoids it.
+    target_link_libraries(${PROJECT_NAME} PRIVATE bcrypt)
+
+    # The same dependency for pkg-config consumers. The exported CMake target
+    # covers itself - CMake records a static library's PRIVATE dependencies as
+    # $<LINK_ONLY:bcrypt> in its interface - but nothing propagates it into the
+    # .pc file, so a static MinGW consumer building through pkg-config was left
+    # with an undefined BCryptGenRandom. A shared build resolves the call inside
+    # the DLL and needs nothing here.
+    if(NOT BUILD_SHARED_LIBS)
+        set(JITTER_PC_LIBS_PRIVATE "${JITTER_PC_LIBS_PRIVATE} -lbcrypt")
+    endif()
+
+    if(MSVC)
+        # The Windows counterpart of the -z now,-z relro hardening applied on
+        # the ELF targets above. /DYNAMICBASE used to sit in JITTER_C_FLAGS,
+        # i.e. among the *compile* options: cl accepts that spelling without a
+        # diagnostic but only forwards it when it drives the link itself, which
+        # it never does under CMake, so the flag reached nothing. Both are
+        # linker defaults today and are stated explicitly so that a toolchain
+        # changing its defaults cannot silently drop ASLR or DEP.
+        #
+        # /GUARD:CF is deliberately not enabled: it also requires the matching
+        # /guard:cf compile flag, which instruments indirect calls in the
+        # entropy-collection core - code whose timing behaviour is the noise
+        # source and is therefore not changed as a side effect of a build-system
+        # cleanup.
+        target_link_options(${PROJECT_NAME} PRIVATE /DYNAMICBASE /NXCOMPAT)
+    endif()
+
+    # JENT_PRIVATE_STATIC in the public header resolves to dllexport only while
+    # the library itself is compiled; consumers get dllimport, or nothing at all
+    # when they link the static archive. See jitterentropy.h.
+    if(BUILD_SHARED_LIBS)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE JENT_BUILDING_DLL)
+    else()
+        target_compile_definitions(${PROJECT_NAME} PUBLIC JENT_STATIC_LIB)
+    endif()
+endif()
+# Only jitterentropy.h is installed (as PUBLIC_HEADER below). The arch/ headers
+# are internal to the build - the public header defines struct jent_notime_ctx
+# itself and includes none of them, and what they declare is not exported from
+# the library - so they are deliberately not part of the installed tree.
 install(TARGETS ${PROJECT_NAME}
     EXPORT jitterentropyTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -191,19 +384,49 @@ endif()
 # Note: "NOT ANDROID", not "NOT ${ANDROID}" - with ANDROID undefined the
 # expansion would leave "AND NOT" with no operand, which CMake evaluates to
 # false, silently dropping the pthread link dependency on every regular build.
-if(INTERNAL_TIMER AND NOT ANDROID)
+#
+# "NOT WIN32" covers MSVC, clang-cl and MinGW alike: the internal timer uses
+# the native Win32 threads there, which come from the platform and the CRT, so
+# there is nothing to name on the link line. MSVC has no pthread.lib to link in
+# the first place - naming it made every executable fail with LNK1104 - and
+# MinGW would otherwise pull in winpthreads, which the Win32 back-end exists
+# precisely to avoid depending on. Cygwin is a POSIX target and CMake does not
+# set WIN32 for it, so it keeps pthreads.
+if(INTERNAL_TIMER AND NOT ANDROID AND NOT WIN32)
     if(NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
         target_link_libraries(${PROJECT_NAME} PUBLIC pthread)
     endif()
+endif()
+
+# The same dependency, phrased for a target that cannot inherit it.
+#
+# The AMALGAMATED test program in tests/raw-entropy/recording_userspace #includes
+# the library sources rather than linking the library, so nothing above reaches
+# it and it has to resolve the internal timer's pthread_create() itself. That
+# went unnoticed for a long time because the platforms built until now hide it:
+# glibc 2.34 and later, Apple's libSystem and bionic all fold the pthread
+# symbols into the C library. The BSDs keep them in a separate library, so
+# OpenBSD was the first target where the link actually failed.
+#
+# Spelled -pthread rather than -lpthread because that is the form the BSDs need:
+# on FreeBSD the library to link is libthr and only the driver flag selects it,
+# which is exactly why FreeBSD is excluded from the -lpthread branch above.
+# Every other non-Windows toolchain here accepts the flag. Windows needs no
+# entry at all: _beginthreadex() and the Win32 thread calls resolve against the
+# CRT and kernel32, both of which every Windows link already pulls in.
+set(JITTER_THREAD_LIBRARIES "")
+if(INTERNAL_TIMER AND NOT ANDROID AND NOT WIN32)
+    set(JITTER_THREAD_LIBRARIES -pthread)
 endif()
 
 # testing/validation tools
 add_subdirectory(tests/gcd)
 add_subdirectory(tests/raw-entropy/validation-runtime)
 add_subdirectory(tests/raw-entropy/recording_userspace)
-add_subdirectory(tests/raw-entropy/recording_runtime_kernelspace)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Talks to the kernel module's chardev ioctl interface; Linux-only.
+    # Both talk to the kernel module's ioctl interface (linux_kernel/
+    # jitterentropy_uapi.h pulls in <linux/ioctl.h>); Linux-only.
+    add_subdirectory(tests/raw-entropy/recording_runtime_kernelspace)
     add_subdirectory(tests/chardev)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,28 @@ CC ?= gcc
 ENABLE_STACK_PROTECTOR ?= 1
 CFLAGS ?= -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align -Wmissing-field-initializers -Wshadow -Wswitch-enum
 CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0 -fwrapv -Wconversion -std=c11
-LDFLAGS +=-Wl,-z,relro,-z,now -lpthread
+
+# -pthread rather than -lpthread: it is the spelling every supported toolchain
+# understands, and on FreeBSD it is the only correct one (the library to link
+# is libthr, which -pthread selects). It belongs in both the compile and the
+# link step.
+CFLAGS +=-pthread
+LDFLAGS +=-pthread
+
+UNAME_S := $(shell uname -s)
 
 # Enable internal timer support
 CFLAGS += -DJENT_CONF_ENABLE_INTERNAL_TIMER
+
+# Haiku maps the POSIX errno names onto its own B_* error codes, which are
+# negative (based at INT_MIN), so the "return -EXXX" convention this library
+# reports failure with comes out inverted: -ENOENT is a positive number there
+# and every "if (ret < 0)" reads the failure as success. B_USE_POSITIVE_POSIX_ERRORS
+# is Haiku's switch for POSIX-convention code and restores the usual positive
+# errno values. See the fuller explanation in CMakeLists.txt.
+ifeq ($(UNAME_S),Haiku)
+CFLAGS += -DB_USE_POSITIVE_POSIX_ERRORS
+endif
 
 GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | tr '.' '\n' | wc -l`)
 ifeq "$(GCCVERSIONFORMAT)" "3"
@@ -19,9 +37,36 @@ endif
 
 ifeq "$(ENABLE_STACK_PROTECTOR)" "1"
   ifeq "$(GCC_GTEQ_490)" "1"
-    CFLAGS += -fstack-protector-strong
+    SSP_FLAG := -fstack-protector-strong
   else
-    CFLAGS += -fstack-protector-all
+    SSP_FLAG := -fstack-protector-all
+  endif
+  # Something has to define the __stack_chk_fail and __stack_chk_guard that
+  # flag emits references to. Most C libraries do, so this costs nothing on
+  # Linux, the BSDs, macOS, Cygwin and Android; Solaris' libc defines neither
+  # and the runtime has to come from GCC's own libssp, without which every link
+  # of an instrumented program fails with "ld: fatal: symbol referencing
+  # errors"; Haiku has neither and cannot honour the flag at all.
+  #
+  # Hence the flag goes into LDFLAGS as well as CFLAGS: the driver links its
+  # SSP runtime when it sees -fstack-protector* while driving the link, and
+  # nothing when it does not, so naming -lssp here would hardcode one
+  # platform's spelling of a choice the driver already makes correctly.
+  #
+  # Probed rather than keyed on UNAME_S, because illumos added both symbols to
+  # its libc (illumos issue #5788) while still reporting SunOS, so the name
+  # cannot separate the two. The probe compiles and links in one driver call
+  # with the flag on it, which is the arrangement used below. It needs a local
+  # array: the -strong variant only instruments frames that have one, and an
+  # empty main() would link anywhere and settle nothing.
+  SSP_USABLE := $(shell printf 'int main(int c,char**v){char b[64];(void)v;b[0]=(char)c;return b[0];}' \
+	| $(CC) $(SSP_FLAG) -x c - -o /dev/null > /dev/null 2>&1 && echo yes)
+  ifeq "$(SSP_USABLE)" "yes"
+    CFLAGS += $(SSP_FLAG)
+    LDFLAGS += $(SSP_FLAG)
+  else
+    $(warning Building WITHOUT $(SSP_FLAG): this toolchain resolves neither \
+	__stack_chk_fail nor __stack_chk_guard, so the flag would break every link)
   endif
 endif
 
@@ -34,12 +79,13 @@ LIBDIR := lib
 INCDIR := include
 SRCDIR := src
 
-INSTALL_STRIP ?= install -s
-
 NAME := jitterentropy
-LIBMAJOR=$(shell cat jitterentropy.h | egrep "define\s+JENT_MAJVERSION" | awk '{print $$3}')
-LIBMINOR=$(shell cat jitterentropy.h | egrep "define\s+JENT_MINVERSION" | awk '{print $$3}')
-LIBPATCH=$(shell cat jitterentropy.h | egrep "define\s+JENT_PATCHLEVEL" | awk '{print $$3}')
+# grep -E rather than egrep: the latter is deprecated and GNU grep 3.8 (RHEL 10,
+# among others) prints an "egrep is obsolescent" warning on every invocation,
+# which lands in the middle of the build output three times over.
+LIBMAJOR=$(shell grep -E "define\s+JENT_MAJVERSION" jitterentropy.h | awk '{print $$3}')
+LIBMINOR=$(shell grep -E "define\s+JENT_MINVERSION" jitterentropy.h | awk '{print $$3}')
+LIBPATCH=$(shell grep -E "define\s+JENT_PATCHLEVEL" jitterentropy.h | awk '{print $$3}')
 LIBVERSION := $(LIBMAJOR).$(LIBMINOR).$(LIBPATCH)
 
 ARCHDIR := arch
@@ -53,7 +99,47 @@ analyze_plists = $(analyze_srcs:%.c=%.plist)
 
 INCLUDE_DIRS := . $(SRCDIR)
 LIBRARY_DIRS :=
+
+# Shared-library naming and hardening flags are toolchain specific. Apple's
+# ld64 understands neither -z relro/now nor -soname, macOS has no librt (the
+# POSIX timer/clock functions live in libSystem), and shared libraries are
+# .dylib carrying an install name rather than .so carrying an soname.
+ifeq ($(UNAME_S),Darwin)
+LIBRARIES :=
+SOEXT := dylib
+SONAME := lib$(NAME).$(LIBMAJOR).$(SOEXT)
+SOFILE := lib$(NAME).$(LIBVERSION).$(SOEXT)
+SONAME_FLAGS = -install_name $(PREFIX)/$(LIBDIR)/$(SONAME) \
+	-current_version $(LIBVERSION) -compatibility_version $(LIBMAJOR)
+# Apple's strip(1) refuses a full strip of a dylib (the exported symbols
+# must remain), so "install -s" aborts the install; install unstripped and
+# remove only the local symbols afterwards.
+INSTALL_STRIP ?= install
+STRIP_SHARED := strip -x
+else
+# librt is a separate library only on Linux (glibc before 2.17) and Solaris.
+# On the BSDs the POSIX clock and timer functions live in libc, and OpenBSD
+# ships no librt at all - naming it unconditionally made the link fail there
+# with "cannot find -lrt".
+ifneq (,$(filter $(UNAME_S),Linux SunOS))
 LIBRARIES := rt
+else
+LIBRARIES :=
+endif
+SOEXT := so
+SONAME := lib$(NAME).$(SOEXT).$(LIBMAJOR)
+SOFILE := lib$(NAME).$(SOEXT).$(LIBVERSION)
+SONAME_FLAGS = -Wl,-soname,$(SONAME)
+# -z relro / -z now are GNU ld and lld spellings. Apple's ld64 is handled by
+# the Darwin branch above; the Solaris link editor takes neither in this form,
+# so the hardening is applied only where it is known to be understood.
+ifneq (,$(filter $(UNAME_S),Linux FreeBSD OpenBSD NetBSD DragonFly))
+LDFLAGS += -Wl,-z,relro,-z,now
+endif
+INSTALL_STRIP ?= install -s
+STRIP_SHARED := :
+endif
+SOLINK := lib$(NAME).$(SOEXT)
 
 CFLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir))
@@ -66,11 +152,11 @@ all: $(NAME) $(NAME)-static
 lib$(NAME).a: $(OBJS)
 	$(AR) rcs lib$(NAME).a $(OBJS)
 
-lib$(NAME).so.$(LIBVERSION): $(OBJS)
-	$(CC) -shared -Wl,-soname,lib$(NAME).so.$(LIBMAJOR) -o lib$(NAME).so.$(LIBVERSION) $(OBJS) $(LDFLAGS)
+$(SOFILE): $(OBJS)
+	$(CC) -shared $(SONAME_FLAGS) -o $(SOFILE) $(OBJS) $(LDFLAGS)
 
 $(NAME)-static: lib$(NAME).a
-$(NAME): lib$(NAME).so.$(LIBVERSION)
+$(NAME): $(SOFILE)
 
 $(analyze_plists): %.plist: %.c
 	@echo "  CCSA  " $@
@@ -90,11 +176,17 @@ install-man:
 
 install-shared:
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(LIBDIR)
-	$(INSTALL_STRIP) -m 0755 lib$(NAME).so.$(LIBVERSION) $(DESTDIR)$(PREFIX)/$(LIBDIR)/
-	$(RM) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so.$(LIBMAJOR)
-	ln -sf lib$(NAME).so.$(LIBVERSION) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so.$(LIBMAJOR)
-	ln -sf lib$(NAME).so.$(LIBMAJOR) $(DESTDIR)$(PREFIX)/$(LIBDIR)/lib$(NAME).so
+	$(INSTALL_STRIP) -m 0755 $(SOFILE) $(DESTDIR)$(PREFIX)/$(LIBDIR)/
+	$(STRIP_SHARED) $(DESTDIR)$(PREFIX)/$(LIBDIR)/$(SOFILE)
+	$(RM) $(DESTDIR)$(PREFIX)/$(LIBDIR)/$(SONAME)
+	ln -sf $(SOFILE) $(DESTDIR)$(PREFIX)/$(LIBDIR)/$(SONAME)
+	ln -sf $(SONAME) $(DESTDIR)$(PREFIX)/$(LIBDIR)/$(SOLINK)
 
+# jitterentropy.h is the whole installed interface. The arch/ headers are
+# internal to the build: nothing the public header declares needs them - struct
+# jent_notime_ctx is defined in jitterentropy.h itself, so it compiles on its
+# own - and they declare functions that are not exported from the library.
+# CMakeLists.txt installs the same set.
 install-includes:
 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(INCDIR)
 	install -m 0644 jitterentropy.h $(DESTDIR)$(PREFIX)/$(INCDIR)/
@@ -107,7 +199,7 @@ clean:
 	@- $(RM) $(NAME)
 	@- $(RM) $(OBJS)
 	@- $(RM) $(addprefix $(SRCDIR)/,$(C_OBJS)) $(addprefix $(ARCHDIR)/,$(C_OBJS))
-	@- $(RM) lib$(NAME).so*
+	@- $(RM) lib$(NAME).so* lib$(NAME).*dylib
 	@- $(RM) lib$(NAME).a
 	@- $(RM) $(analyze_plists)
 

--- a/arch/android/AndroidManifest.xml
+++ b/arch/android/AndroidManifest.xml
@@ -15,5 +15,10 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="9" />
+    <!--
+        Matches the APP_PLATFORM the library is built at: API 21 is the lowest
+        level the current NDK targets at all, so a lower value here would
+        advertise a range no toolchain can produce.
+    -->
+    <uses-sdk android:minSdkVersion="21" />
 </manifest> 

--- a/arch/jitterentropy-arch-cache.c
+++ b/arch/jitterentropy-arch-cache.c
@@ -43,6 +43,18 @@
  * DAMAGE.
  */
 
+/*
+ * GetLogicalProcessorInformationEx() and RelationCache are declared by the
+ * Windows SDK only when the translation unit asks for Windows 7 or newer.
+ * mingw-w64 in particular has defaulted to older values across its releases,
+ * so the minimum is stated here rather than left to the toolchain; it has to
+ * precede every system header, including the <windows.h> included below. An
+ * externally supplied, higher value is left alone.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 
@@ -54,11 +66,33 @@
  * cache ID registers (arm64, readable at EL1). These headers must not reach the
  * -O0 core, which is why this discovery is out of line here.
  */
+#include <linux/cpu.h>		/* cpus_read_lock()/unlock() */
+#include <linux/cpumask.h>	/* for_each_online_cpu() */
+#include <linux/smp.h>		/* smp_call_function_single() */
 #ifdef CONFIG_X86
-#include <asm/processor.h>	/* cpuid_count(), boot_cpu_data */
+/*
+ * cpuid_count() has moved twice. It used to live in <asm/processor.h>; the x86
+ * CPUID centralisation split it out into <asm/cpuid.h>, and that header then
+ * became the directory <asm/cpuid/api.h>. <asm/processor.h> carried the API
+ * along for a while, but once the circular dependency between the two was
+ * resolved it was reduced to including <asm/cpuid/types.h> - types only, no
+ * cpuid_count() - which is what broke this file on 7.2-rc.
+ *
+ * boot_cpu_data still comes from <asm/processor.h> in every one of those
+ * arrangements, so that include stays unconditional and only the CPUID API is
+ * probed for. Kernels predating the split resolve cpuid_count() from it as
+ * before, which is why no version test is needed here.
+ */
+#if defined(__has_include)
+# if __has_include(<asm/cpuid/api.h>)
+#  include <asm/cpuid/api.h>	/* cpuid_count() */
+# elif __has_include(<asm/cpuid.h>)
+#  include <asm/cpuid.h>	/* cpuid_count() */
+# endif
+#endif
+#include <asm/processor.h>	/* boot_cpu_data */
 #endif
 #ifdef CONFIG_ARM64
-#include <linux/preempt.h>	/* preempt_disable()/enable() */
 #include <asm/barrier.h>	/* isb() */
 #include <asm/sysreg.h>		/* read_sysreg(), write_sysreg() */
 #endif
@@ -71,7 +105,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 # include <windows.h>
 # define JENT_ARCH_CACHE_WINDOWS
 #elif defined(__linux__)
@@ -84,23 +118,37 @@
 #elif defined(__APPLE__)
 # include <sys/sysctl.h>
 # define JENT_ARCH_CACHE_APPLE
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)) && \
-      (defined(__x86_64__) || defined(__i386__) ||                            \
-       defined(__aarch64__) || defined(__riscv))
-# define JENT_ARCH_CACHE_BSD
-# if defined(__x86_64__) || defined(__i386__)
-#  include <cpuid.h>
-#  define JENT_ARCH_CACHE_BSD_CPUID
-# endif
 #elif defined(_AIX)
 # include <sys/systemcfg.h>
 # define JENT_ARCH_CACHE_AIX
+#elif (defined(__x86_64__) || defined(__i386__)) && \
+      (defined(__GNUC__) || defined(__clang__))
+/*
+ * Generic x86 fallback: read the geometry straight out of CPUID. This is the
+ * backend for every x86 platform that has no OS interface of its own here -
+ * the BSDs (which do not export data-cache sizes through sysctl in any uniform
+ * way), DragonFly, Solaris/illumos, Haiku and Cygwin. It deliberately sits
+ * after the OS-specific branches so that a platform which does have a better
+ * interface keeps using it.
+ *
+ * Cygwin is handled here rather than by the Windows branch above. It is a
+ * POSIX environment throughout the rest of this library, and mixing the Win32
+ * cache query into it was the one place that pulled <windows.h> into an
+ * otherwise POSIX translation unit.
+ */
+# include <cpuid.h>
+# define JENT_ARCH_CACHE_CPUID
 #endif
 
 #endif /* LINUX_KERNEL */
 
-static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
-						 int all_caches)
+/*
+ * Combine the discovered L1/L2/L3 data-cache sizes into the memory working-set
+ * size: the smallest power of two strictly greater than the summed cache size,
+ * or 0 when nothing was discovered.
+ */
+static uint32_t jent_cache_roundup_from_sizes(long l1, long l2, long l3,
+					      int all_caches)
 {
 	uint32_t cache_size = 0;
 
@@ -114,6 +162,9 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
 			cache_size += (uint32_t)l3;
 	}
 
+	if (cache_size == 0)
+		return 0;
+
 	/* Force the output_size to be of the form (bounding_power_of_2 - 1). */
 	cache_size |= (cache_size >> 1);
 	cache_size |= (cache_size >> 2);
@@ -121,19 +172,66 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
 	cache_size |= (cache_size >> 8);
 	cache_size |= (cache_size >> 16);
 
-	return cache_size;
+	/* smallest power of 2 strictly greater than the summed cache size */
+	return cache_size + 1;
+}
+
+/*
+ * Per-backend data-cache size discovery, defined exactly once below for the
+ * active platform. Every backend reports the same three values - the L1 data,
+ * L2 and L3 cache size in bytes, each 0 when that level is not discoverable -
+ * and leaves both the all_caches selection and the round-up to the common code
+ * above. Backends that enumerate several CPUs report the largest cache seen at
+ * each level.
+ *
+ * This is the uncached discovery: it is called once, from the memoising entry
+ * point below, and must not be called directly.
+ */
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3);
+
+/*
+ * Enumerating every CPU's data-cache geometry - the sysfs walk in userspace, a
+ * cross-CPU call per online CPU in the kernel - is comparatively expensive, and
+ * the answer is fixed for the life of the process / module. Run the discovery
+ * once, on the first call, derive both the L1-only (all_caches == 0) and the
+ * all-levels (all_caches == 1) working-set size from that single result, and
+ * return the cached answers afterwards so that repeated
+ * jent_entropy_collector_alloc() calls do not each trigger a full CPU walk and
+ * the latency spike it brings.
+ *
+ * The two results are deterministic, so the library's usual "initialise once
+ * before concurrent use" contract (see jent_entropy_init()) makes this safe. A
+ * thread still racing the very first call at worst recomputes the same values;
+ * a 32-bit slot is read/written atomically, so a racing reader observes either
+ * the old zero (harmless - the caller then falls back to its default size) or
+ * the final value, never a torn one.
+ */
+uint32_t jent_cache_size_roundup(int all_caches)
+{
+	static uint32_t cached[2];
+	static int cached_valid;
+
+	if (!cached_valid) {
+		long l1 = 0, l2 = 0, l3 = 0;
+
+		jent_get_cachesize_uncached(&l1, &l2, &l3);
+		cached[0] = jent_cache_roundup_from_sizes(l1, l2, l3, 0);
+		cached[1] = jent_cache_roundup_from_sizes(l1, l2, l3, 1);
+		cached_valid = 1;
+	}
+
+	return cached[!!all_caches];
 }
 
 /*
  * Compiled only for the backends that use it, so the other platforms do not
  * carry dead code (and clang's -Wunused-function noise) around.
  *
- * x86 data-cache discovery via CPUID leaf 4 (deterministic cache parameters,
- * Intel SDM Vol. 2A; also supported by modern AMD CPUs), shared by every x86
- * backend that can issue CPUID. The instruction is issued through the supplied
- * callback so each environment can plug in its own primitive (the userspace
- * __get_cpuid_count() from <cpuid.h>, the kernel's cpuid_count(), ...). The
- * callback returns non-zero on success and must fail when the leaf is
+ * x86 data-cache discovery via the deterministic cache parameters leaf, shared
+ * by every x86 backend that can issue CPUID. The instruction is issued through
+ * the supplied callback so each environment can plug in its own primitive (the
+ * userspace __get_cpuid_count() from <cpuid.h>, the kernel's cpuid_count(),
+ * ...). The callback returns non-zero on success and must fail when the leaf is
  * unsupported, matching __get_cpuid_count().
  *
  *   EAX[ 4: 0]  cache type (1 = data, 2 = instruction, 3 = unified)
@@ -144,19 +242,28 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
  *   ECX         S = number of sets - 1
  * Total size = (W + 1) * (P + 1) * (L + 1) * (S + 1).
  */
-#if defined(JENT_ARCH_CACHE_BSD_CPUID) || \
+#if defined(JENT_ARCH_CACHE_CPUID) || \
     (defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_X86))
+
+/* Intel SDM Vol. 2A, CPUID leaf 4: deterministic cache parameters. */
+#define JENT_CPUID_LEAF_CACHE		0x00000004U
+/* AMD APM Vol. 3, CPUID Fn8000_001D: the same layout, on AMD and Hygon. */
+#define JENT_CPUID_LEAF_CACHE_EXT	0x8000001DU
 
 typedef int (*jent_cpuid_count_t)(unsigned int leaf, unsigned int subleaf,
 				  unsigned int *eax, unsigned int *ebx,
 				  unsigned int *ecx, unsigned int *edx);
 
-static inline uint32_t jent_cache_size_roundup_cpuid(jent_cpuid_count_t cpuid,
-						     int all_caches)
+/* Walk the subleaves of @leaf; returns non-zero if any cache was found. */
+static inline int jent_cache_sizes_cpuid_leaf(jent_cpuid_count_t cpuid,
+					      unsigned int leaf,
+					      long *l1, long *l2, long *l3)
 {
-	long l1 = 0, l2 = 0, l3 = 0;
-	uint32_t cache_size;
 	unsigned int sub;
+
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
 
 	for (sub = 0; sub < 16; sub++) {
 		unsigned int eax, ebx, ecx, edx;
@@ -164,7 +271,7 @@ static inline uint32_t jent_cache_size_roundup_cpuid(jent_cpuid_count_t cpuid,
 		unsigned int ways, partitions, line_size, sets;
 		long size;
 
-		if (!cpuid(4, sub, &eax, &ebx, &ecx, &edx))
+		if (!cpuid(leaf, sub, &eax, &ebx, &ecx, &edx))
 			break;
 
 		cache_type = eax & 0x1F;
@@ -188,23 +295,38 @@ static inline uint32_t jent_cache_size_roundup_cpuid(jent_cpuid_count_t cpuid,
 		 * caches; only the data cache (type 1) is relevant here. L2/L3
 		 * are usually unified, so accept data or unified.
 		 */
-		if (cache_level == 1 && cache_type == 1 && l1 == 0)
-			l1 = size;
-		else if (cache_level == 2 && l2 == 0)
-			l2 = size;
-		else if (cache_level == 3 && l3 == 0)
-			l3 = size;
+		if (cache_level == 1 && cache_type == 1 && *l1 == 0)
+			*l1 = size;
+		else if (cache_level == 2 && *l2 == 0)
+			*l2 = size;
+		else if (cache_level == 3 && *l3 == 0)
+			*l3 = size;
 	}
 
-	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-	if (cache_size == 0)
-		return 0;
-
-	/* smallest power of 2 strictly greater than the summed cache size */
-	return cache_size + 1;
+	return (*l1 != 0 || *l2 != 0 || *l3 != 0);
 }
 
-#endif /* JENT_ARCH_CACHE_BSD_CPUID || (LINUX_KERNEL && CONFIG_X86) */
+static inline void jent_cache_sizes_cpuid(jent_cpuid_count_t cpuid,
+					  long *l1, long *l2, long *l3)
+{
+	/*
+	 * Leaf 4 is Intel's. AMD and Hygon parts leave it empty - it reports
+	 * cache type 0 in the first subleaf - and expose the identical structure
+	 * through extended leaf 0x8000001D instead (gated by the
+	 * TopologyExtensions feature; parts without it, and hypervisors hiding
+	 * it, again report cache type 0 and leave the sizes at zero). A guest
+	 * sees whichever leaf its host CPU implements, so probe both rather than
+	 * dispatching on the vendor ID.
+	 */
+	if (jent_cache_sizes_cpuid_leaf(cpuid, JENT_CPUID_LEAF_CACHE,
+					l1, l2, l3))
+		return;
+
+	jent_cache_sizes_cpuid_leaf(cpuid, JENT_CPUID_LEAF_CACHE_EXT,
+				    l1, l2, l3);
+}
+
+#endif /* JENT_ARCH_CACHE_CPUID || (LINUX_KERNEL && CONFIG_X86) */
 
 #if defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_ARM64)
 
@@ -220,13 +342,15 @@ static inline uint32_t jent_cache_size_roundup_cpuid(jent_cpuid_count_t cpuid,
  */
 typedef uint64_t (*jent_read_ccsidr_t)(unsigned int level);
 
-static inline uint32_t jent_cache_size_roundup_arm64(uint64_t clidr, int ccidx,
-						     jent_read_ccsidr_t ccsidr_fn,
-						     int all_caches)
+static inline void jent_cache_sizes_arm64(uint64_t clidr, int ccidx,
+					  jent_read_ccsidr_t ccsidr_fn,
+					  long *l1, long *l2, long *l3)
 {
-	long l1 = 0, l2 = 0, l3 = 0;
-	uint32_t cache_size;
 	unsigned int level;
+
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
 
 	for (level = 1; level <= 7; level++) {
 		/* CLIDR_EL1 holds a 3-bit cache type per level. */
@@ -257,27 +381,18 @@ static inline uint32_t jent_cache_size_roundup_arm64(uint64_t clidr, int ccidx,
 		}
 		size = (long)(((unsigned long)1 << (line + 4)) * assoc * sets);
 
-		if (level == 1 && l1 == 0)
-			l1 = size;
-		else if (level == 2 && l2 == 0)
-			l2 = size;
-		else if (level == 3 && l3 == 0)
-			l3 = size;
+		if (level == 1 && *l1 == 0)
+			*l1 = size;
+		else if (level == 2 && *l2 == 0)
+			*l2 = size;
+		else if (level == 3 && *l3 == 0)
+			*l3 = size;
 	}
-
-	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-	if (cache_size == 0)
-		return 0;
-
-	/* smallest power of 2 strictly greater than the summed cache size */
-	return cache_size + 1;
 }
 
 #endif /* JENT_ARCH_CACHE_LINUX_KERNEL && CONFIG_ARM64 */
 
-#if defined(JENT_ARCH_CACHE_LINUX) || defined(JENT_ARCH_CACHE_APPLE)
-
-#ifdef JENT_ARCH_CACHE_LINUX
+#if defined(JENT_ARCH_CACHE_LINUX)
 
 /*
  * The _SC_LEVEL*_*CACHE_SIZE selectors are a glibc extension. musl, uClibc
@@ -318,229 +433,382 @@ static void jent_get_cachesize_sysconf(long *l1, long *l2, long *l3)
 # endif
 }
 
-static void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
+/*
+ * Read a whole sysfs attribute file into @buf (always NUL-terminated on
+ * success). Returns the byte count read (> 0) or -1 on any failure. A read
+ * that fills the entire buffer is reported as such (rlen == buflen) so callers
+ * that care about truncation - the size attribute carries a K/M suffix - can
+ * reject it.
+ */
+static ssize_t jent_read_sysfs_attr(const char *file, char *buf, size_t buflen)
 {
-#define JENT_SYSFS_CACHE_DIR "/sys/devices/system/cpu/cpu0/cache"
-	long val;
-	unsigned int i;
-	char buf[32], file[50];
-	int fd = 0;
+	int fd;
 	ssize_t rlen;
 
-	/* Iterate over all caches */
-	for (i = 0; i < 4; i++) {
-		unsigned int shift = 0;
-		char *ext, *endptr;
-
-		/*
-		 * Check the cache type - we are only interested in Unified
-		 * and Data caches.
-		 */
-		memset(buf, 0, sizeof(buf));
-		snprintf(file, sizeof(file), "%s/index%u/type",
-			 JENT_SYSFS_CACHE_DIR, i);
-		fd = open(file, O_RDONLY);
-		if (fd < 0)
-			continue;
-		do {
-			rlen = read(fd, buf, sizeof(buf));
-		} while (rlen < 0 && errno == EINTR);
-		close(fd);
-		if (rlen <= 0)
-			continue;
-		buf[sizeof(buf) - 1] = '\0';
-
-		if (strncmp(buf, "Data", 4) && strncmp(buf, "Unified", 7))
-			continue;
-
-		/* Get size of cache */
-		memset(buf, 0, sizeof(buf));
-		snprintf(file, sizeof(file), "%s/index%u/size",
-			 JENT_SYSFS_CACHE_DIR, i);
-
-		fd = open(file, O_RDONLY);
-		if (fd < 0)
-			continue;
-		do {
-			rlen = read(fd, buf, sizeof(buf));
-		} while (rlen < 0 && errno == EINTR);
-		close(fd);
-		if (rlen <= 0)
-			continue;
-		/*
-		 * A read filling the entire buffer may have truncated the
-		 * K/M suffix; parsing the bare number would undercount the
-		 * cache size 1024-fold. Skip this cache instead.
-		 */
-		if ((size_t)rlen == sizeof(buf))
-			continue;
-		buf[sizeof(buf) - 1] = '\0';
-
-		ext = strstr(buf, "K");
-		if (ext) {
-			shift = 10;
-			*ext = '\0';
-		} else {
-			ext = strstr(buf, "M");
-			if (ext) {
-				shift = 20;
-				*ext = '\0';
-			}
-		}
-
-		errno = 0;
-		val = strtol(buf, &endptr, 10);
-		if (errno != 0 || endptr == buf || val <= 0 || val == LONG_MAX)
-			continue;
-		val <<= shift;
-
-		if (!*l1)
-			*l1 = val;
-		else if (!*l2)
-			*l2 = val;
-		else {
-			*l3 = val;
-			break;
-		}
-	}
-#undef JENT_SYSFS_CACHE_DIR
+	memset(buf, 0, buflen);
+	fd = open(file, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	do {
+		rlen = read(fd, buf, buflen);
+	} while (rlen < 0 && errno == EINTR);
+	close(fd);
+	if (rlen <= 0)
+		return -1;
+	buf[buflen - 1] = '\0';
+	return rlen;
 }
 
-#endif /* JENT_ARCH_CACHE_LINUX */
-
-#ifdef JENT_ARCH_CACHE_APPLE
-
-static void jent_get_cachesize_sysconf(long *l1, long *l2, long *l3)
+static void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
 {
-	size_t size;
+#define JENT_SYSFS_CPU_DIR "/sys/devices/system/cpu"
+	long conf, cpu;
 
-	size = sizeof(*l1);
-	if (sysctlbyname("hw.l1dcachesize", l1, &size, NULL, 0) != 0)
-		*l1 = 0;
-
-	size = sizeof(*l2);
-	if (sysctlbyname("hw.l2cachesize", l2, &size, NULL, 0) != 0)
-		*l2 = 0;
-
-	size = sizeof(*l3);
-	if (sysctlbyname("hw.l3cachesize", l3, &size, NULL, 0) != 0)
-		*l3 = 0;
-}
-
-#endif /* JENT_ARCH_CACHE_APPLE */
-
-uint32_t jent_cache_size_roundup(int all_caches)
-{
-	uint32_t cache_size = 0;
-	long l1 = 0, l2 = 0, l3 = 0;
-
-	jent_get_cachesize_sysconf(&l1, &l2, &l3);
-
-	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-#ifdef JENT_ARCH_CACHE_LINUX
-	if (cache_size == 0) {
-		jent_get_cachesize_sysfs(&l1, &l2, &l3);
-		cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-
-		if (cache_size == 0)
-			return 0;
-	}
-#endif
-
-	if (cache_size == 0)
-		return 0;
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
 
 	/*
-	 * Make the output_size the smallest power of 2 strictly greater
-	 * than cache_size.
+	 * Enumerate every configured CPU, not just cpu0: on a hybrid CPU
+	 * (Intel P-cores + E-cores, Arm big.LITTLE) the per-core data-cache
+	 * sizes differ, and the collector normally runs on the more capable
+	 * core, so keep the largest cache seen at each level rather than
+	 * trusting whatever cpu0 happens to report.
+	 *
+	 * _SC_NPROCESSORS_CONF counts configured (not merely online) CPUs,
+	 * whose sysfs indices lie in [0, conf); offline CPUs have no cache
+	 * directory and are simply skipped. Fall back to cpu0 only when the
+	 * count is unavailable, and cap the scan so an implausible topology
+	 * cannot spin unbounded.
 	 */
-	cache_size++;
+#ifdef _SC_NPROCESSORS_CONF
+	conf = sysconf(_SC_NPROCESSORS_CONF);
+#else
+	conf = -1;
+#endif
+	if (conf <= 0)
+		conf = 1;
+	if (conf > 65536)
+		conf = 65536;
 
-	return cache_size;
+	for (cpu = 0; cpu < conf; cpu++) {
+		unsigned int idx;
+
+		for (idx = 0; idx < 16; idx++) {
+			char buf[32];
+			/* the filename buffer is larger than necessary for testing
+			 * with artifical sysfs e.g. under /tmp */
+			char file[128];
+			long *slot, val, level;
+			ssize_t rlen;
+			char *ext, *endptr;
+			unsigned int shift = 0;
+
+			/*
+			 * Cache type - only Data and Unified are relevant. The
+			 * kernel numbers cache indices contiguously from 0, so
+			 * a missing index means this CPU has no further caches
+			 * (or is offline and exposes no cache directory).
+			 */
+			snprintf(file, sizeof(file),
+				 "%s/cpu%ld/cache/index%u/type",
+				 JENT_SYSFS_CPU_DIR, cpu, idx);
+			if (jent_read_sysfs_attr(file, buf, sizeof(buf)) <= 0)
+				break;
+			if (strncmp(buf, "Data", 4) &&
+			    strncmp(buf, "Unified", 7))
+				continue;
+
+			/* Cache level selects the L1/L2/L3 bucket. */
+			snprintf(file, sizeof(file),
+				 "%s/cpu%ld/cache/index%u/level",
+				 JENT_SYSFS_CPU_DIR, cpu, idx);
+			if (jent_read_sysfs_attr(file, buf, sizeof(buf)) <= 0)
+				continue;
+			errno = 0;
+			level = strtol(buf, &endptr, 10);
+			if (errno != 0 || endptr == buf || level < 1)
+				continue;
+			if (level == 1)
+				slot = l1;
+			else if (level == 2)
+				slot = l2;
+			else
+				slot = l3;
+
+			/* Size of the cache, carrying a K or M suffix. */
+			snprintf(file, sizeof(file),
+				 "%s/cpu%ld/cache/index%u/size",
+				 JENT_SYSFS_CPU_DIR, cpu, idx);
+			rlen = jent_read_sysfs_attr(file, buf, sizeof(buf));
+			if (rlen <= 0)
+				continue;
+			/*
+			 * A read filling the entire buffer may have truncated
+			 * the K/M suffix; parsing the bare number would
+			 * undercount the cache size 1024-fold. Skip it instead.
+			 */
+			if ((size_t)rlen == sizeof(buf))
+				continue;
+
+			ext = strstr(buf, "K");
+			if (ext) {
+				shift = 10;
+				*ext = '\0';
+			} else {
+				ext = strstr(buf, "M");
+				if (ext) {
+					shift = 20;
+					*ext = '\0';
+				}
+			}
+
+			errno = 0;
+			val = strtol(buf, &endptr, 10);
+			if (errno != 0 || endptr == buf || val <= 0 ||
+			    val == LONG_MAX)
+				continue;
+			val <<= shift;
+
+			/* Keep the largest cache seen at this level. */
+			if (val > *slot)
+				*slot = val;
+		}
+	}
+#undef JENT_SYSFS_CPU_DIR
 }
+
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
+{
+	long s1 = 0, s2 = 0, s3 = 0;
+
+	/*
+	 * Prefer the sysfs scan: it enumerates every CPU and therefore captures
+	 * the largest (performance-core) data cache on a hybrid part, whereas
+	 * glibc's sysconf reflects only the single core its one-shot CPUID probe
+	 * happened to run on.
+	 */
+	jent_get_cachesize_sysfs(l1, l2, l3);
+	if (*l1 > 0)
+		return;
+
+	/*
+	 * No L1 data cache found - sysfs is unavailable (not mounted, a
+	 * restricted container, ...) or does not describe the caches. Fall back
+	 * to sysconf, keeping the larger value per level so a partial sysfs
+	 * result is never made worse.
+	 */
+	jent_get_cachesize_sysconf(&s1, &s2, &s3);
+	if (s1 > *l1)
+		*l1 = s1;
+	if (s2 > *l2)
+		*l2 = s2;
+	if (s3 > *l3)
+		*l3 = s3;
+}
+
+#elif defined(JENT_ARCH_CACHE_APPLE)
+
+#define JENT_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/*
+ * Return the first of @names that resolves, or 0 when none does.
+ *
+ * The value is read into a uint64_t rather than straight into the caller's
+ * long: the hw.* cache sysctls are 64 bit, so a 32-bit build passing
+ * sizeof(long) == 4 would be rejected with ENOMEM and lose the size entirely.
+ * A kernel answering with a narrower type is still handled - the destination
+ * is zeroed first and every Apple target is little-endian, so a short write
+ * lands in the low bytes.
+ */
+static long jent_sysctl_cachesize(const char *const *names, size_t nnames)
+{
+	size_t i;
+
+	for (i = 0; i < nnames; i++) {
+		uint64_t val = 0;
+		size_t len = sizeof(val);
+
+		if (sysctlbyname(names[i], &val, &len, NULL, 0) != 0)
+			continue;
+		if (len != sizeof(val) && len != sizeof(uint32_t))
+			continue;
+		if (val == 0 || val > (uint64_t)LONG_MAX)
+			continue;
+
+		return (long)val;
+	}
+
+	return 0;
+}
+
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
+{
+	/*
+	 * Apple Silicon is heterogeneous, and the flat hw.l1dcachesize /
+	 * hw.l2cachesize report the *least* capable cluster - the efficiency
+	 * cores. On an M-series part that is 64 kB / 4 MB where the
+	 * performance cores have 128 kB / 12 MB. Sizing the memory access
+	 * working set from the efficiency core understates it for the
+	 * performance cores the collector normally runs on, so ask for the
+	 * perflevel0 (most performant) cluster first.
+	 *
+	 * The perflevel* names only exist on Apple Silicon; on Intel Macs and
+	 * on homogeneous parts the lookup falls through to the flat names.
+	 */
+	static const char *const l1_names[] = {
+		"hw.perflevel0.l1dcachesize",
+		"hw.l1dcachesize"
+	};
+	static const char *const l2_names[] = {
+		"hw.perflevel0.l2cachesize",
+		"hw.l2cachesize"
+	};
+	/*
+	 * Apple Silicon exposes no L3 size through sysctl at all (the SLC is
+	 * not reported); these names only resolve on older Intel Macs. A
+	 * missing L3 simply leaves the value at zero.
+	 */
+	static const char *const l3_names[] = {
+		"hw.perflevel0.l3cachesize",
+		"hw.l3cachesize"
+	};
+
+	*l1 = jent_sysctl_cachesize(l1_names, JENT_ARRAY_SIZE(l1_names));
+	*l2 = jent_sysctl_cachesize(l2_names, JENT_ARRAY_SIZE(l2_names));
+	*l3 = jent_sysctl_cachesize(l3_names, JENT_ARRAY_SIZE(l3_names));
+}
+
+#undef JENT_ARRAY_SIZE
 
 #elif defined(JENT_ARCH_CACHE_WINDOWS)
 
-uint32_t jent_cache_size_roundup(int all_caches)
+/*
+ * GetLogicalProcessorInformationEx() rather than the older
+ * GetLogicalProcessorInformation(): the latter only ever describes processor
+ * group 0, so on a machine with more than 64 logical CPUs - and on the
+ * heterogeneous parts where the per-level scan below actually matters - every
+ * cache outside that first group was invisible.
+ *
+ * The Ex variant returns a packed sequence of variable-length records, so it
+ * has to be walked by each record's own Size field instead of being indexed
+ * like an array.
+ */
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
 {
-	long l1 = 0, l2 = 0, l3 = 0;
 	DWORD len = 0;
-	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = NULL;
-	DWORD count;
-	DWORD i;
-	uint32_t cache_size;
+	BYTE *buffer, *pos, *end;
+	/* Bytes that must be readable before Relationship and Size are touched. */
+	const size_t hdr = offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+				    Cache);
+	/* ... and before the Cache member itself is read. */
+	const size_t cache_rec = hdr + sizeof(CACHE_RELATIONSHIP);
+
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
 
 	/* First call to get buffer size */
-	if (!GetLogicalProcessorInformation(NULL, &len) &&
+	if (!GetLogicalProcessorInformationEx(RelationCache, NULL, &len) &&
 	    GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-		return 0;
+		return;
 
-	buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)malloc(len);
+	buffer = (BYTE *)malloc(len);
 	if (!buffer)
-		return 0;
+		return;
 
 	/* Second call to retrieve data */
-	if (!GetLogicalProcessorInformation(buffer, &len)) {
+	if (!GetLogicalProcessorInformationEx(
+			RelationCache,
+			(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)buffer,
+			&len)) {
 		free(buffer);
-		return 0;
+		return;
 	}
 
-	count = len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+	/*
+	 * One record is reported per cache, so every level shows up as many
+	 * times as the machine has such caches. Keep the largest of each level
+	 * rather than whatever happens to be enumerated last: on a
+	 * heterogeneous CPU (Intel P-cores and E-cores report different L2
+	 * sizes) the picked value would otherwise depend on enumeration order,
+	 * and a memory region sized after the smaller cache would still fit
+	 * into the larger one. On a homogeneous machine all entries of a level
+	 * are equal and the result is unchanged.
+	 */
+	pos = buffer;
+	end = buffer + len;
+	while ((size_t)(end - pos) >= hdr) {
+		PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX rec =
+			(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)pos;
+		CACHE_RELATIONSHIP *cache;
+		long size;
 
-	for (i = 0; i < count; i++) {
-		if (buffer[i].Relationship == RelationCache) {
-			CACHE_DESCRIPTOR *cache = &buffer[i].Cache;
+		/*
+		 * A zero or oversized Size would make the walk spin or read
+		 * past the buffer; treat either as the end of the data.
+		 */
+		if (rec->Size < hdr || (size_t)(end - pos) < rec->Size)
+			break;
 
-			if (cache->Level == 1 && cache->Type == CacheData) {
-				l1 = (long)cache->Size;
-			} else if (cache->Level == 2 &&
-				   (cache->Type == CacheUnified ||
-				    cache->Type == CacheData)) {
-				l2 = (long)cache->Size;
-			} else if (cache->Level == 3 &&
-				   (cache->Type == CacheUnified ||
-				    cache->Type == CacheData)) {
-				l3 = (long)cache->Size;
-			}
+		if (rec->Relationship != RelationCache) {
+			pos += rec->Size;
+			continue;
 		}
+
+		/*
+		 * The bound checked above covers Relationship and Size only,
+		 * while the Cache member reaches past hdr. A record claiming
+		 * to describe a cache in less space than a CACHE_RELATIONSHIP
+		 * occupies is malformed, and reading it would run off the end
+		 * of the buffer when it is the last record; stop rather than
+		 * trust the remainder of the walk. The pointer is formed only
+		 * after this check, so it never even points past the
+		 * allocation.
+		 */
+		if (rec->Size < cache_rec)
+			break;
+
+		cache = &rec->Cache;
+		size = (long)cache->CacheSize;
+
+		if (cache->Level == 1 && cache->Type == CacheData) {
+			if (size > *l1)
+				*l1 = size;
+		} else if (cache->Level == 2 &&
+			   (cache->Type == CacheUnified ||
+			    cache->Type == CacheData)) {
+			if (size > *l2)
+				*l2 = size;
+		} else if (cache->Level == 3 &&
+			   (cache->Type == CacheUnified ||
+			    cache->Type == CacheData)) {
+			if (size > *l3)
+				*l3 = size;
+		}
+
+		pos += rec->Size;
 	}
 
 	free(buffer);
-
-	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-	if (cache_size == 0)
-		return 0;
-
-	/*
-	 * Make the output_size the smallest power of 2 strictly greater
-	 * than cache_size.
-	 */
-	cache_size++;
-
-	return cache_size;
 }
 
-#elif defined(JENT_ARCH_CACHE_BSD)
+#elif defined(JENT_ARCH_CACHE_CPUID)
 
-uint32_t jent_cache_size_roundup(int all_caches)
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
 {
-#ifdef JENT_ARCH_CACHE_BSD_CPUID
 	/*
-	 * The BSDs do not export data-cache sizes through sysctl in a uniform
-	 * way; on x86 read them directly via CPUID leaf 4. __get_cpuid_count()
-	 * (from <cpuid.h>) already fails when the leaf is unsupported.
+	 * __get_cpuid_count() (from <cpuid.h>) already fails when the leaf is
+	 * unsupported, which is what jent_cache_sizes_cpuid() relies on to
+	 * probe the Intel and the AMD/Hygon leaf in turn.
+	 *
+	 * Unlike the sysfs and kernel backends this reads only the CPU the
+	 * caller happens to be running on, so on a hybrid part it reports that
+	 * core's geometry rather than the largest in the system. Every platform
+	 * routed here lacks a portable way to enumerate the others; the result
+	 * is a working-set size that is correct for some core rather than none.
 	 */
-	return jent_cache_size_roundup_cpuid(__get_cpuid_count, all_caches);
-#else
-	/*
-	 * AArch64 carries the data cache sizes in CCSIDR_EL1, an EL1 register
-	 * that the BSD arm64 kernels do not currently emulate for EL0. RISC-V
-	 * has no standardised user-mode cache-discovery instruction at all. In
-	 * both cases return zero so the caller falls back to its default.
-	 */
-	(void)all_caches;
-	return 0;
-#endif /* JENT_ARCH_CACHE_BSD_CPUID */
+	jent_cache_sizes_cpuid(__get_cpuid_count, l1, l2, l3);
 }
 
 #elif defined(JENT_ARCH_CACHE_AIX)
@@ -551,45 +819,58 @@ uint32_t jent_cache_size_roundup(int all_caches)
  * L2_cache_size for L2. AIX does not provide an L3 size in this struct, so
  * leave it at zero.
  */
-uint32_t jent_cache_size_roundup(int all_caches)
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
 {
-	long l1 = (long)_system_configuration.dcache_size;
-	long l2 = (long)_system_configuration.L2_cache_size;
-	long l3 = 0;
-	uint32_t cache_size;
-
-	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-	if (cache_size == 0)
-		return 0;
-
-	/*
-	 * Make the output_size the smallest power of 2 strictly greater
-	 * than cache_size.
-	 */
-	cache_size++;
-
-	return cache_size;
+	*l1 = (long)_system_configuration.dcache_size;
+	*l2 = (long)_system_configuration.L2_cache_size;
+	*l3 = 0;
 }
 
-#elif defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_X86)
+#elif defined(JENT_ARCH_CACHE_LINUX_KERNEL) && \
+      (defined(CONFIG_X86) || defined(CONFIG_ARM64))
+
+struct jent_cpu_cache_sizes {
+	long l1, l2, l3;
+};
+
+#ifdef CONFIG_X86
 
 static int jent_cpuid_count(unsigned int leaf, unsigned int subleaf,
 			    unsigned int *eax, unsigned int *ebx,
 			    unsigned int *ecx, unsigned int *edx)
 {
-	if (boot_cpu_data.cpuid_level < (int)leaf)
+	/*
+	 * The basic (0x00000000-) and extended (0x80000000-) leaf ranges are
+	 * capped separately - by CPUID.0:EAX and CPUID.0x80000000:EAX - which
+	 * the kernel keeps in cpuid_level and extended_cpuid_level. Querying
+	 * past either cap does not fault but returns another leaf's contents,
+	 * so check the one belonging to the requested range.
+	 */
+	if (leaf & 0x80000000U) {
+		if (boot_cpu_data.extended_cpuid_level < leaf)
+			return 0;
+	} else if (boot_cpu_data.cpuid_level < (int)leaf) {
 		return 0;
+	}
 
 	cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);
 	return 1;
 }
 
-uint32_t jent_cache_size_roundup(int all_caches)
+/*
+ * Runs on the target CPU via smp_call_function_single(), so the whole leaf-4
+ * walk stays pinned to that core - the per-level sizes cannot be torn across a
+ * migration between a P-core and an E-core.
+ */
+static void jent_cache_sizes_worker(void *info)
 {
-	return jent_cache_size_roundup_cpuid(jent_cpuid_count, all_caches);
+	struct jent_cpu_cache_sizes *sizes = info;
+
+	jent_cache_sizes_cpuid(jent_cpuid_count,
+			       &sizes->l1, &sizes->l2, &sizes->l3);
 }
 
-#elif defined(JENT_ARCH_CACHE_LINUX_KERNEL) && defined(CONFIG_ARM64)
+#else /* CONFIG_ARM64 */
 
 /* Read CCSIDR_EL1 for the data/unified cache at @level (1-based). */
 static uint64_t jent_read_ccsidr(unsigned int level)
@@ -600,30 +881,77 @@ static uint64_t jent_read_ccsidr(unsigned int level)
 	return read_sysreg(ccsidr_el1);
 }
 
-uint32_t jent_cache_size_roundup(int all_caches)
+/*
+ * Runs on the target PE via smp_call_function_single(). CSSELR_EL1/CCSIDR_EL1
+ * form a per-PE selector, so executing the whole sequence on one CPU is what
+ * keeps it consistent - and, unlike the former manual preempt_disable(), it
+ * also reads each cluster's own geometry on big.LITTLE / DynamIQ parts.
+ */
+static void jent_cache_sizes_worker(void *info)
 {
-	uint64_t clidr;
-	int ccidx;
-	uint32_t ret;
-
-	/* CSSELR_EL1/CCSIDR_EL1 form a per-PE selector; stay on one CPU. */
-	preempt_disable();
-	clidr = read_sysreg(clidr_el1);
+	struct jent_cpu_cache_sizes *sizes = info;
+	uint64_t clidr = read_sysreg(clidr_el1);
 	/* ID_AA64MMFR2_EL1.CCIDX is bits[23:20]; non-zero => wide CCSIDR format. */
-	ccidx = (int)((read_sysreg(id_aa64mmfr2_el1) >> 20) & 0xf);
-	ret = jent_cache_size_roundup_arm64(clidr, ccidx, jent_read_ccsidr,
-					    all_caches);
-	preempt_enable();
+	int ccidx = (int)((read_sysreg(id_aa64mmfr2_el1) >> 20) & 0xf);
 
-	return ret;
+	jent_cache_sizes_arm64(clidr, ccidx, jent_read_ccsidr,
+			       &sizes->l1, &sizes->l2, &sizes->l3);
+}
+
+#endif /* CONFIG_X86 */
+
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
+{
+	int cpu;
+
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
+
+	/*
+	 * Read the cache geometry on every online CPU and keep the largest at
+	 * each level. Heterogeneous CPUs - Intel P-cores + E-cores with
+	 * differing L2, big.LITTLE / DynamIQ clusters with differing geometry
+	 * altogether - would otherwise be sized after the smaller cache, while
+	 * the collector normally runs on the more capable core.
+	 */
+	cpus_read_lock();
+	for_each_online_cpu(cpu) {
+		struct jent_cpu_cache_sizes sizes = { 0, 0, 0 };
+
+		if (smp_call_function_single(cpu, jent_cache_sizes_worker,
+					     &sizes, 1))
+			continue;
+
+		if (sizes.l1 > *l1)
+			*l1 = sizes.l1;
+		if (sizes.l2 > *l2)
+			*l2 = sizes.l2;
+		if (sizes.l3 > *l3)
+			*l3 = sizes.l3;
+	}
+	cpus_read_unlock();
 }
 
 #else /* no cache discovery available */
 
-uint32_t jent_cache_size_roundup(int all_caches)
+/*
+ * Reached by every remaining combination, most notably the non-Linux, non-Apple
+ * platforms on a non-x86 CPU: the BSDs on aarch64, powerpc or riscv, and any
+ * target whose compiler provides no <cpuid.h>.
+ *
+ * AArch64 carries the data cache sizes in CCSIDR_EL1, an EL1 register that the
+ * BSD arm64 kernels do not currently emulate for EL0 (the Linux kernel backend
+ * above can read it because it runs at EL1). RISC-V has no standardised
+ * user-mode cache-discovery instruction at all. Reporting nothing makes
+ * jent_update_memsize() fall back to JENT_DEFAULT_MEMORY_BITS, which is a
+ * conservative working-set size rather than a failure.
+ */
+static void jent_get_cachesize_uncached(long *l1, long *l2, long *l3)
 {
-	(void)all_caches;
-	return 0;
+	*l1 = 0;
+	*l2 = 0;
+	*l3 = 0;
 }
 
 #endif

--- a/arch/jitterentropy-arch-cache.h
+++ b/arch/jitterentropy-arch-cache.h
@@ -47,14 +47,19 @@
  * or 0 when the platform offers no way to discover it. Defined in
  * arch/jitterentropy-arch-cache.c.
  *
+ * Every backend there implements the same hook - report the L1 data, L2 and L3
+ * cache size, 0 for a level it cannot discover - and the common code does the
+ * discovery once and answers from a cache afterwards.
+ *
  * Dispatch:
- *   - Linux            -> sysconf(_SC_LEVEL{1,2,3}_*) with /sys/devices fallback
+ *   - Linux            -> /sys/devices/system/cpu walk with sysconf(_SC_LEVEL{1,2,3}_*) fallback
  *   - macOS            -> sysctlbyname("hw.l{1d,2,3}cachesize")
  *   - Windows / Cygwin -> GetLogicalProcessorInformation
- *   - {Open,Free,Net}BSD x86 -> CPUID leaf 4 (deterministic cache parameters)
+ *   - {Open,Free,Net}BSD x86 -> CPUID deterministic cache parameters
+ *                               (leaf 4, or 0x8000001D on AMD / Hygon)
  *   - {Open,Free,Net}BSD aarch64 / riscv -> zero stub (no EL0-readable source)
  *   - AIX              -> _system_configuration (dcache_size / L2_cache_size)
- *   - Linux Kernel x86 -> CPUID leaf 4
+ *   - Linux Kernel x86 -> CPUID leaf 4 / 0x8000001D, on every online CPU
  *   - Linux Kernel arm64 -> CLIDR_EL1 / CCSIDR_EL1 cache ID registers
  *   - other            -> return 0
  */

--- a/arch/jitterentropy-arch-fips.c
+++ b/arch/jitterentropy-arch-fips.c
@@ -69,12 +69,20 @@ int jent_fips_enabled(void)
 # include <openssl/evp.h>
 #endif
 
+/*
+ * The switch file below is a Linux interface. It used to be read on every
+ * platform that is neither Windows nor backed by a crypto library, which meant
+ * the BSDs, macOS, AIX and Solaris each performed an open() that could only
+ * ever fail. The answer was still correct - no file, not in FIPS mode - but the
+ * dispatch said nothing about which platforms actually have the concept.
+ */
 #if !defined(LIBGCRYPT) && !defined(AWSLC) && !defined(OPENSSL) && \
-    !defined(_MSC_VER) && !defined(__MINGW32__)
+    defined(__linux__)
 # include <errno.h>
 # include <fcntl.h>
 # include <sys/types.h>
 # include <unistd.h>
+# define JENT_ARCH_FIPS_PROC
 #endif
 
 int jent_fips_enabled(void)
@@ -85,9 +93,7 @@ int jent_fips_enabled(void)
 	return FIPS_mode();
 #elif defined(OPENSSL)
 	return EVP_default_properties_is_fips_enabled(NULL);
-#elif defined(_MSC_VER) || defined(__MINGW32__)
-	return 0;
-#else
+#elif defined(JENT_ARCH_FIPS_PROC)
 #define FIPS_MODE_SWITCH_FILE "/proc/sys/crypto/fips_enabled"
 	char buf[2] = "0";
 	int fd = 0;
@@ -106,6 +112,13 @@ int jent_fips_enabled(void)
 	else
 		return 0;
 #undef FIPS_MODE_SWITCH_FILE
+#else
+	/*
+	 * No system-wide FIPS indicator on this platform (Windows, the BSDs,
+	 * macOS, AIX, Solaris, ...). Callers that need FIPS behaviour there ask
+	 * for it explicitly with the JENT_FORCE_FIPS flag.
+	 */
+	return 0;
 #endif
 }
 

--- a/arch/jitterentropy-arch-memory.c
+++ b/arch/jitterentropy-arch-memory.c
@@ -47,18 +47,6 @@
  */
 
 /*
- * GetProcessWorkingSetSizeEx() and SetProcessWorkingSetSizeEx() are declared by
- * the Windows SDK only from Windows Vista onwards. mingw-w64 has defaulted to
- * older values across its releases, so the minimum is stated here rather than
- * left to the toolchain; it has to precede every system header, including the
- * <windows.h> included below. An externally supplied, higher value is left
- * alone.
- */
-#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
-# define _WIN32_WINNT 0x0601
-#endif
-
-/*
  * MAP_ANONYMOUS, MAP_ANON and madvise()/MADV_DONTDUMP are all __USE_MISC on
  * glibc, so a strict -std=c11 - which the Makefile uses - hides them. Current
  * glibc happens to define MAP_ANONYMOUS unconditionally, which is why this was
@@ -141,16 +129,6 @@
 
 #endif /* JENT_ARCH_MEM_LINUX_KERNEL */
 
-#define JENT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-#define JENT_IS_POWER_OF_2(n) (JENT_BUILD_BUG_ON(((n) & ((n) - 1)) != 0))
-
-/*
- * Slack kept between the process minimum and maximum working set when the
- * Windows backend raises them (see jent_virtual_lock()). The maximum only has
- * to exceed the minimum; the value merely avoids pinning the two together.
- */
-#define JENT_WS_HEADROOM	65536
-
 /*
  * Whether the active backend provides secure (locked / wiped) memory. This
  * mirrors the dispatch priority in jent_zalloc() below: the crypto libraries
@@ -164,12 +142,33 @@
 # define JENT_MEM_SECURE
 #elif defined(LIBGCRYPT) || defined(OPENSSL)
 # define JENT_MEM_SECURE
+  /*
+   * The secure arena of these two - libgcrypt's secmem pool, OpenSSL's secure
+   * heap - is created by the application, so it can be absent altogether and
+   * it can run out. Either way the allocation comes back from the regular
+   * heap, which is the one thing that is not secure memory.
+   */
+# define JENT_MEM_SECURE_ON_REQUEST
 #elif defined(AWSLC)
   /* AWS-LC memory is wiped but not locked; not advertised as secure. */
-#elif (defined(JENT_ARCH_MEM_WINDOWS) || defined(JENT_ARCH_MEM_POSIX_MLOCK)) && \
-      !defined(JENT_CONF_RELAX_MLOCK)
+#elif defined(JENT_ARCH_MEM_WINDOWS) || defined(JENT_ARCH_MEM_POSIX_MLOCK)
 # define JENT_MEM_SECURE
+  /*
+   * Here it is the memory lock that provides the security property, and the
+   * lock is the one thing the environment can refuse.
+   */
+# define JENT_MEM_SECURE_ON_REQUEST
 #endif
+
+/*
+ * JENT_MEM_SECURE_ON_REQUEST marks the backends whose secure memory can be
+ * denied at runtime: the memory lock the environment refuses, and the arena
+ * the application did not provide. Only there does JENT_FORCE_SECURE_MEM
+ * have a meaning - it turns that denial from a silent fallback to
+ * unprotected memory into a failed allocation. The Linux kernel backend
+ * cannot be denied and AWS-LC never claimed to be secure, so neither
+ * consults the flag.
+ */
 
 int jent_secure_memory_supported(void)
 {
@@ -178,6 +177,26 @@ int jent_secure_memory_supported(void)
 #else
 	return 0;
 #endif
+}
+
+int jent_memory_is_secure(unsigned int flags)
+{
+#ifdef JENT_MEM_SECURE_ON_REQUEST
+	/*
+	 * Only JENT_FORCE_SECURE_MEM makes secure memory a condition of the
+	 * allocation and therefore a property the memory is known to have.
+	 * Without it the lock is still attempted and the secure arena still
+	 * tried first and, on a normal system, both still succeed - but whether
+	 * they did is not recorded, so the caller is told the conservative
+	 * answer.
+	 */
+	if (!(flags & JENT_FORCE_SECURE_MEM))
+		return 0;
+#else
+	(void)flags;
+#endif
+
+	return jent_secure_memory_supported();
 }
 
 void jent_memset_secure(void *s, size_t n)
@@ -194,7 +213,7 @@ void jent_memset_secure(void *s, size_t n)
 #endif
 }
 
-#if defined(JENT_ARCH_MEM_WINDOWS) && !defined(JENT_CONF_RELAX_MLOCK)
+#ifdef JENT_ARCH_MEM_WINDOWS
 static size_t jent_pagesize(void)
 {
 	SYSTEM_INFO si;
@@ -202,84 +221,7 @@ static size_t jent_pagesize(void)
 	GetSystemInfo(&si);
 	return si.dwPageSize;
 }
-
-/*
- * Lock @len bytes at @addr into RAM. Returns 0 on success.
- *
- * VirtualLock() charges its pages against the process *minimum* working set -
- * "the maximum number of pages a process can lock is equal to the number of
- * pages in its minimum working set minus a small overhead" - and fails with
- * ERROR_WORKING_SET_QUOTA once that budget is exhausted. Raising the minimum
- * is therefore part of locking, not an independent knob: without it every
- * request larger than the (small) default minimum working set failed and
- * jent_entropy_collector_alloc() returned EMEM - which is what a JENT_CACHE_ALL
- * collector, asking for the summed L1+L2+L3 size, ran into on every machine.
- *
- * The limits are read and extended rather than set to a fixed size: they are
- * process-wide, so overwriting them would evict the working set the host
- * application has reserved for itself. dwMaximumWorkingSetSize must stay
- * strictly greater than dwMinimumWorkingSetSize, otherwise the call is
- * rejected with ERROR_INVALID_PARAMETER.
- *
- * The same applies to the quota flags, which is why they are read back with
- * GetProcessWorkingSetSizeEx() and handed to SetProcessWorkingSetSizeEx()
- * unchanged. The non-Ex getter used here before cannot report them, so the
- * flags argument was a fixed QUOTA_LIMITS_HARDWS_MIN_ENABLE: that silently
- * replaced whatever quota policy the host application had established and left
- * the process with a hard working-set floor - one this code never lowers again
- * - as a side effect of allocating an entropy collector. Raising the minimum is
- * what lifts the lock quota; making that minimum a hard limit is not required
- * for it and is not a library's decision to make.
- *
- * The raise happens only after a lock has actually failed, and the quota is
- * not lowered again on free (another thread may have locked memory against it
- * in the meantime). Growing on demand is what keeps a repeated
- * allocate/free cycle from ratcheting the process working set up without
- * bound: once the quota covers the collector, every later lock succeeds on
- * the first attempt.
- */
-static int jent_virtual_lock(void *addr, size_t len)
-{
-	SIZE_T minWS = 0, maxWS = 0, want_min, want_max;
-	DWORD ws_flags = 0;
-
-	if (VirtualLock(addr, len))
-		return 0;
-	if (GetLastError() != ERROR_WORKING_SET_QUOTA)
-		return -1;
-
-	if (!GetProcessWorkingSetSizeEx(GetCurrentProcess(), &minWS, &maxWS,
-					&ws_flags))
-		return -1;
-
-	/*
-	 * A process that has never had its quota configured reports
-	 * QUOTA_LIMITS_HARDWS_MIN_DISABLE | QUOTA_LIMITS_HARDWS_MAX_DISABLE,
-	 * i.e. soft limits on both ends - which is all VirtualLock() needs.
-	 * Should an implementation ever answer with no flags at all, name the
-	 * documented default explicitly rather than forwarding a zero the
-	 * setter may reject with ERROR_INVALID_PARAMETER.
-	 */
-	if (!ws_flags)
-		ws_flags = QUOTA_LIMITS_HARDWS_MIN_DISABLE |
-			   QUOTA_LIMITS_HARDWS_MAX_DISABLE;
-
-	/* Headroom above the new minimum, and the guard against wrapping. */
-	if (len > (SIZE_T)-1 - minWS)
-		return -1;
-	want_min = minWS + len;
-	if (want_min > (SIZE_T)-1 - JENT_WS_HEADROOM)
-		return -1;
-	want_max = (maxWS > want_min + JENT_WS_HEADROOM) ?
-		   maxWS : want_min + JENT_WS_HEADROOM;
-
-	if (!SetProcessWorkingSetSizeEx(GetCurrentProcess(), want_min, want_max,
-					ws_flags))
-		return -1;
-
-	return VirtualLock(addr, len) ? 0 : -1;
-}
-#endif /* JENT_ARCH_MEM_WINDOWS && !JENT_CONF_RELAX_MLOCK */
+#endif /* JENT_ARCH_MEM_WINDOWS */
 
 #ifdef JENT_ARCH_MEM_POSIX_MLOCK
 /* Some BSDs / macOS only provide the older MAP_ANON spelling. */
@@ -297,8 +239,10 @@ static size_t jent_pagesize(void)
 
 #ifdef JENT_ARCH_MEM_LINUX_KERNEL
 
-void *jent_zalloc(size_t len)
+void *jent_zalloc(size_t len, unsigned int flags)
 {
+	/* Kernel memory is not paged out, so there is nothing to relax. */
+	(void)flags;
 	return kvzalloc(len, GFP_KERNEL);
 }
 
@@ -309,35 +253,51 @@ void jent_zfree(void *ptr, size_t len)
 
 #else /* !JENT_ARCH_MEM_LINUX_KERNEL */
 
-void *jent_zalloc(size_t len)
+void *jent_zalloc(size_t len, unsigned int flags)
 {
 	void *tmp = NULL;
+
+#ifndef JENT_MEM_SECURE_ON_REQUEST
+	/* Only a backend that can be denied secure memory reads the flag. */
+	(void)flags;
+#endif
 
 #ifdef LIBGCRYPT
 
 	/*
-	 * Set the maximum usable locked memory to 2 MiB at first call.
+	 * The secmem pool is not initialized here: it is created once per
+	 * process with GCRYCTL_INIT_SECMEM, which fixes its size for every
+	 * user of libgcrypt in that process, and libgcrypt has to be
+	 * initialized (gcry_check_version(), GCRYCTL_INITIALIZATION_FINISHED)
+	 * by the application anyway. Sizing it from in here would overrule a
+	 * decision that is not the library's to make - see
+	 * arch/jitterentropy-arch-memory.h.
 	 *
-	 * You may have to adapt or delete this if you also use libgcrypt
-	 * elsewhere in your software!
-	 */
-	if (!gcry_control(GCRYCTL_INITIALIZATION_FINISHED_P)) {
-		gcry_control(GCRYCTL_INIT_SECMEM, JENT_SECURE_MEMORY_SIZE_MAX, 0);
-		gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
-	}
-	/*
-	 * When using the libgcrypt secure memory mechanism, all precautions
-	 * are taken to protect our state. If the user disables secmem during
-	 * runtime, it is their decision and we thus try not to overrule that
-	 * decision for less memory protection.
-	 */
-	/*
 	 * gcry_malloc_secure(), not gcry_xmalloc_secure(): the x-variant
 	 * invokes libgcrypt's fatal out-of-core handler when the secmem pool
 	 * is exhausted, terminating the host process from inside the library.
 	 * The NULL return is handled by all callers.
 	 */
 	tmp = gcry_malloc_secure(len);
+
+	/*
+	 * Check that the memory really came out of the pool. libgcrypt returns
+	 * NULL when the pool is absent or exhausted, so this is the belt to
+	 * the braces.
+	 */
+	if (tmp && !gcry_is_secure(tmp)) {
+		gcry_free(tmp);
+		tmp = NULL;
+	}
+
+	/*
+	 * No pool, or none left in it: fall back to ordinary memory, which is
+	 * what an application that did not configure secmem asks for by not
+	 * setting the flag. jent_memory_is_secure() reports the same
+	 * distinction to the caller, and jent_zfree() releases either kind.
+	 */
+	if (!tmp && !(flags & JENT_FORCE_SECURE_MEM))
+		tmp = gcry_malloc(len);
 
 #elif defined(AWSLC)
 
@@ -346,17 +306,14 @@ void *jent_zalloc(size_t len)
 #elif defined(OPENSSL)
 
 	/*
-	 * Initialize OpenSSL secure malloc here only if not already done.
-	 * The 2 MiB max reserved is sufficient for jitterentropy but probably
-	 * too small for a whole application doing crypto operations with
-	 * OpenSSL. Both min and max value must be a power of 2; min must be
-	 * smaller than max.
+	 * The secure heap is not initialized here: CRYPTO_secure_malloc_init()
+	 * reserves one arena for the whole process whose size cannot be
+	 * changed afterwards, so the size belongs to the application, which
+	 * knows what else in the process allocates from it - see
+	 * arch/jitterentropy-arch-memory.h. Only its presence is checked.
 	 */
-	JENT_IS_POWER_OF_2(JENT_SECURE_MEMORY_SIZE_MAX);
-	if (CRYPTO_secure_malloc_initialized() ||
-	    CRYPTO_secure_malloc_init(JENT_SECURE_MEMORY_SIZE_MAX, 32)) {
+	if (CRYPTO_secure_malloc_initialized())
 		tmp = OPENSSL_secure_malloc(len);
-	}
 	/*
 	 * If secure memory was not available, OpenSSL falls back to "normal"
 	 * memory. Double check.
@@ -366,9 +323,19 @@ void *jent_zalloc(size_t len)
 		tmp = NULL;
 	}
 
+	/*
+	 * No secure heap, or none left in it: fall back to ordinary memory,
+	 * which is what an application that did not configure the secure heap
+	 * asks for by not setting the flag. jent_memory_is_secure() reports the
+	 * same distinction to the caller, and jent_zfree() releases either kind
+	 * - OPENSSL_secure_free() forwards a pointer that is not in the arena
+	 * to the regular free().
+	 */
+	if (!tmp && !(flags & JENT_FORCE_SECURE_MEM))
+		tmp = OPENSSL_malloc(len);
+
 #elif defined(JENT_ARCH_MEM_WINDOWS)
 
-# ifndef JENT_CONF_RELAX_MLOCK
 	{
 		/*
 		 * Guard-page layout as on the POSIX path: commit the whole
@@ -398,14 +365,39 @@ void *jent_zalloc(size_t len)
 
 		tmp = base + page_size;
 
-		if (jent_virtual_lock(tmp, payload)) {
+		/*
+		 * A refused lock is only an error when the caller demanded
+		 * the lock. Either way the mapping and its guard pages are
+		 * the same, so jent_zfree() needs no knowledge of the flag.
+		 *
+		 * VirtualLock() charges its pages against the process
+		 * *minimum* working set - "the maximum number of pages a
+		 * process can lock is equal to the number of pages in its
+		 * minimum working set minus a small overhead" - and fails
+		 * with ERROR_WORKING_SET_QUOTA once that budget is exhausted.
+		 * The default minimum is smaller than the memory block of a
+		 * collector asking for a large size (most visibly a
+		 * JENT_CACHE_ALL one, which asks for the summed L1+L2+L3
+		 * size), so with JENT_FORCE_SECURE_MEM such an allocation
+		 * fails unless the quota has been raised beforehand.
+		 *
+		 * Raising it is deliberately not done here: the working set
+		 * limits are process-wide state, extending them evicts the
+		 * working set the host application has reserved for itself,
+		 * and they cannot be restored on free (another thread may
+		 * have locked memory against the raised quota in the
+		 * meantime). That is the application's decision to make, just
+		 * as RLIMIT_MEMLOCK is on the POSIX path below. The recording
+		 * tools - which own their process - raise both for the
+		 * compliance modes in
+		 * tests/raw-entropy/recording_userspace/jitterentropy-memlock.h.
+		 */
+		if (!VirtualLock(tmp, payload) &&
+		    (flags & JENT_FORCE_SECURE_MEM)) {
 			VirtualFree(base, 0, MEM_RELEASE);
 			return NULL;
 		}
 	}
-# else
-	tmp = malloc(len);
-# endif
 
 #elif defined(JENT_ARCH_MEM_POSIX_MLOCK)
 
@@ -495,16 +487,30 @@ void *jent_zalloc(size_t len)
 		 * Prevent paging out of the memory state to swap space. If
 		 * this fails, check the current memory lock limits and
 		 * capabilities (e.g. RLIMIT_MEMLOCK and CAP_IPC_LOCK).
+		 *
+		 * With JENT_FORCE_SECURE_MEM the caller demanded the lock and
+		 * any failure fails the allocation. Without it the errors that
+		 * say the environment does not permit locking are tolerated,
+		 * but not one that indicates a malformed request (EINVAL),
+		 * which would be a bug here rather than a property of the
+		 * environment:
+		 *
+		 *  - EPERM:  no privilege, which is what Linux reports for a
+		 *            RLIMIT_MEMLOCK of 0 without CAP_IPC_LOCK.
+		 *  - ENOMEM: the limit would be exceeded - the case of a
+		 *            container with a small but non-zero
+		 *            RLIMIT_MEMLOCK on Linux and of the per-process
+		 *            and system limits on the BSDs. It cannot mean
+		 *            "range not mapped" here, the mapping was just
+		 *            established above.
+		 *  - EAGAIN: the same condition on macOS.
+		 *
+		 * The mapping itself is unaffected by the flag, so
+		 * jent_zfree() needs no knowledge of it.
 		 */
-# ifndef JENT_CONF_RELAX_MLOCK
-		if (mlock(tmp, len)) {
-# else
-		/*
-		 * Use this only for CI or restricted containers if not
-		 * possible otherwise.
-		 */
-		if (mlock(tmp, len) && errno != EPERM && errno != EAGAIN) {
-# endif
+		if (mlock(tmp, len) &&
+		    ((flags & JENT_FORCE_SECURE_MEM) ||
+		     (errno != EPERM && errno != ENOMEM && errno != EAGAIN))) {
 			munmap(base, total);
 			return NULL;
 		}
@@ -526,10 +532,13 @@ void jent_zfree(void *ptr, size_t len)
 #ifdef LIBGCRYPT
 
 	/*
-	 * gcry_free automatically wipes memory allocated with
-	 * gcry_(x)malloc_secure.
+	 * gcry_free() automatically wipes memory allocated with
+	 * gcry_(x)malloc_secure(), but not the ordinary memory jent_zalloc()
+	 * falls back to when the pool is unavailable - that is the one case
+	 * this has to wipe itself. gcry_free() releases either kind.
 	 */
-	(void)len;
+	if (!gcry_is_secure(ptr))
+		jent_memset_secure(ptr, len);
 	gcry_free(ptr);
 
 #elif defined(AWSLC)
@@ -543,17 +552,28 @@ void jent_zfree(void *ptr, size_t len)
 
 #elif defined(OPENSSL)
 
-	OPENSSL_cleanse(ptr, len);
+	/*
+	 * OPENSSL_secure_free() clears what it takes back into the secure
+	 * heap, so only the ordinary memory jent_zalloc() falls back to when
+	 * the heap is unavailable is wiped here - the same pointer that
+	 * OPENSSL_secure_free() forwards to the regular free().
+	 */
+	if (!CRYPTO_secure_allocated(ptr))
+		jent_memset_secure(ptr, len);
 	OPENSSL_secure_free(ptr);
 
 #elif defined(JENT_ARCH_MEM_WINDOWS)
 
 	SecureZeroMemory(ptr, len);
-# ifndef JENT_CONF_RELAX_MLOCK
 	{
 		/*
 		 * Mirror the guard-page layout of jent_zalloc(): the region
 		 * starts one page before the returned pointer.
+		 *
+		 * VirtualUnlock() on a region that was never locked (the
+		 * allocation was made without JENT_FORCE_SECURE_MEM and the
+		 * lock failed) reports ERROR_NOT_LOCKED and does nothing else,
+		 * which is why the free path does not need the flag.
 		 */
 		size_t page_size = jent_pagesize();
 		size_t payload = (len + page_size - 1) & ~(page_size - 1);
@@ -562,9 +582,6 @@ void jent_zfree(void *ptr, size_t len)
 		VirtualUnlock(ptr, payload);
 		VirtualFree(base, 0, MEM_RELEASE);
 	}
-# else
-	free(ptr);
-# endif
 
 #elif defined(JENT_ARCH_MEM_POSIX_MLOCK)
 
@@ -598,7 +615,3 @@ void jent_zfree(void *ptr, size_t len)
 }
 
 #endif /* JENT_ARCH_MEM_LINUX_KERNEL */
-
-#undef JENT_WS_HEADROOM
-#undef JENT_IS_POWER_OF_2
-#undef JENT_BUILD_BUG_ON

--- a/arch/jitterentropy-arch-memory.c
+++ b/arch/jitterentropy-arch-memory.c
@@ -46,19 +46,66 @@
  * DAMAGE.
  */
 
+/*
+ * GetProcessWorkingSetSizeEx() and SetProcessWorkingSetSizeEx() are declared by
+ * the Windows SDK only from Windows Vista onwards. mingw-w64 has defaulted to
+ * older values across its releases, so the minimum is stated here rather than
+ * left to the toolchain; it has to precede every system header, including the
+ * <windows.h> included below. An externally supplied, higher value is left
+ * alone.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
+/*
+ * MAP_ANONYMOUS, MAP_ANON and madvise()/MADV_DONTDUMP are all __USE_MISC on
+ * glibc, so a strict -std=c11 - which the Makefile uses - hides them. Current
+ * glibc happens to define MAP_ANONYMOUS unconditionally, which is why this was
+ * only noticed on glibc 2.17 (RHEL 7), where neither spelling exists and the
+ * MAP_ANON fallback below expands to an undeclared identifier.
+ *
+ * _DEFAULT_SOURCE is the modern spelling and _BSD_SOURCE the one glibc before
+ * 2.19 understands; both are defined because 2.17 ignores the former and
+ * everything from 2.20 on warns about the latter unless the former is present
+ * too. Defined here rather than in the public jitterentropy.h so the header
+ * imposes no feature-test macro on consumers; they must precede every system
+ * header. Same reasoning as arch/jitterentropy-arch-timer.c.
+ */
+#if defined(__linux__)
+# ifndef _DEFAULT_SOURCE
+#  define _DEFAULT_SOURCE
+# endif
+# ifndef _BSD_SOURCE
+#  define _BSD_SOURCE
+# endif
+#endif
+
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 
 /*
  * Platform detection.
+ *
+ * The POSIX backend is selected from the option macros the platform itself
+ * publishes in <unistd.h>, not from a list of operating systems.
+ *
+ * _POSIX_MEMLOCK_RANGE is required to be strictly positive rather than merely
+ * not -1: a value of 0 means "ask sysconf() at runtime", and since a failed
+ * mlock() makes jent_zalloc() fail the allocation outright, such a platform is
+ * better served by the malloc() path than by an allocator that might refuse
+ * every request.
  */
 #ifdef LINUX_KERNEL
 # define JENT_ARCH_MEM_LINUX_KERNEL
+#elif defined(_MSC_VER) || defined(__MINGW32__)
+# define JENT_ARCH_MEM_WINDOWS
 #else
-# if defined(_MSC_VER) || defined(__MINGW32__)
-#  define JENT_ARCH_MEM_WINDOWS
-# elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
-       defined(__NetBSD__) || defined(__APPLE__)
+# include <unistd.h>
+# if defined(_POSIX_MAPPED_FILES) && (_POSIX_MAPPED_FILES - 0) > 0 &&	      \
+     defined(_POSIX_MEMORY_PROTECTION) &&				      \
+     (_POSIX_MEMORY_PROTECTION - 0) > 0 &&				      \
+     defined(_POSIX_MEMLOCK_RANGE) && (_POSIX_MEMLOCK_RANGE - 0) > 0
 #  define JENT_ARCH_MEM_POSIX_MLOCK
 # endif
 #endif
@@ -96,6 +143,13 @@
 
 #define JENT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
 #define JENT_IS_POWER_OF_2(n) (JENT_BUILD_BUG_ON(((n) & ((n) - 1)) != 0))
+
+/*
+ * Slack kept between the process minimum and maximum working set when the
+ * Windows backend raises them (see jent_virtual_lock()). The maximum only has
+ * to exceed the minimum; the value merely avoids pinning the two together.
+ */
+#define JENT_WS_HEADROOM	65536
 
 /*
  * Whether the active backend provides secure (locked / wiped) memory. This
@@ -140,7 +194,7 @@ void jent_memset_secure(void *s, size_t n)
 #endif
 }
 
-#ifdef JENT_ARCH_MEM_WINDOWS
+#if defined(JENT_ARCH_MEM_WINDOWS) && !defined(JENT_CONF_RELAX_MLOCK)
 static size_t jent_pagesize(void)
 {
 	SYSTEM_INFO si;
@@ -148,7 +202,84 @@ static size_t jent_pagesize(void)
 	GetSystemInfo(&si);
 	return si.dwPageSize;
 }
-#endif /* JENT_ARCH_MEM_WINDOWS */
+
+/*
+ * Lock @len bytes at @addr into RAM. Returns 0 on success.
+ *
+ * VirtualLock() charges its pages against the process *minimum* working set -
+ * "the maximum number of pages a process can lock is equal to the number of
+ * pages in its minimum working set minus a small overhead" - and fails with
+ * ERROR_WORKING_SET_QUOTA once that budget is exhausted. Raising the minimum
+ * is therefore part of locking, not an independent knob: without it every
+ * request larger than the (small) default minimum working set failed and
+ * jent_entropy_collector_alloc() returned EMEM - which is what a JENT_CACHE_ALL
+ * collector, asking for the summed L1+L2+L3 size, ran into on every machine.
+ *
+ * The limits are read and extended rather than set to a fixed size: they are
+ * process-wide, so overwriting them would evict the working set the host
+ * application has reserved for itself. dwMaximumWorkingSetSize must stay
+ * strictly greater than dwMinimumWorkingSetSize, otherwise the call is
+ * rejected with ERROR_INVALID_PARAMETER.
+ *
+ * The same applies to the quota flags, which is why they are read back with
+ * GetProcessWorkingSetSizeEx() and handed to SetProcessWorkingSetSizeEx()
+ * unchanged. The non-Ex getter used here before cannot report them, so the
+ * flags argument was a fixed QUOTA_LIMITS_HARDWS_MIN_ENABLE: that silently
+ * replaced whatever quota policy the host application had established and left
+ * the process with a hard working-set floor - one this code never lowers again
+ * - as a side effect of allocating an entropy collector. Raising the minimum is
+ * what lifts the lock quota; making that minimum a hard limit is not required
+ * for it and is not a library's decision to make.
+ *
+ * The raise happens only after a lock has actually failed, and the quota is
+ * not lowered again on free (another thread may have locked memory against it
+ * in the meantime). Growing on demand is what keeps a repeated
+ * allocate/free cycle from ratcheting the process working set up without
+ * bound: once the quota covers the collector, every later lock succeeds on
+ * the first attempt.
+ */
+static int jent_virtual_lock(void *addr, size_t len)
+{
+	SIZE_T minWS = 0, maxWS = 0, want_min, want_max;
+	DWORD ws_flags = 0;
+
+	if (VirtualLock(addr, len))
+		return 0;
+	if (GetLastError() != ERROR_WORKING_SET_QUOTA)
+		return -1;
+
+	if (!GetProcessWorkingSetSizeEx(GetCurrentProcess(), &minWS, &maxWS,
+					&ws_flags))
+		return -1;
+
+	/*
+	 * A process that has never had its quota configured reports
+	 * QUOTA_LIMITS_HARDWS_MIN_DISABLE | QUOTA_LIMITS_HARDWS_MAX_DISABLE,
+	 * i.e. soft limits on both ends - which is all VirtualLock() needs.
+	 * Should an implementation ever answer with no flags at all, name the
+	 * documented default explicitly rather than forwarding a zero the
+	 * setter may reject with ERROR_INVALID_PARAMETER.
+	 */
+	if (!ws_flags)
+		ws_flags = QUOTA_LIMITS_HARDWS_MIN_DISABLE |
+			   QUOTA_LIMITS_HARDWS_MAX_DISABLE;
+
+	/* Headroom above the new minimum, and the guard against wrapping. */
+	if (len > (SIZE_T)-1 - minWS)
+		return -1;
+	want_min = minWS + len;
+	if (want_min > (SIZE_T)-1 - JENT_WS_HEADROOM)
+		return -1;
+	want_max = (maxWS > want_min + JENT_WS_HEADROOM) ?
+		   maxWS : want_min + JENT_WS_HEADROOM;
+
+	if (!SetProcessWorkingSetSizeEx(GetCurrentProcess(), want_min, want_max,
+					ws_flags))
+		return -1;
+
+	return VirtualLock(addr, len) ? 0 : -1;
+}
+#endif /* JENT_ARCH_MEM_WINDOWS && !JENT_CONF_RELAX_MLOCK */
 
 #ifdef JENT_ARCH_MEM_POSIX_MLOCK
 /* Some BSDs / macOS only provide the older MAP_ANON spelling. */
@@ -239,59 +370,37 @@ void *jent_zalloc(size_t len)
 
 # ifndef JENT_CONF_RELAX_MLOCK
 	{
-		size_t minWS, maxWS;
-
-		JENT_BUILD_BUG_ON(JENT_SECURE_MEMORY_SIZE_MAX / 2 == 0);
 		/*
-		 * On query failure assume a zero working set so the raise
-		 * below always runs; the outputs are uninitialized otherwise.
+		 * Guard-page layout as on the POSIX path: commit the whole
+		 * region inaccessible and enable only the payload, leaving a
+		 * PAGE_NOACCESS guard page on each side that faults on any
+		 * accidental access beyond the state.
 		 */
-		if (!GetProcessWorkingSetSize(GetCurrentProcess(), &minWS,
-					      &maxWS))
-			minWS = maxWS = 0;
-		if (maxWS < JENT_SECURE_MEMORY_SIZE_MAX &&
-		    !SetProcessWorkingSetSizeEx(
-			GetCurrentProcess(),
-			JENT_SECURE_MEMORY_SIZE_MAX / 2,
-			JENT_SECURE_MEMORY_SIZE_MAX,
-			QUOTA_LIMITS_HARDWS_MIN_ENABLE))
+		size_t page_size = jent_pagesize();
+		size_t payload, total;
+		uint8_t *base;
+		DWORD oldprot;
+
+		if (len > (size_t)-1 - 3 * page_size)
 			return NULL;
+		payload = (len + page_size - 1) & ~(page_size - 1);
+		total = payload + 2 * page_size;
 
-		{
-			/*
-			 * Guard-page layout as on the POSIX path: commit the
-			 * whole region inaccessible and enable only the
-			 * payload, leaving a PAGE_NOACCESS guard page on each
-			 * side that faults on any accidental access beyond
-			 * the state.
-			 */
-			size_t page_size = jent_pagesize();
-			size_t payload, total;
-			uint8_t *base;
-			DWORD oldprot;
+		base = VirtualAlloc(NULL, total, MEM_COMMIT | MEM_RESERVE,
+				    PAGE_NOACCESS);
+		if (!base)
+			return NULL;
+		if (!VirtualProtect(base + page_size, payload, PAGE_READWRITE,
+				    &oldprot)) {
+			VirtualFree(base, 0, MEM_RELEASE);
+			return NULL;
+		}
 
-			if (len > (size_t)-1 - 3 * page_size)
-				return NULL;
-			payload = (len + page_size - 1) & ~(page_size - 1);
-			total = payload + 2 * page_size;
+		tmp = base + page_size;
 
-			base = VirtualAlloc(NULL, total,
-					    MEM_COMMIT | MEM_RESERVE,
-					    PAGE_NOACCESS);
-			if (!base)
-				return NULL;
-			if (!VirtualProtect(base + page_size, payload,
-					    PAGE_READWRITE, &oldprot)) {
-				VirtualFree(base, 0, MEM_RELEASE);
-				return NULL;
-			}
-
-			tmp = base + page_size;
-
-			if (!VirtualLock(tmp, payload)) {
-				VirtualFree(base, 0, MEM_RELEASE);
-				return NULL;
-			}
+		if (jent_virtual_lock(tmp, payload)) {
+			VirtualFree(base, 0, MEM_RELEASE);
+			return NULL;
 		}
 	}
 # else
@@ -304,29 +413,59 @@ void *jent_zalloc(size_t len)
 		/*
 		 * Layout: [guard page | payload (page-rounded) | guard page]
 		 *
-		 * The whole region is mapped PROT_NONE first and only the
-		 * payload is made accessible, leaving one inaccessible guard
-		 * page on each side: any accidental access beyond the state
-		 * faults immediately instead of silently reading or
-		 * corrupting adjacent data. The page-aligned payload is also
-		 * what allows the madvise() dump exclusion below.
+		 * One inaccessible guard page on each side of the payload, so
+		 * that any accidental access beyond the state faults
+		 * immediately instead of silently reading or corrupting
+		 * adjacent data. The page-aligned payload is also what allows
+		 * the madvise() dump exclusion below.
+		 *
+		 * The region is mapped readable and writable and the two guard
+		 * pages are then protected *down* to PROT_NONE. The reverse -
+		 * map the whole region PROT_NONE and raise the payload to
+		 * PROT_READ|PROT_WRITE - is the more common spelling of this
+		 * idiom and is what this code did until NetBSD rejected it:
+		 * mprotect() there returns EACCES, "the requested protection
+		 * would exceed the maximum protection allowed on the region",
+		 * because NetBSD clamps a mapping's maximum protection to the
+		 * protection mmap() was called with. A region mapped PROT_NONE
+		 * can then never be made accessible again, so jent_zalloc()
+		 * failed every allocation on that platform and every caller
+		 * reported it as an out-of-memory condition.
+		 *
+		 * Lowering protection is permitted everywhere, so this order
+		 * needs no platform conditional and reaches the same final
+		 * layout. The guard pages are briefly writable, which is not
+		 * observable: the mapping is fresh and its address has not
+		 * been handed out yet.
 		 */
 		size_t page_size = jent_pagesize();
 		size_t payload, total;
 		uint8_t *base;
+		/*
+		 * OpenBSD excludes a mapping from core dumps at mmap() time
+		 * rather than through madvise(); it has no MADV_DONTDUMP or
+		 * MADV_NOCORE. The flag is the OpenBSD counterpart of the
+		 * madvise() call below.
+		 */
+		int mmap_flags = MAP_PRIVATE | MAP_ANONYMOUS;
+
+# ifdef MAP_CONCEAL
+		mmap_flags |= MAP_CONCEAL;
+# endif
 
 		if (len > SIZE_MAX - 3 * page_size)
 			return NULL;
 		payload = (len + page_size - 1) & ~(page_size - 1);
 		total = payload + 2 * page_size;
 
-		base = mmap(NULL, total, PROT_NONE,
-			    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		base = mmap(NULL, total, PROT_READ | PROT_WRITE, mmap_flags,
+			    -1, 0);
 		if (base == MAP_FAILED)
 			return NULL;
 
-		if (mprotect(base + page_size, payload,
-			     PROT_READ | PROT_WRITE)) {
+		if (mprotect(base, page_size, PROT_NONE) ||
+		    mprotect(base + page_size + payload, page_size,
+			     PROT_NONE)) {
 			munmap(base, total);
 			return NULL;
 		}
@@ -339,6 +478,12 @@ void *jent_zalloc(size_t len)
 		 * (e.g. old kernels) does not fail the allocation. No revert
 		 * is needed on free: munmap() destroys the mapping including
 		 * its madvise state.
+		 *
+		 * macOS provides no equivalent - it has neither MADV_DONTDUMP
+		 * nor MADV_NOCORE nor MAP_CONCEAL - so on that platform the
+		 * state stays mlock()ed but is not excluded from a core dump.
+		 * The only lever there is process-wide (RLIMIT_CORE), which is
+		 * the application's decision to make, not a library's.
 		 */
 # if defined(MADV_DONTDUMP)
 		madvise(tmp, len, MADV_DONTDUMP);	/* Linux */
@@ -454,5 +599,6 @@ void jent_zfree(void *ptr, size_t len)
 
 #endif /* JENT_ARCH_MEM_LINUX_KERNEL */
 
+#undef JENT_WS_HEADROOM
 #undef JENT_IS_POWER_OF_2
 #undef JENT_BUILD_BUG_ON

--- a/arch/jitterentropy-arch-memory.h
+++ b/arch/jitterentropy-arch-memory.h
@@ -89,9 +89,14 @@ void *jent_zalloc(size_t len);
 void jent_zfree(void *ptr, size_t len);
 
 /*
- * Return whether the active memory backend provides secure (locked / wiped)
- * memory. Also declared in the public jitterentropy.h.
+ * jent_secure_memory_supported() - which reports whether the active backend
+ * provides locked / wiped memory - is part of the public API and is declared
+ * once, in jitterentropy.h. It is deliberately not repeated here: that
+ * declaration carries JENT_PRIVATE_STATIC, and an undecorated copy in this
+ * header silently dropped the attribute again ("redeclared without dllimport
+ * attribute: previous dllimport ignored" on a Windows shared build). Like the
+ * size_t above, it reaches every user of this header through jitterentropy.h,
+ * which src/jitterentropy-internal.h includes first.
  */
-int jent_secure_memory_supported(void);
 
 #endif /* _JITTERENTROPY_ARCH_MEMORY_H */

--- a/arch/jitterentropy-arch-memory.h
+++ b/arch/jitterentropy-arch-memory.h
@@ -43,11 +43,12 @@
  * Architecture / OS-specific secure memory management.
  *
  * Provides (defined in arch/jitterentropy-arch-memory.c):
- *   - jent_zalloc(len): allocate zeroed memory, locked into RAM where the
- *     platform supports it (mlock, VirtualLock, libgcrypt secmem, OpenSSL
- *     secure heap, ...).
- *   - raise JENT_SECURE_MEMORY_SIZE_MAX (and the memlock limits) when
- *     requesting memory sizes beyond the default secure-arena capacity.
+ *   - jent_zalloc(len, flags): allocate zeroed memory, locked into RAM where
+ *     the platform supports it (mlock, VirtualLock, libgcrypt secmem, OpenSSL
+ *     secure heap, ...). flags are the collector flags; only
+ *     JENT_FORCE_SECURE_MEM is consulted, which turns secure memory the
+ *     environment does not grant from a (silent) fallback to ordinary memory
+ *     into an allocation failure.
  *   - jent_zfree(ptr, len): zero and release memory previously allocated
  *     with jent_zalloc().
  *   - jent_memset_secure(s, n): wipe a buffer in a way the compiler may
@@ -58,18 +59,42 @@
  *   - AWSLC         -> OPENSSL_malloc / OPENSSL_free (auto-wipe)
  *   - OPENSSL       -> OPENSSL_secure_malloc / OPENSSL_secure_free
  *   - Windows       -> VirtualAlloc + VirtualLock with PAGE_NOACCESS guard
- *                      pages around the payload (or plain malloc with
- *                      JENT_CONF_RELAX_MLOCK)
+ *                      pages around the payload
  *   - Linux/BSD/Mac -> mmap + mlock with PROT_NONE guard pages around the
  *                      payload; additionally excluded from core dumps via
  *                      madvise(MADV_DONTDUMP) on Linux and
- *                      madvise(MADV_NOCORE) on FreeBSD, best effort. With
- *                      JENT_CONF_RELAX_MLOCK only the mlock failure is
- *                      tolerated; the layout is unchanged.
+ *                      madvise(MADV_NOCORE) on FreeBSD, best effort.
  *   - Linux Kernel  -> kvmalloc + kvfree_sensitive; counts as secure since
  *                      kernel memory is never paged out to swap, does not
  *                      appear in user space core dumps and is wiped on free
  *   - other         -> plain malloc
+ *
+ * Secure memory can be denied at runtime on four of these backends: Windows
+ * and POSIX mlock, where the operating system refuses the memory lock, and
+ * libgcrypt and OpenSSL, where the secure arena the allocation would come out
+ * of is absent or exhausted. All four then fall back to ordinary memory unless
+ * the caller set JENT_FORCE_SECURE_MEM, which makes the same situation fail
+ * the allocation. Only that one property differs: on the mlock backends the
+ * guard-page layout and the dump exclusion are established either way, and on
+ * the crypto backends the free path tells the two kinds of pointer apart by
+ * itself, which is why jent_zfree() does not take the flags.
+ *
+ * How much memory may be locked is a property of the environment that the
+ * library does not change: RLIMIT_MEMLOCK on POSIX and the process working set
+ * quota on Windows, both process-wide state that belongs to the application.
+ * An application that needs a large collector locked (JENT_FORCE_SECURE_MEM
+ * with JENT_CACHE_ALL, say) raises them itself before the allocation; the
+ * recording tools do so in
+ * tests/raw-entropy/recording_userspace/jitterentropy-memlock.h.
+ *
+ * The secure memory arenas of libgcrypt and OpenSSL are the same kind of
+ * process-wide state and are likewise left to the application: libgcrypt's
+ * secmem pool is created once with GCRYCTL_INIT_SECMEM and OpenSSL's secure
+ * heap once with CRYPTO_secure_malloc_init(). A size chosen here would bound
+ * every other user of those libraries in the process - and could not be
+ * applied at all once the application had configured them itself - so
+ * jent_zalloc() only checks that the allocation came out of a configured
+ * arena. The recording tools configure the arena in the same header.
  *
  * Whether the active path provides locked / wiped memory is reported at
  * runtime by jent_secure_memory_supported() (defined in
@@ -79,14 +104,20 @@
 #ifndef _JITTERENTROPY_ARCH_MEMORY_H
 #define _JITTERENTROPY_ARCH_MEMORY_H
 
-/* Override this if you want to allocate more than 2 MB of secure memory */
-#ifndef JENT_SECURE_MEMORY_SIZE_MAX
-# define JENT_SECURE_MEMORY_SIZE_MAX 2097152
-#endif
-
 void jent_memset_secure(void *s, size_t n);
-void *jent_zalloc(size_t len);
+void *jent_zalloc(size_t len, unsigned int flags);
 void jent_zfree(void *ptr, size_t len);
+
+/*
+ * Whether an allocation made with @flags is known to yield secure memory: the
+ * backend capability reported by jent_secure_memory_supported(), narrowed to
+ * the callers that set JENT_FORCE_SECURE_MEM on the backends where that
+ * capability can be denied at runtime - only they are guaranteed to have got
+ * it. This is the question the library asks internally - the exported
+ * jent_secure_memory_supported() keeps reporting the backend alone, as it has
+ * no collector to consult.
+ */
+int jent_memory_is_secure(unsigned int flags);
 
 /*
  * jent_secure_memory_supported() - which reports whether the active backend

--- a/arch/jitterentropy-arch-ncpu.c
+++ b/arch/jitterentropy-arch-ncpu.c
@@ -43,6 +43,29 @@
  * DAMAGE.
  */
 
+/*
+ * _GNU_SOURCE exposes the Linux CPU-affinity interfaces used below on glibc
+ * (sched_getaffinity(), the CPU_* set macros). It is defined here, in the
+ * translation unit that needs it, rather than in the public jitterentropy.h so
+ * the installed header does not impose a feature-test macro on consumers; it
+ * must precede every system header.
+ */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+# define _GNU_SOURCE
+#endif
+
+/*
+ * GetActiveProcessorCount() and ALL_PROCESSOR_GROUPS are declared by the
+ * Windows SDK only when the translation unit asks for Windows 7 or newer.
+ * mingw-w64 has defaulted to older values across its releases, so the minimum
+ * is stated here rather than left to the toolchain; like _GNU_SOURCE above it
+ * must precede every system header, including the <windows.h> included below.
+ * An externally supplied, higher value is left alone.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 

--- a/arch/jitterentropy-arch-sched.c
+++ b/arch/jitterentropy-arch-sched.c
@@ -71,11 +71,23 @@
 #  include <x86intrin.h>
 # endif
 # define JENT_ARCH_SCHED_PAUSE_X86
+#elif defined(_M_ARM64) || defined(_M_ARM)
+/*
+ * Windows on ARM. MSVC defines neither __aarch64__ nor __arm__, so without
+ * these two macros the branch below did not match and a Windows-on-ARM build
+ * emitted no yield hint at all - the same pair jitterentropy-arch-timer.c
+ * matches for its QueryPerformanceCounter back-end. The hint goes through the
+ * intrinsic because MSVC rejects inline asm on ARM targets entirely.
+ */
+# include <intrin.h>
+# define JENT_ARCH_SCHED_PAUSE_ARM_INTRIN
 #elif defined(__aarch64__) || \
       (defined(__arm__) && defined(__ARM_ARCH) && __ARM_ARCH >= 7)
 # define JENT_ARCH_SCHED_PAUSE_ARM
 #elif defined(__powerpc) || defined(__powerpc__)
 # define JENT_ARCH_SCHED_PAUSE_POWERPC
+#elif defined(__riscv)
+# define JENT_ARCH_SCHED_PAUSE_RISCV
 #endif
 
 #endif /* LINUX_KERNEL */
@@ -84,10 +96,22 @@ void jent_yield(void)
 {
 #if defined(JENT_ARCH_SCHED_PAUSE_X86)
 	_mm_pause();
+#elif defined(JENT_ARCH_SCHED_PAUSE_ARM_INTRIN)
+	__yield();
 #elif defined(JENT_ARCH_SCHED_PAUSE_ARM)
 	__asm__ __volatile__("yield" ::: "memory");
 #elif defined(JENT_ARCH_SCHED_PAUSE_POWERPC)
 	__asm__ __volatile__("or 27,27,27" ::: "memory");
+#elif defined(JENT_ARCH_SCHED_PAUSE_RISCV)
+	/*
+	 * The Zihintpause "pause" hint, spelled as its raw encoding rather than
+	 * as the mnemonic. The assembler only accepts "pause" when the
+	 * extension is enabled in the target's -march string, which it usually
+	 * is not; the instruction itself is architecturally a FENCE hint and so
+	 * executes as a no-op on hardware that predates Zihintpause. Emitting
+	 * the encoding directly therefore works everywhere.
+	 */
+	__asm__ __volatile__(".insn i 0x0F, 0, x0, x0, 0x010" ::: "memory");
 #endif
 
 #if defined(JENT_ARCH_SCHED_OS_WINDOWS)

--- a/arch/jitterentropy-arch-thread.c
+++ b/arch/jitterentropy-arch-thread.c
@@ -45,6 +45,30 @@
  * DAMAGE.
  */
 
+/*
+ * _GNU_SOURCE exposes the Linux CPU-affinity interfaces used below on glibc
+ * (the CPU_* set macros, sched_setaffinity(), pthread_setaffinity_np()). It is
+ * defined here, in the translation unit that needs it, rather than in the
+ * public jitterentropy.h so the installed header does not impose a feature-test
+ * macro on consumers; it must precede every system header.
+ */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+# define _GNU_SOURCE
+#endif
+
+/*
+ * GetLogicalProcessorInformationEx(), RelationGroup, SetThreadGroupAffinity()
+ * and the GROUP_AFFINITY / GROUP_RELATIONSHIP structs are declared by the
+ * Windows SDK only when the translation unit asks for Windows 7 or newer.
+ * mingw-w64 has defaulted to older values across its releases, so the minimum
+ * is stated here rather than left to the toolchain; like _GNU_SOURCE above it
+ * must precede every system header, including the <windows.h> included below.
+ * An externally supplied, higher value is left alone.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 #include "jitterentropy-arch-thread.h"	/* not pulled in by internal.h */
@@ -58,6 +82,8 @@
 /* CPU pinning back-end selection */
 #if defined(_MSC_VER) || defined(__MINGW32__)
 # include <windows.h>
+# include <stddef.h>	/* offsetof() */
+# include <stdlib.h>	/* malloc(), free() */
 # define JENT_ARCH_THREAD_PIN_WINDOWS
 #elif defined(__linux__)
 # include <sched.h>
@@ -80,6 +106,17 @@
 # define JENT_ARCH_THREAD_PIN_OPENBSD
 #endif
 
+#ifdef JENT_WIN_THREADS
+/*
+ * <windows.h> already came in with the pinning back-end above - the Win32
+ * thread back-end is only ever selected on the same platforms - but it is
+ * named again so this block does not silently depend on that.
+ */
+# include <windows.h>
+# include <process.h>	/* _beginthreadex() */
+# include <stdint.h>	/* uintptr_t */
+#endif
+
 /*
  * Pin the calling thread to a single logical CPU.
  *
@@ -94,29 +131,101 @@ int jent_thread_pin_to_cpu(unsigned long cpu)
 	 * A processor group holds at most 64 logical CPUs, so the flat CPU
 	 * index is resolved to a (group, in-group bit) pair by walking the
 	 * groups. This lets us pin to CPUs beyond 64 on systems that span
-	 * multiple processor groups.
+	 * multiple processor groups. The flat index space is the one
+	 * jent_ncpu() reports, i.e. the active processors of all groups
+	 * concatenated in group order.
+	 *
+	 * The groups are enumerated with GetLogicalProcessorInformationEx()
+	 * rather than counted with GetActiveProcessorGroupCount() /
+	 * GetActiveProcessorCount(): the index selects the n-th *active*
+	 * processor, and only ActiveProcessorMask says which bit positions
+	 * those actually are. Deriving the bit from the count alone assumes
+	 * the active processors occupy the lowest bits of the group without a
+	 * gap, which stops holding as soon as one is parked or disabled - the
+	 * thread would then be pinned to a different CPU than the caller asked
+	 * for, or to an inactive one.
 	 */
-	WORD group_count = GetActiveProcessorGroupCount();
-	WORD group;
+	DWORD len = 0;
+	BYTE *buffer;
+	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX rec;
+	GROUP_RELATIONSHIP *groups;
+	/* Bytes that must be readable before Relationship and Size are read. */
+	const size_t hdr = offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+				    Group);
+	size_t need;
 	unsigned long idx = cpu;
+	WORD group;
+	int ret = -EINVAL;
 
-	for (group = 0; group < group_count; group++) {
-		DWORD in_group = GetActiveProcessorCount(group);
-		GROUP_AFFINITY ga;
+	if (!GetLogicalProcessorInformationEx(RelationGroup, NULL, &len) &&
+	    GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+		return -EFAULT;
 
-		if (idx >= (unsigned long)in_group) {
-			idx -= in_group;
+	buffer = (BYTE *)malloc(len);
+	if (!buffer)
+		return -ENOMEM;
+
+	if (!GetLogicalProcessorInformationEx(
+			RelationGroup,
+			(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)buffer,
+			&len)) {
+		free(buffer);
+		return -EFAULT;
+	}
+
+	/*
+	 * RelationGroup is reported as a single record covering every group,
+	 * with the per-group entries as a trailing array. Validate the header,
+	 * then the array the announced ActiveGroupCount implies, before either
+	 * is dereferenced.
+	 */
+	rec = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)buffer;
+	need = hdr + offsetof(GROUP_RELATIONSHIP, GroupInfo);
+	if ((size_t)len < hdr || (size_t)len < rec->Size ||
+	    rec->Relationship != RelationGroup || rec->Size < need) {
+		free(buffer);
+		return -EFAULT;
+	}
+
+	groups = &rec->Group;
+	need += (size_t)groups->ActiveGroupCount * sizeof(PROCESSOR_GROUP_INFO);
+	if (rec->Size < need) {
+		free(buffer);
+		return -EFAULT;
+	}
+
+	for (group = 0; group < groups->ActiveGroupCount; group++) {
+		const PROCESSOR_GROUP_INFO *gi = &groups->GroupInfo[group];
+		unsigned long seen = 0;
+		unsigned int bit;
+
+		if (idx >= (unsigned long)gi->ActiveProcessorCount) {
+			idx -= gi->ActiveProcessorCount;
 			continue;
 		}
 
-		ZeroMemory(&ga, sizeof(ga));
-		ga.Group = group;
-		ga.Mask = (KAFFINITY)1 << idx;
-		if (!SetThreadGroupAffinity(GetCurrentThread(), &ga, NULL))
-			return -EFAULT;
-		return 0;
+		/* The idx-th set bit of this group's active mask. */
+		for (bit = 0; bit < (unsigned int)(sizeof(KAFFINITY) * 8);
+		     bit++) {
+			GROUP_AFFINITY ga;
+
+			if (!((gi->ActiveProcessorMask >> bit) & (KAFFINITY)1))
+				continue;
+			if (seen++ != idx)
+				continue;
+
+			ZeroMemory(&ga, sizeof(ga));
+			ga.Group = group;
+			ga.Mask = (KAFFINITY)1 << bit;
+			ret = SetThreadGroupAffinity(GetCurrentThread(), &ga,
+						     NULL) ? 0 : -EFAULT;
+			break;
+		}
+		break;
 	}
-	return -EINVAL;
+
+	free(buffer);
+	return ret;
 #elif defined(JENT_ARCH_THREAD_PIN_LINUX)
 	cpu_set_t set;
 
@@ -128,14 +237,40 @@ int jent_thread_pin_to_cpu(unsigned long cpu)
 		return -errno;
 	return 0;
 #elif defined(JENT_ARCH_THREAD_PIN_MACOS)
+	/*
+	 * macOS exposes no CPU pinning API at all. THREAD_AFFINITY_POLICY is
+	 * the closest thing, but an affinity tag is only a hint that threads
+	 * sharing a tag should share an L2 cache - it does not name a CPU and
+	 * does not bind the thread to one. It is used here purely to push the
+	 * counting thread into an affinity set of its own (tag 0 means "no
+	 * affinity", hence the +1), which is the most the OS allows.
+	 *
+	 * On Apple Silicon even that is gone: thread_policy_set() returns
+	 * KERN_NOT_SUPPORTED for THREAD_AFFINITY_POLICY, so this always fails.
+	 * That is reported as -ENOTSUP rather than an error, matching OpenBSD
+	 * below. Pinning is advisory, so the internal timer keeps working; the
+	 * counting thread simply runs wherever the scheduler puts it.
+	 */
 	thread_affinity_policy_data_t policy;
+	kern_return_t kr;
 
-	/* Affinity tag 0 means "no affinity", so offset the CPU index. */
+	/*
+	 * affinity_tag is a 32-bit signed integer and tag 0 means "no
+	 * affinity": reject CPU indices whose +1 does not fit, instead of
+	 * letting the truncated conversion silently request tag 0 (un-pin)
+	 * or a negative tag.
+	 */
+	if (cpu >= INT32_MAX)
+		return -EINVAL;
+
 	policy.affinity_tag = (integer_t)(cpu + 1);
-	if (thread_policy_set(pthread_mach_thread_np(pthread_self()),
-			      THREAD_AFFINITY_POLICY,
-			      (thread_policy_t)&policy,
-			      THREAD_AFFINITY_POLICY_COUNT) != KERN_SUCCESS)
+	kr = thread_policy_set(pthread_mach_thread_np(pthread_self()),
+			       THREAD_AFFINITY_POLICY,
+			       (thread_policy_t)&policy,
+			       THREAD_AFFINITY_POLICY_COUNT);
+	if (kr == KERN_NOT_SUPPORTED)
+		return -ENOTSUP;
+	if (kr != KERN_SUCCESS)
 		return -EFAULT;
 	return 0;
 #elif defined(JENT_ARCH_THREAD_PIN_FREEBSD)
@@ -173,6 +308,24 @@ int jent_thread_pin_to_cpu(unsigned long cpu)
 #endif
 }
 
+#ifdef JENT_WIN_THREADS
+/*
+ * Win32 thread entry point.
+ *
+ * _beginthreadex() wants unsigned __stdcall (*)(void *), which is neither of
+ * the signatures the public thread-handler interface offers (struct
+ * jent_notime_thread in jitterentropy.h). Rather than adding a third,
+ * Windows-only one to that public struct, the routine and its argument travel
+ * in the context and this trampoline unpacks them.
+ */
+static unsigned __stdcall jent_notime_thread_win32(void *arg)
+{
+	struct jent_notime_ctx *ctx = (struct jent_notime_ctx *)arg;
+
+	return (unsigned)ctx->notime_routine(ctx->notime_arg);
+}
+#endif
+
 /*
  * Spawn the counting thread running start_routine(arg).
  *
@@ -182,7 +335,7 @@ int jent_notime_thread_create(struct jent_notime_ctx *ctx,
 			      jent_notime_start_routine routine,
 			      void *arg)
 {
-#ifdef JENT_PTHREAD
+#if defined(JENT_PTHREAD)
 	int ret = -pthread_attr_init(&ctx->notime_pthread_attr);
 
 	if (ret)
@@ -200,21 +353,40 @@ int jent_notime_thread_create(struct jent_notime_ctx *ctx,
 	}
 	ctx->notime_thread_started = 1;
 	return 0;
-#else
-	switch (thrd_create(&ctx->notime_thread_id, routine, arg)) {
-	case thrd_success:
-		ctx->notime_thread_started = 1;
-		return 0;
-	case thrd_nomem:
-		return -ENOMEM;
-	case thrd_timedout:
-		return -ETIMEDOUT;
-	case thrd_busy:
-		return -EBUSY;
-	case thrd_error:
-	default:
-		return -EINVAL;
+#else /* JENT_WIN_THREADS; the header rejects anything else */
+	/*
+	 * _beginthreadex() rather than CreateThread(): the counting thread runs
+	 * CRT code - jent_thread_pin_to_cpu() above allocates - and a thread
+	 * that reaches the CRT without having been started through it leaks the
+	 * per-thread state the CRT then initializes lazily. Since the internal
+	 * timer starts and stops the thread on every entropy request, that leak
+	 * would accumulate for the life of the process. The handle it returns is
+	 * a real Win32 HANDLE and is closed by the join below.
+	 *
+	 * The default stack size (0, i.e. the value in the image header) and no
+	 * creation flags are deliberate: the thread only increments a counter,
+	 * and it must run immediately rather than be created suspended.
+	 */
+	uintptr_t handle;
+
+	ctx->notime_routine = routine;
+	ctx->notime_arg = arg;
+
+	handle = _beginthreadex(NULL, 0, jent_notime_thread_win32, ctx, 0, NULL);
+	if (!handle) {
+		/*
+		 * _beginthreadex() reports the reason in errno (EAGAIN,
+		 * EINVAL, EACCES). It is only meaningful when it was actually
+		 * set, hence the fallback.
+		 */
+		int ret = errno;
+
+		return ret ? -ret : -EAGAIN;
 	}
+
+	ctx->notime_thread_id = (void *)handle;
+	ctx->notime_thread_started = 1;
+	return 0;
 #endif
 }
 
@@ -229,11 +401,19 @@ void jent_notime_thread_join(struct jent_notime_ctx *ctx)
 	if (!ctx->notime_thread_started)
 		return;
 
-#ifdef JENT_PTHREAD
+#if defined(JENT_PTHREAD)
 	pthread_join(ctx->notime_thread_id, NULL);
 	pthread_attr_destroy(&ctx->notime_pthread_attr);
-#else
-	thrd_join(ctx->notime_thread_id, NULL);
+#else /* JENT_WIN_THREADS */
+	/*
+	 * The wait is the join; the handle then has to be closed explicitly, as
+	 * a Win32 thread handle keeps the (already terminated) thread object
+	 * alive until its last reference goes away. Clearing it afterwards keeps
+	 * a second join from operating on a closed handle.
+	 */
+	WaitForSingleObject((HANDLE)ctx->notime_thread_id, INFINITE);
+	CloseHandle((HANDLE)ctx->notime_thread_id);
+	ctx->notime_thread_id = NULL;
 #endif
 	ctx->notime_thread_started = 0;
 }

--- a/arch/jitterentropy-arch-thread.h
+++ b/arch/jitterentropy-arch-thread.h
@@ -44,22 +44,23 @@
  *
  * The internal ("notime") timer spawns a helper thread that does nothing
  * but increment a counter. This header declares the two pieces of code
- * that differ between platforms and defines the context struct they use;
- * the definitions live in arch/jitterentropy-arch-thread.c.
+ * that differ between platforms; the definitions live in
+ * arch/jitterentropy-arch-thread.c.
  *
  *   1. Thread creation / joining. jent_notime_thread_create() /
  *      jent_notime_thread_join() hide the back-end behind a single
- *      signature and a single context struct (struct jent_notime_ctx).
+ *      signature and a single context struct (struct jent_notime_ctx,
+ *      defined in jitterentropy.h).
  *
  *   2. Pinning the calling thread to a single logical CPU via
  *      jent_thread_pin_to_cpu(). Keeping the counting thread on one CPU
  *      avoids inter-core migration of the running counter.
  *
- * Three execution environments are distinguished: hosted userspace
- * (JENT_ARCH_THREAD_HOSTED, POSIX or C11 threads plus the native affinity
- * API) and the freestanding Linux kernel / FreeBSD kernel / baremetal
- * targets (stub handler, pinning is a no-op). Pinning is best-effort:
- * callers treat a negative return as "not pinned" and continue.
+ * Both come in a hosted userspace flavour (JENT_ARCH_THREAD_HOSTED, POSIX or
+ * Win32 threads plus the native affinity API) and a freestanding one for the
+ * Linux kernel / FreeBSD kernel / baremetal targets (stub handler, pinning is
+ * a no-op). Pinning is best-effort: callers treat a negative return as "not
+ * pinned" and continue.
  */
 
 #ifndef _JITTERENTROPY_ARCH_THREAD_H
@@ -68,74 +69,14 @@
 #ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
 
 /*
- * Execution environment selection. A freestanding target is the Linux
- * kernel (__KERNEL__), the FreeBSD kernel (_KERNEL) or a baremetal/EFI
- * environment. The latter is detected from -ffreestanding
- * (__STDC_HOSTED__ == 0, as used by gnu-efi and similar baremetal
- * toolchains) or requested explicitly with JENT_BAREMETAL. The FreeBSD
- * kernel is matched before the generic baremetal test because it also
- * builds freestanding. Everything else is treated as hosted userspace.
+ * Include after jitterentropy.h, which is where the threading back-end and the
+ * execution environment are selected (JENT_PTHREAD / JENT_WIN_THREADS and the
+ * JENT_ARCH_THREAD_* macros) and where struct jent_notime_ctx and
+ * jent_notime_start_routine are defined - both are part of the public
+ * interface, since a consumer installing its own thread handler is handed that
+ * context. This header only declares what arch/jitterentropy-arch-thread.c
+ * implements on top of them.
  */
-#if defined(__KERNEL__) || defined(LINUX_KERNEL)
-	/*
-	 * Match both the kernel's own __KERNEL__ and the build-system macro
-	 * LINUX_KERNEL used by every other arch file, so a TU compiled with
-	 * only one of them cannot pair the kernel memory backend with the
-	 * hosted thread backend.
-	 */
-# define JENT_ARCH_THREAD_LINUX_KERNEL
-#elif defined(_KERNEL) && defined(__FreeBSD__)
-# define JENT_ARCH_THREAD_FREEBSD_KERNEL
-#elif defined(JENT_BAREMETAL) || \
-      (defined(__STDC_HOSTED__) && (__STDC_HOSTED__ == 0))
-# define JENT_ARCH_THREAD_BAREMETAL
-#else
-# define JENT_ARCH_THREAD_HOSTED
-#endif
-
-#if defined(JENT_ARCH_THREAD_HOSTED)
-
-/* Threading back-end: pthreads or C11 threads (see jitterentropy.h) */
-#ifdef JENT_PTHREAD
-# include <pthread.h>
-struct jent_notime_ctx {
-	pthread_attr_t notime_pthread_attr;	/* pthreads library */
-	pthread_t notime_thread_id;		/* pthreads thread ID */
-	unsigned long notime_cpu;		/* CPU the thread pins to */
-	int notime_thread_started;		/* thread successfully created? */
-};
-
-typedef void *(*jent_notime_start_routine)(void *);
-#else
-# ifdef __STDC_NO_THREADS__
-	/*
-	 * No auto-fallback to pthreads here: JENT_PTHREAD changes the callback
-	 * signature of the public struct jent_notime_thread (jitterentropy.h),
-	 * so it must be selected consistently by the build system for every
-	 * translation unit including external consumers, not silently by this
-	 * header.
-	 */
-#  error "C11 <threads.h> is unavailable (__STDC_NO_THREADS__); build with -DJENT_PTHREAD and link against pthreads instead"
-# endif
-# include <threads.h>
-struct jent_notime_ctx {
-	thrd_t notime_thread_id;		/* thread ID */
-	unsigned long notime_cpu;		/* CPU the thread pins to */
-	int notime_thread_started;		/* thread successfully created? */
-};
-
-typedef int (*jent_notime_start_routine)(void *);
-#endif
-
-#else /* freestanding: LINUX_KERNEL / FREEBSD_KERNEL / BAREMETAL */
-
-struct jent_notime_ctx {
-	unsigned long notime_cpu;		/* CPU the thread pins to */
-};
-
-typedef int (*jent_notime_start_routine)(void *);
-
-#endif /* JENT_ARCH_THREAD_HOSTED */
 
 /* Definitions in arch/jitterentropy-arch-thread.c. */
 int jent_thread_pin_to_cpu(unsigned long cpu);

--- a/arch/jitterentropy-arch-timer.c
+++ b/arch/jitterentropy-arch-timer.c
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Architecture-specific high-resolution timestamp source.
+ *
+ * Definition of jent_get_nstime() (declared in
+ * arch/jitterentropy-arch-timer.h); see that header for the dispatch
+ * rationale.
+ *
+ * Every backend lives here rather than inline in the header so that the
+ * platform headers they need - <windows.h>, <x86intrin.h>, the Mach headers,
+ * <linux/timex.h> - stay out of the entropy-collection core. In the Linux
+ * kernel that is a requirement rather than a preference:
+ * linux_kernel/Kbuild.source compiles the core at -O0, and <linux/timex.h>
+ * does not compile at -O0 on current kernels, because x86's
+ * random_get_entropy() reaches _static_cpu_has(), whose asm goto needs a
+ * compile-time-constant feature operand that no unoptimized build can supply.
+ * Kbuild.source therefore compiles this file with the kernel's normal flags,
+ * unlike the core objects around it. Note that only the architectures without
+ * a counter instruction reach <linux/timex.h> at all - the ones that have one
+ * read it directly below, in kernel mode as in user space.
+ *
+ * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2026
+ *
+ * License
+ * =======
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU General Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * _DEFAULT_SOURCE exposes clock_gettime()/CLOCK_* (POSIX.1b) on glibc under a
+ * strict -std=c11. The generic fallback below uses them on architectures
+ * without a counter instruction. The macro is defined here rather than in the
+ * public jitterentropy.h so the header imposes no feature-test macro on
+ * consumers; it must precede every system header.
+ */
+#if defined(__linux__) && !defined(_DEFAULT_SOURCE)
+# define _DEFAULT_SOURCE
+#endif
+
+#include "jitterentropy.h"
+#include "jitterentropy-arch-timer.h"
+
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && \
+    (defined(_M_ARM) || defined(_M_ARM64))
+# include <windows.h>
+# include <profileapi.h>
+# define JENT_ARCH_TIMER_WINDOWS_QPC
+
+#elif defined(__x86_64__) || defined(__i386__) || \
+      defined(_M_X64)     || defined(_M_IX86)
+# ifdef LINUX_KERNEL
+/*
+ * The kernel gets the same instruction through inline asm rather than through
+ * the intrinsic: <x86intrin.h> is a user-space compiler header that kernel
+ * code does not include, and the kernel's own rdtsc() lives in <asm/msr.h>,
+ * which drags in the cpufeature machinery this file exists to keep away from
+ * the core.
+ *
+ * This assumes the TSC exists, as the user-space backend has always done for
+ * this architecture. That is architecturally guaranteed on x86_64 and true of
+ * every 32-bit CPU from the Pentium onwards; a kernel built for a 486 would
+ * need the random_get_entropy() fallback instead.
+ */
+#  define JENT_ARCH_TIMER_X86_ASM
+# else
+#  define JENT_ARCH_TIMER_X86
+#  if defined(_MSC_VER)
+#   include <intrin.h>
+#  else
+#   include <x86intrin.h>
+#  endif
+# endif
+
+#elif defined(__aarch64__)
+# define JENT_ARCH_TIMER_AARCH64
+# ifndef AARCH64_NSTIME_REGISTER
+#  define AARCH64_NSTIME_REGISTER "cntvct_el0"
+# endif
+/*
+ * Apple platforms deliberately use the same cntvct_el0 read as every other
+ * aarch64 target. clock_gettime_nsec_np(CLOCK_UPTIME_RAW) was used here
+ * before on the assumption that the system counter is too coarse on M1+, but
+ * that is not the case: CLOCK_UPTIME_RAW *is* the system counter, merely
+ * rescaled to nanoseconds by mach_timebase_info() (numer/denom = 125/3 on
+ * M-series, i.e. a 24 MHz counter with a ~41.67 ns period). Tracking both
+ * sources over 100k samples shows a constant offset and no additional
+ * resolution.
+ *
+ * The rescale is actively harmful: multiplying by 125/3 makes consecutive
+ * deltas alternate between 41 and 42, so jent_gcd_analyze() computes a GCD of
+ * 1 and concludes there is no fixed increment to divide out, when the real
+ * quantum is one ~41.67 ns tick. Reading the register keeps the timestamp
+ * unit equal to the hardware quantum, so the GCD health test and the
+ * ECOARSETIME detection see the counter as it actually is. It is also a
+ * single instruction rather than a libsystem call.
+ *
+ * CNTVCT_EL0 is readable at EL1 as well, so the kernel takes the same path.
+ * It does so without the errata workarounds the kernel applies to its own
+ * reads of the register (Cortex-A73 858921 and relatives, where a read can
+ * observe a torn value): a counter that occasionally jumps is a defect for a
+ * clocksource but not for a jitter measurement, whose health tests watch the
+ * distribution of the deltas rather than trusting any single one.
+ */
+
+#elif defined(__s390x__)
+# define JENT_ARCH_TIMER_S390X
+/* memcpy() for the unaligned load in the backend below. */
+# ifdef LINUX_KERNEL
+#  include <linux/string.h>
+# else
+#  include <string.h>
+# endif
+
+#elif defined(_AIX)
+/*
+ * Must precede the PowerPC branch: see the dispatch note in
+ * arch/jitterentropy-arch-timer.h. GCC and clang expose the timebase through
+ * the builtin; xlc does not, and falls back to read_real_time() from
+ * <sys/time.h>.
+ */
+# if defined(__GNUC__) || defined(__clang__)
+#  define JENT_ARCH_TIMER_POWERPC
+# else
+#  include <sys/time.h>
+#  define JENT_ARCH_TIMER_AIX_READ_REAL_TIME
+# endif
+
+#elif defined(__powerpc) || defined(__powerpc__)
+# define JENT_ARCH_TIMER_POWERPC
+
+#elif defined(__riscv)
+# define JENT_ARCH_TIMER_RISCV
+/*
+ * The "time" CSR is the platform timer and is reliably accessible from
+ * user mode on Linux (the kernel enables [s|m]counteren.TM). The "cycle"
+ * CSR has higher resolution but is not always user-readable. Override
+ * RISCV_NSTIME_INSN (and RISCV_NSTIME_INSN_HI on RV32) to switch sources,
+ * e.g. to "rdcycle" / "rdcycleh".
+ *
+ * Be aware that the "time" CSR is driven by the platform timer, which on
+ * currently shipping RISC-V hardware ticks at 1 MHz (10 MHz on a few boards).
+ * That is a ~1 us quantum, coarse enough that jent_entropy_init() commonly
+ * rejects the timer with ECOARSETIME. "rdcycle" resolves that where it is
+ * permitted, but it is deliberately not the default: when the supervisor has
+ * not set [s|m]counteren.CY - which is the norm, as the cycle counter is a
+ * side-channel - the instruction traps and the process dies with SIGILL.
+ * Silently coarse timestamps that are detected and reported by the health
+ * tests are the safer default; a crash is not. See README.md.
+ */
+# ifndef RISCV_NSTIME_INSN
+#  define RISCV_NSTIME_INSN "rdtime"
+# endif
+# if __riscv_xlen < 64
+#  ifndef RISCV_NSTIME_INSN_HI
+#   define RISCV_NSTIME_INSN_HI "rdtimeh"
+#  endif
+# endif
+
+#elif defined(__sparc__) && defined(__arch64__)
+/*
+ * The SPARC V9 %tick register counts CPU clock cycles and is readable from
+ * user mode unless the supervisor sets %tick.NPT. 32-bit SPARC is not covered:
+ * "rd %tick" yields a 64-bit result that needs a two-register split there, and
+ * the remaining hardware is not worth the separate path.
+ */
+# define JENT_ARCH_TIMER_SPARC64
+
+#elif defined(__loongarch64)
+/*
+ * LoongArch64 has a constant-frequency counter read with rdtime.d, which
+ * returns the counter in the first register and its stable counter ID in the
+ * second. The ID is discarded.
+ */
+# define JENT_ARCH_TIMER_LOONGARCH64
+
+#elif defined(LINUX_KERNEL)
+/*
+ * The architecture offers no counter instruction of its own, so the kernel's
+ * clock sources have to be asked. This is the branch that pulls in
+ * <linux/timex.h>, and hence the reason this translation unit is built with
+ * the kernel's normal flags; see the note at the top of this file.
+ */
+# define JENT_ARCH_TIMER_LINUX_KERNEL
+# include <linux/ktime.h>	/* ktime_t (required by timekeeping.h on older kernels) */
+# include <linux/time.h>
+# include <linux/timekeeping.h>	/* ktime_get_ns() */
+# include <linux/timex.h>	/* random_get_entropy() */
+
+#else /* generic fallback */
+# define JENT_ARCH_TIMER_GENERIC
+# include <time.h>
+# ifdef __MACH__
+#  include <mach/mach_time.h>
+# endif
+#endif
+
+void jent_get_nstime(uint64_t *out)
+{
+#if defined(JENT_ARCH_TIMER_WINDOWS_QPC)
+
+	LARGE_INTEGER ticks;
+	QueryPerformanceCounter(&ticks);
+	*out = (uint64_t)ticks.QuadPart;
+
+#elif defined(JENT_ARCH_TIMER_X86)
+
+	*out = (uint64_t)__rdtsc();
+
+#elif defined(JENT_ARCH_TIMER_X86_ASM)
+
+	/*
+	 * rdtsc always returns the counter split across edx:eax, on x86_64 as
+	 * well, where it also clears the upper 32 bits of both registers.
+	 */
+	uint32_t lo, hi;
+
+	__asm__ __volatile__("rdtsc" : "=a" (lo), "=d" (hi));
+	*out = ((uint64_t)hi << 32) | (uint64_t)lo;
+
+#elif defined(JENT_ARCH_TIMER_AARCH64)
+
+	uint64_t ctr_val;
+	__asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
+	*out = ctr_val;
+
+#elif defined(JENT_ARCH_TIMER_S390X)
+
+	/*
+	 * GCC + STCKE. STCKE command and data format:
+	 * z/Architecture - Principles of Operation
+	 * http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+	 *
+	 * The current value of bits 0-103 of the TOD clock is stored in
+	 * bytes 1-13 of the sixteen-byte output. Bit 59 (TOD-Clock bit 51)
+	 * effectively increments every microsecond; the stepping value of
+	 * TOD-clock bit 63 is approximately 244 picoseconds.
+	 */
+	uint8_t clk[16];
+	uint64_t v;
+
+	__asm__ __volatile__("stcke %0" : "=Q" (clk) : : "cc");
+
+	/*
+	 * s390x is big-endian, so just copy the relevant 8 bytes. Use memcpy
+	 * rather than dereferencing (uint64_t *)(clk + 1): that address is
+	 * unaligned and the access would violate strict-aliasing rules (UB the
+	 * optimizer may break, even though s390x hardware tolerates the load).
+	 */
+	memcpy(&v, clk + 1, sizeof(v));
+	*out = v;
+
+#elif defined(JENT_ARCH_TIMER_POWERPC)
+
+	*out = (uint64_t)__builtin_ppc_get_timebase();
+
+#elif defined(JENT_ARCH_TIMER_AIX_READ_REAL_TIME)
+
+	/*
+	 * AIX without the GCC/clang timebase builtin (xlc). read_real_time()
+	 * is used rather than clock_gettime(), whose AIX implementation
+	 * advances in steps of 1000.
+	 */
+	uint64_t tmp = 0;
+	timebasestruct_t aixtime;
+
+	read_real_time(&aixtime, TIMEBASE_SZ);
+	time_base_to_time(&aixtime, TIMEBASE_SZ);
+	tmp = (uint64_t)aixtime.tb_high * 1000000000UL;
+	tmp += (uint64_t)aixtime.tb_low;
+	*out = tmp;
+
+#elif defined(JENT_ARCH_TIMER_SPARC64)
+
+	uint64_t ctr_val;
+	__asm__ __volatile__("rd %%tick, %0" : "=r" (ctr_val));
+	*out = ctr_val;
+
+#elif defined(JENT_ARCH_TIMER_LOONGARCH64)
+
+	uint64_t ctr_val, ctr_id;
+	__asm__ __volatile__("rdtime.d %0, %1"
+			     : "=r" (ctr_val), "=r" (ctr_id));
+	*out = ctr_val;
+
+#elif defined(JENT_ARCH_TIMER_RISCV)
+
+# if __riscv_xlen >= 64
+	uint64_t ctr_val;
+	__asm__ __volatile__(RISCV_NSTIME_INSN " %0" : "=r" (ctr_val));
+	*out = ctr_val;
+# else
+	/*
+	 * RV32: the time CSR is 64 bits wide but only 32 bits are read at a
+	 * time. Re-read the high half and retry on rollover so the combined
+	 * value is consistent.
+	 */
+	uint32_t hi, lo, hi2;
+	__asm__ __volatile__(
+		"1:\n\t"
+		RISCV_NSTIME_INSN_HI " %0\n\t"
+		RISCV_NSTIME_INSN    " %1\n\t"
+		RISCV_NSTIME_INSN_HI " %2\n\t"
+		"bne %0, %2, 1b"
+		: "=&r" (hi), "=&r" (lo), "=&r" (hi2));
+	*out = ((uint64_t)hi << 32) | (uint64_t)lo;
+# endif
+
+#elif defined(JENT_ARCH_TIMER_LINUX_KERNEL)
+
+	__u64 tmp = 0;
+
+	tmp = random_get_entropy();
+
+	/*
+	 * If random_get_entropy does not return a value, i.e. it is not
+	 * implemented for a given architecture, use a clock source.
+	 * hoping that there are timers we can work with.
+	 */
+	if (tmp == 0)
+		tmp = ktime_get_ns();
+
+	*out = tmp;
+
+#else /* JENT_ARCH_TIMER_GENERIC */
+
+# ifdef __MACH__
+	/*
+	 * macOS lacks clock_gettime on older releases. Taken from
+	 * http://developer.apple.com/library/mac/qa/qa1398/_index.html
+	 */
+	*out = mach_absolute_time();
+# else
+	/*
+	 * CLOCK_MONOTONIC is used rather than CLOCK_REALTIME: the realtime
+	 * clock is stepped and slewed by adjtime/NTP, which is external
+	 * interference rather than entropy the CPU itself produced, and it can
+	 * make the timestamp jump backwards. The measured jitter must come
+	 * from the execution of the entropy collection loop alone, so the
+	 * clock source with the least outside influence is the right one here.
+	 */
+	uint64_t tmp = 0;
+	struct timespec time;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &time) == 0) {
+		tmp = ((uint64_t)time.tv_sec & 0xFFFFFFFF) * 1000000000UL;
+		tmp = tmp + (uint64_t)time.tv_nsec;
+	}
+	*out = tmp;
+# endif
+
+#endif
+}

--- a/arch/jitterentropy-arch-timer.h
+++ b/arch/jitterentropy-arch-timer.h
@@ -42,234 +42,62 @@
 /*
  * Architecture-specific high-resolution timestamp source.
  *
- * Provides jent_get_nstime() implemented via the highest-resolution counter
- * available on the target. The dispatch order is:
+ * Provides jent_get_nstime(), which reads the highest-resolution counter
+ * available on the target. Every backend is defined in
+ * arch/jitterentropy-arch-timer.c; the dispatch order is:
  *
  *   - Windows ARM / ARM64 (MSVC / MinGW) -> QueryPerformanceCounter()
- *   - x86 / x86_64       -> __rdtsc() intrinsic
- *                           (<intrin.h> on MSVC, <x86intrin.h> elsewhere)
- *   - aarch64            -> mrs <reg> (cntvct_el0 by default), or
- *                           clock_gettime_nsec_np(CLOCK_UPTIME_RAW) on Apple
+ *   - x86 / x86_64       -> __rdtsc() intrinsic in user space (<intrin.h> on
+ *                           MSVC, <x86intrin.h> elsewhere), rdtsc inline asm
+ *                           in the kernel
+ *   - aarch64            -> mrs <reg> (cntvct_el0 by default), Apple included
  *   - s390x              -> stcke inline asm
+ *   - AIX                -> the PowerPC timebase, via the GCC/clang builtin
+ *                           where available and read_real_time() otherwise
  *   - powerpc            -> __builtin_ppc_get_timebase()
  *   - riscv              -> rdtime (RV64), or rdtimeh/rdtime retry pair (RV32);
  *                           override via RISCV_NSTIME_INSN[_HI] to use rdcycle
- *   - Linux kernel       -> random_get_entropy and ktime_get_ns as fallback
- *   - generic fallback   -> mach_absolute_time() on Mach,
- *                           read_real_time() on AIX,
- *                           clock_gettime(CLOCK_REALTIME) elsewhere
+ *   - sparc64            -> rd %tick
+ *   - loongarch64        -> rdtime.d
+ *   - no counter instruction, Linux kernel
+ *                        -> random_get_entropy and ktime_get_ns as fallback
+ *   - no counter instruction, user space
+ *                        -> mach_absolute_time() on Mach,
+ *                           clock_gettime(CLOCK_MONOTONIC) elsewhere
  *
- * Where a compiler intrinsic exists for the underlying instruction we use it
- * instead of inline asm. Inline asm is retained only on architectures (s390x,
- * aarch64, riscv) where no portable intrinsic covers the same register or
- * instruction.
+ * The dispatch is by architecture first and by execution environment second:
+ * every backend that is a counter read reachable from the instruction set is
+ * used in kernel mode exactly as it is in user space. On those architectures
+ * the kernel's own random_get_entropy() ends in get_cycles(), i.e. in the very
+ * same instruction, so going through it would buy nothing while making the
+ * entropy core depend on <linux/timex.h>. Only where the instruction set
+ * offers no counter at all does the kernel backend earn its place.
+ *
+ * Keeping the backends out of this header is what keeps their platform headers
+ * - <windows.h>, <x86intrin.h>, the Mach headers, <linux/timex.h> - out of the
+ * entropy-collection core, which includes this file through
+ * src/jitterentropy-internal.h. That is a hard requirement in the Linux kernel,
+ * where linux_kernel/Kbuild.source compiles the core at -O0 and <linux/timex.h>
+ * does not survive that; see the note at the top of
+ * arch/jitterentropy-arch-timer.c. The out-of-line call costs one branchless
+ * call/return per timestamp, which is constant overhead: it delays the
+ * measurement uniformly rather than removing jitter from it, and the -O0
+ * requirement exists to protect the measured loops, not the counter read.
  */
 
 #ifndef _JITTERENTROPY_ARCH_TIMER_H
 #define _JITTERENTROPY_ARCH_TIMER_H
 
+/*
+ * Only the fixed-width types the declaration below needs. The platform headers
+ * the backends use belong to arch/jitterentropy-arch-timer.c.
+ */
 #ifdef LINUX_KERNEL
-
-#include <linux/ktime.h>	/* ktime_t (required by timekeeping.h on older kernels) */
-#include <linux/time.h>
-#include <linux/timekeeping.h>	/* ktime_get_ns() */
-#include <linux/timex.h>	/* random_get_entropy() */
-# define JENT_ARCH_TIMER_LINUX_KERNEL
-
-#else /* LINUX_KERNEL */
-
+#include <linux/types.h>
+#else
 #include <stdint.h>
-
-#if (defined(_MSC_VER) || defined(__MINGW32__)) && \
-    (defined(_M_ARM) || defined(_M_ARM64))
-# include <windows.h>
-# include <profileapi.h>
-# define JENT_ARCH_TIMER_WINDOWS_QPC
-
-#elif defined(__x86_64__) || defined(__i386__) || \
-      defined(_M_X64)     || defined(_M_IX86)
-# define JENT_ARCH_TIMER_X86
-# if defined(_MSC_VER)
-#  include <intrin.h>
-# else
-#  include <x86intrin.h>
-# endif
-
-#elif defined(__aarch64__)
-# define JENT_ARCH_TIMER_AARCH64
-# ifndef AARCH64_NSTIME_REGISTER
-#  define AARCH64_NSTIME_REGISTER "cntvct_el0"
-# endif
-# ifdef __MACH__
-/*
- * On modern Apple platforms (M1+), the system counter is too coarse.
- * Use clock_gettime_nsec_np(CLOCK_UPTIME_RAW) instead.
- */
-#  include <time.h>
-#  define JENT_ARCH_TIMER_AARCH64_APPLE
-# endif
-
-#elif defined(__s390x__)
-# define JENT_ARCH_TIMER_S390X
-
-#elif defined(__powerpc) || defined(__powerpc__)
-# define JENT_ARCH_TIMER_POWERPC
-
-#elif defined(__riscv)
-# define JENT_ARCH_TIMER_RISCV
-/*
- * The "time" CSR is the platform timer and is reliably accessible from
- * user mode on Linux (the kernel enables [s|m]counteren.TM). The "cycle"
- * CSR has higher resolution but is not always user-readable. Override
- * RISCV_NSTIME_INSN (and RISCV_NSTIME_INSN_HI on RV32) to switch sources,
- * e.g. to "rdcycle" / "rdcycleh".
- */
-# ifndef RISCV_NSTIME_INSN
-#  define RISCV_NSTIME_INSN "rdtime"
-# endif
-# if __riscv_xlen < 64
-#  ifndef RISCV_NSTIME_INSN_HI
-#   define RISCV_NSTIME_INSN_HI "rdtimeh"
-#  endif
-# endif
-
-#else /* generic fallback */
-# define JENT_ARCH_TIMER_GENERIC
-# include <time.h>
-# ifdef __MACH__
-#  include <mach/mach_time.h>
-# endif
 #endif
 
-#endif /* LINUX_KERNEL */
-
-static inline void jent_get_nstime(uint64_t *out)
-{
-#if defined(JENT_ARCH_TIMER_WINDOWS_QPC)
-
-	LARGE_INTEGER ticks;
-	QueryPerformanceCounter(&ticks);
-	*out = (uint64_t)ticks.QuadPart;
-
-#elif defined(JENT_ARCH_TIMER_X86)
-
-	*out = (uint64_t)__rdtsc();
-
-#elif defined(JENT_ARCH_TIMER_AARCH64_APPLE)
-
-	*out = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-
-#elif defined(JENT_ARCH_TIMER_AARCH64)
-
-	uint64_t ctr_val;
-	__asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
-	*out = ctr_val;
-
-#elif defined(JENT_ARCH_TIMER_S390X)
-
-	/*
-	 * GCC + STCKE. STCKE command and data format:
-	 * z/Architecture - Principles of Operation
-	 * http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
-	 *
-	 * The current value of bits 0-103 of the TOD clock is stored in
-	 * bytes 1-13 of the sixteen-byte output. Bit 59 (TOD-Clock bit 51)
-	 * effectively increments every microsecond; the stepping value of
-	 * TOD-clock bit 63 is approximately 244 picoseconds.
-	 */
-	uint8_t clk[16];
-	uint64_t v;
-
-	__asm__ __volatile__("stcke %0" : "=Q" (clk) : : "cc");
-
-	/*
-	 * s390x is big-endian, so just copy the relevant 8 bytes. Use memcpy
-	 * rather than dereferencing (uint64_t *)(clk + 1): that address is
-	 * unaligned and the access would violate strict-aliasing rules (UB the
-	 * optimizer may break, even though s390x hardware tolerates the load).
-	 */
-	memcpy(&v, clk + 1, sizeof(v));
-	*out = v;
-
-#elif defined(JENT_ARCH_TIMER_POWERPC)
-
-	*out = (uint64_t)__builtin_ppc_get_timebase();
-
-#elif defined(JENT_ARCH_TIMER_RISCV)
-
-# if __riscv_xlen >= 64
-	uint64_t ctr_val;
-	__asm__ __volatile__(RISCV_NSTIME_INSN " %0" : "=r" (ctr_val));
-	*out = ctr_val;
-# else
-	/*
-	 * RV32: the time CSR is 64 bits wide but only 32 bits are read at a
-	 * time. Re-read the high half and retry on rollover so the combined
-	 * value is consistent.
-	 */
-	uint32_t hi, lo, hi2;
-	__asm__ __volatile__(
-		"1:\n\t"
-		RISCV_NSTIME_INSN_HI " %0\n\t"
-		RISCV_NSTIME_INSN    " %1\n\t"
-		RISCV_NSTIME_INSN_HI " %2\n\t"
-		"bne %0, %2, 1b"
-		: "=&r" (hi), "=&r" (lo), "=&r" (hi2));
-	*out = ((uint64_t)hi << 32) | (uint64_t)lo;
-# endif
-
-#elif defined (JENT_ARCH_TIMER_LINUX_KERNEL)
-
-	__u64 tmp = 0;
-
-	tmp = random_get_entropy();
-
-	/*
-	 * If random_get_entropy does not return a value, i.e. it is not
-	 * implemented for a given architecture, use a clock source.
-	 * hoping that there are timers we can work with.
-	 */
-	if (tmp == 0)
-		tmp = ktime_get_ns();
-
-	*out = tmp;
-
-#else /* JENT_ARCH_TIMER_GENERIC */
-
-# ifdef __MACH__
-	/*
-	 * macOS lacks clock_gettime on older releases. Taken from
-	 * http://developer.apple.com/library/mac/qa/qa1398/_index.html
-	 */
-	*out = mach_absolute_time();
-# elif defined(_AIX)
-	/*
-	 * clock_gettime() on AIX returns a timer value that increments in
-	 * steps of 1000.
-	 */
-	uint64_t tmp = 0;
-	timebasestruct_t aixtime;
-	read_real_time(&aixtime, TIMEBASE_SZ);
-	time_base_to_time(&aixtime, TIMEBASE_SZ);
-	tmp = (uint64_t)aixtime.tb_high * 1000000000UL;
-	tmp += (uint64_t)aixtime.tb_low;
-	*out = tmp;
-# else
-	/*
-	 * We could use CLOCK_MONOTONIC(_RAW), but with CLOCK_REALTIME we
-	 * pick up some nice extra entropy once in a while from NTP.
-	 */
-	uint64_t tmp = 0;
-	struct timespec time;
-
-	if (clock_gettime(CLOCK_REALTIME, &time) == 0) {
-		tmp = ((uint64_t)time.tv_sec & 0xFFFFFFFF) * 1000000000UL;
-		tmp = tmp + (uint64_t)time.tv_nsec;
-	}
-	*out = tmp;
-# endif
-
-#endif
-}
+void jent_get_nstime(uint64_t *out);
 
 #endif /* _JITTERENTROPY_ARCH_TIMER_H */

--- a/arch/jitterentropy-arch-uuid.c
+++ b/arch/jitterentropy-arch-uuid.c
@@ -44,6 +44,17 @@
  * DAMAGE.
  */
 
+/*
+ * <bcrypt.h> and BCryptGenRandom() are declared by the Windows SDK only from
+ * Windows Vista onwards. mingw-w64 has defaulted to older values across its
+ * releases, so the minimum is stated here rather than left to the toolchain; it
+ * must precede every system header, including the <windows.h> included below.
+ * An externally supplied, higher value is left alone.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
 
@@ -73,11 +84,39 @@
 # include <stdlib.h>
 # define JENT_UUID_ARC4RANDOM
 #elif defined(__linux__)
-# include <sys/random.h>
 # include <errno.h>
 # include <fcntl.h>
 # include <unistd.h>
-# define JENT_UUID_GETRANDOM
+/*
+ * <sys/random.h> and the getrandom() wrapper are glibc 2.25 and newer; RHEL 7
+ * ships 2.17 and has neither, which is a missing-header build failure rather
+ * than a link error. Its kernel would not answer the syscall either - that is
+ * Linux 3.17 - so nothing is lost by taking the /dev/urandom path there, which
+ * is where the getrandom() branch below falls back to anyway.
+ *
+ * Bionic is checked the same way and for the same reason, only against an API
+ * level rather than a libc version. Its <sys/random.h> is always present - the
+ * NDK ships one set of headers for every level - but the declaration inside it
+ * carries __INTRODUCED_IN(28), so below that the header is a no-op and the call
+ * is an implicit declaration, which current NDK clang rejects outright. The
+ * bound is the wrapper's alone and not the kernel's - API 21 is already Linux
+ * 3.4 and up, where the syscall may or may not be there - which is exactly the
+ * case the runtime fallback below covers. This is what lets the NDK build
+ * target the whole range its toolchain supports (API 21 and up, see flake.nix)
+ * rather than only the levels that happen to declare getrandom().
+ *
+ * musl (>= 1.1.20) publishes the header with no version macro to test and is
+ * current enough to have it wherever this library is built.
+ */
+# if defined(__ANDROID__) && __ANDROID_API__ < 28
+#  define JENT_UUID_DEVURANDOM
+# elif defined(__GLIBC__) && \
+       (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 25))
+#  define JENT_UUID_DEVURANDOM
+# else
+#  include <sys/random.h>
+#  define JENT_UUID_GETRANDOM
+# endif
 #elif defined(__unix__) || defined(__sun) || defined(_AIX) || \
       defined(__HAIKU__) || defined(__CYGWIN__)
 # include <errno.h>

--- a/doc/jitterentropy.3
+++ b/doc/jitterentropy.3
@@ -193,6 +193,38 @@ FIPS setting of the underlying operating system.
 .B JENT_NTG1
 Enable the BSI AIS 20/31 v3.0 NTG.1 compliant behavior.
 .TP
+.B JENT_FORCE_SECURE_MEM
+Require the memory of the entropy collector to be secure memory.
+The Jitter RNG always asks for it - a memory lock from the operating
+system, or an allocation from the secure memory arena of the crypto
+library it was built against; this flag decides what happens when that
+request cannot be granted. Without it - the default - the collector is
+created regardless, at the price of a state that may be written to the
+swap space. It is then treated as insecure memory: the
+.I secureMemory
+entry of
+.BR jent_status ()
+reports
+.IR false ,
+and the enhanced backtracking operation is kept. With the flag the
+allocation fails instead, which is what an environment not permitting
+locking - a CI system or a restricted container with a too small
+.IR RLIMIT_MEMLOCK ,
+say - will run into, as will an application that has not configured the
+secure memory arena of libgcrypt (GCRYCTL_INIT_SECMEM) or OpenSSL
+.RB ( CRYPTO_secure_malloc_init ()),
+each of which is process-wide state the library does not establish
+itself.
+.IP
+The flag is implied by
+.B JENT_NTG1
+and
+.BR JENT_FORCE_FIPS ,
+whose compliance claims cover the protection of the collector state.
+It has no effect in the Linux kernel, where the memory is secure by
+construction, nor with AWS-LC, which wipes its memory but does not lock
+it and therefore never claims to be secure.
+.TP
 .B JENT_MAX_MEMSIZE_*
 Define the maximum amount of memory that the Jitter RNG will use
 for its operation supporting the collection of raw noise. Without

--- a/flake.nix
+++ b/flake.nix
@@ -22,18 +22,152 @@
           src = self;
           nativeBuildInputs = [ pkgs.cmake ];
           enableParallelBuilding = true;
+          # The entropy-collection core must be built at -O0 (CMakeLists.txt
+          # sets it explicitly, and src/jitterentropy-base.c has an __OPTIMIZE__
+          # guard to enforce it), which _FORTIFY_SOURCE cannot be combined with.
+          # Left enabled, the nixpkgs default hardening emits "_FORTIFY_SOURCE
+          # requires compiling with optimization" once per translation unit -
+          # 17 warnings that bury anything worth reading.
+          #
+          # This gives up no hardening. The flag appends -D_FORTIFY_SOURCE=2
+          # after the project's flags, where -O0 has already made it inert -
+          # glibc only defines the _chk variants under optimization, which is
+          # exactly what it is warning about. It also prepends -O2, but before
+          # the project's flags, so the -O0 that follows wins either way.
+          # Compiling src/jitterentropy-base.c with and without this line
+          # produces a byte-identical object file.
+          hardeningDisable = [ "fortify" "fortify3" ];
           meta = {
             description = "Jitter RNG userspace library and validation tools";
             license = lib.licenses.bsd3;
           };
         };
 
+      # The same tools against musl instead of glibc.
+      #
+      # Every Linux build elsewhere in this flake is a glibc one, yet the
+      # library reaches for a good deal of what the two libcs disagree about:
+      # the pthread_setaffinity_np()/CPU_SET pinning in
+      # arch/jitterentropy-arch-sched.c, the mlock/getrlimit handling in
+      # arch/jitterentropy-arch-memory.c, and clock_gettime(), which musl keeps
+      # in libc while glibc split it out into librt. musl is also stricter about
+      # which headers declare what, so a missing include that glibc supplies
+      # transitively fails here and nowhere else.
+      #
+      # pkgsMusl rather than pkgsCross.musl64: it is the same architecture, so
+      # the tools this produces run on the machine that built them rather than
+      # only linking.
+      #
+      # CI does not build this one - the workflow covers dynamic musl through
+      # Debian's musl-gcc and takes only muslStaticFor from here, so that the
+      # Nix job is the configuration nothing else reaches. It stays for anyone
+      # wanting dynamic musl out of the flake directly.
+      #
+      # Renamed from what toolsFor would otherwise call it, so that the store
+      # path and the build log say which libc this is - the two derivations are
+      # identical but for the package set behind them.
+      muslFor = pkgs:
+        (toolsFor pkgs.pkgsMusl).overrideAttrs
+        (_: { pname = "jitterentropy-tools-musl"; });
+
+      # Fully static musl: no interpreter, no libc.so, nothing to resolve at
+      # run time. pkgsStatic is musl-based on Linux
+      # (x86_64-unknown-linux-musl), so this is the same libc as muslFor with
+      # the linkage changed, which is the point - static linking is where the
+      # library's use of pthreads and of clock_gettime() has to hold up without
+      # a dynamic loader to fall back on.
+      #
+      # pname is deliberately left as toolsFor sets it: the static stdenv
+      # already appends "-static-x86_64-unknown-linux-musl" to the derivation
+      # name, so the store path says both libc and linkage on its own.
+      muslStaticFor = pkgs: toolsFor pkgs.pkgsStatic;
+
+      # Cross-compilation smoke builds.
+      #
+      # The VM tests below only ever exercise the host architecture, which left
+      # every platform outside x86-64/aarch64/i686 Linux with no coverage at
+      # all - and those are exactly the targets whose arch/ backends are
+      # selected by preprocessor conditions that nothing here evaluates. These
+      # derivations compile and link the library and its tools for each target;
+      # they are not run, which is enough to catch the class of breakage that
+      # actually occurs (a missing declaration, an unavailable header, an
+      # unlinked import library, inline asm that does not assemble).
+      #
+      # Build them all with:
+      #   nix build .#cross-riscv64 .#cross-s390x .#cross-mingwW64 ...
+      crossFor = { cross, timer ? true, shared ? false }:
+        cross.stdenv.mkDerivation {
+          pname = "jitterentropy-cross";
+          version = "3.7.1";
+          src = self;
+          nativeBuildInputs = [ nixpkgs.legacyPackages.x86_64-linux.cmake ];
+          cmakeFlags = [ "-DINTERNAL_TIMER=${if timer then "on" else "off"}" ]
+            ++ lib.optional shared "-DBUILD_SHARED_LIBS=ON";
+          enableParallelBuilding = true;
+          # Same reason as in toolsFor above, and it matters more here: these
+          # builds exist to surface diagnostics, so 17 lines of
+          # "_FORTIFY_SOURCE requires compiling with optimization" per target
+          # would bury the one warning worth reading.
+          hardeningDisable = [ "fortify" "fortify3" ];
+          meta = {
+            description = "Jitter RNG cross-compilation smoke build";
+            license = lib.licenses.bsd3;
+          };
+        };
+
+      crossTargets = pkgs:
+        let p = pkgs.pkgsCross;
+        in {
+          # Architectures with a dedicated jent_get_nstime() backend that the
+          # native builds never compile: stcke, the PowerPC timebase, rdtime,
+          # rdtime.d. armv7 covers the generic clock_gettime() fallback and,
+          # with i686, the 32-bit paths (JENT_MAX_AUTO_MEMSIZE, the div64
+          # helpers).
+          cross-s390x = crossFor { cross = p.s390x; };
+          cross-ppc64 = crossFor { cross = p.powernv; };
+          cross-riscv64 = crossFor { cross = p.riscv64; };
+          cross-loongarch64 = crossFor { cross = p.loongarch64-linux; };
+          cross-armv7 = crossFor { cross = p."armv7l-hf-multiplatform"; };
+          cross-i686 = crossFor { cross = p.gnu32; };
+
+          # Windows/MinGW. Both link widths, and the shared build in addition
+          # because it is the only configuration that exercises the
+          # dllexport/dllimport split in jitterentropy.h and the bcrypt import
+          # library.
+          #
+          # The internal timer is built here, unlike everything else about this
+          # toolchain would suggest: nixpkgs builds its mingw-w64 without
+          # winpthreads, so it ships no <pthread.h> at all, and the timer had
+          # to be switched off for want of a threading back-end.
+          # It now uses the Win32 threads, which come from the CRT and
+          # kernel32, so this is the one target that proves the Win32 back-end
+          # needs nothing a Windows toolchain may lack.
+          cross-mingwW64 = crossFor { cross = p.mingwW64; };
+          cross-mingwW64-shared = crossFor { cross = p.mingwW64; shared = true; };
+          cross-mingw32 = crossFor { cross = p.mingw32; };
+        };
+
       # Android build of the userspace library via ndk-build, verifying
       # arch/android/Android.mk against the real NDK toolchain. The NDK is
       # unfree, so a dedicated nixpkgs instance accepts its license for this
       # output only; every other output stays on the unmodified package set.
-      # APP_PLATFORM=android-30 is the floor for the C11 <threads.h> that the
-      # internal-timer thread helper uses on Linux/bionic.
+      #
+      # APP_PLATFORM is the NDK's own floor and not a level of this library's
+      # choosing: r29 supports API 21 upwards for every ABI built here (see
+      # ndk/abis.py, where anything below is rejected outright). It used to be
+      # android-30, which was the floor the internal timer's threading back-end
+      # imposed on bionic. Linux, Android included, now takes pthreads
+      # unconditionally (see the threading back-end note in jitterentropy.h),
+      # and bionic has had those since API 1, so that floor is gone with it.
+      #
+      # Nothing else the library calls holds a floor above 21 either: mmap,
+      # munmap, madvise, mlock, munlock, sched_setaffinity, sysconf and
+      # clock_gettime are all unguarded in bionic at that level. getrandom() is
+      # the one exception at __INTRODUCED_IN(28), and rather than let it set the
+      # floor arch/jitterentropy-arch-uuid.c takes its /dev/urandom fallback
+      # below 28 - the same thing it does for glibc older than 2.25. Building at
+      # the toolchain floor is what keeps that branch honest: at android-30 it
+      # was never compiled.
       androidFor = system:
         let
           pkgsAndroid = import nixpkgs {
@@ -58,7 +192,7 @@
             ndk-build \
               NDK_PROJECT_PATH=null \
               APP_BUILD_SCRIPT=$(pwd)/arch/android/Android.mk \
-              APP_PLATFORM=android-30 \
+              APP_PLATFORM=android-21 \
               APP_ABI="arm64-v8a x86_64" \
               APP_OPTIM=release \
               NDK_OUT=$TMPDIR/obj \
@@ -78,6 +212,132 @@
             description =
               "Jitter RNG userspace library built with the Android NDK";
             license = lib.licenses.bsd3;
+          };
+        };
+
+      # Downstream consumers compiled against this working tree.
+      #
+      # Everything else here builds the library and its own tools, which says
+      # nothing about whether the installed result is still usable by the
+      # programs that link it: an installed header that no longer declares what
+      # it used to, a symbol that stops being exported, a link dependency that
+      # is not carried into the .pc file are all invisible to a build of this
+      # repository alone and break the consumer instead. rng-tools (whose rngd
+      # feeds the kernel from a jitter entropy source) and ESDM (whose es_jent
+      # entropy source is this library) are the two that matter, and both are
+      # packaged in nixpkgs, so the smoke test is the packaged consumer with its
+      # jitterentropy input swapped for this tree.
+      #
+      # nixpkgs' own jitterentropy derivation with only src and cmakeFlags
+      # replaced, rather than toolsFor above: what is being tested is the
+      # library as a distribution installs it - the dev/out split that puts the
+      # headers, the .pc file and the CMake package files in a separate output -
+      # and reusing the packaging keeps the swap a source-only one.
+      #
+      # Compile and link only. Both consumers ship test suites that exercise the
+      # jitter source at run time (rng-tools' tests/rngtestjitter.sh starts rngd
+      # on it, ESDM's meson test set has an "ES Jitter RNG" case), and both are
+      # switched off here: this is a build check, and the library's behaviour is
+      # covered by the tool runs and the VM tests elsewhere in this flake.
+      # Turning doCheck back on is what to change if that ever becomes the
+      # point.
+      consumersFor = pkgs:
+        let
+          # INTERNAL_TIMER decides which symbols the library exports, and
+          # rng-tools' configure probes for jent_notime_settick(): with the
+          # internal timer off it is absent and rngd_jitter.c compiles without
+          # the tick handling, with it on the same file drives the timer thread
+          # itself. Two different compilations of the consumer, hence both.
+          #
+          # off is what nixpkgs builds (and what the distributions therefore
+          # ship), on is this repository's own default (see the INTERNAL_TIMER
+          # option in CMakeLists.txt).
+          #
+          # ESDM compiles the same code either way, but gates a large part of it
+          # on the JENT_VERSION the installed header defines - jent_status(),
+          # jent_secure_memory_supported(), JENT_NTG1 and the
+          # JENT_MAX_MEMSIZE_*/JENT_HASHLOOP_* flags are all behind
+          # "JENT_VERSION >= 3070000" in its esdm_es_jent.c - which makes it the
+          # consumer that pins the widest part of the API.
+          libFor = timer:
+            pkgs.jitterentropy.overrideAttrs (_: {
+              version = "3.7.1";
+              src = self;
+              cmakeFlags =
+                [ "-DINTERNAL_TIMER=${if timer then "on" else "off"}" ];
+            });
+          notimer = libFor false;
+          timer = libFor true;
+          buildOnly = drv:
+            drv.overrideAttrs (_: {
+              doCheck = false;
+              doInstallCheck = false;
+            });
+        in {
+          consumer-rng-tools =
+            buildOnly (pkgs.rng-tools.override { jitterentropy = notimer; });
+          consumer-rng-tools-timer =
+            buildOnly (pkgs.rng-tools.override { jitterentropy = timer; });
+          consumer-esdm =
+            buildOnly (pkgs.esdm.override { jitterentropy = notimer; });
+          consumer-esdm-timer =
+            buildOnly (pkgs.esdm.override { jitterentropy = timer; });
+        };
+
+      # The three external crypto backends, i.e. the EXTERNAL_CRYPTO option of
+      # CMakeLists.txt.
+      #
+      # With it set, the library stops using its own SHA-3 and its own secure
+      # memory and calls into the named library instead - which changes both
+      # halves of arch/jitterentropy-arch-memory.c and
+      # arch/jitterentropy-arch-fips.c that the default build never compiles:
+      # gcry_malloc_secure() out of libgcrypt's secmem pool, OpenSSL's secure
+      # heap (OPENSSL_secure_malloc()), and AWS-LC's OPENSSL_malloc(), which is
+      # wiped but not locked and so is the one backend that reports itself as
+      # not secure. Nothing else in this flake or the workflow builds any of
+      # them, and each is selected by a preprocessor condition, so a break there
+      # is invisible until a consumer that configures the library this way hits
+      # it.
+      #
+      # BUILD_SHARED_LIBS is on because the two searches in CMakeLists.txt are
+      # tied together: a static jitterentropy makes it look for a static
+      # libcrypto.a / libgcrypt.a, which is not what these packages install.
+      #
+      # The secure-memory arena these two allocate the collector out of is not
+      # sized by the library - it is process-wide state that the application
+      # establishes, which for these builds means the recording tools
+      # themselves (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h).
+      # An application that establishes none still gets a collector, from
+      # ordinary memory, unless it asked for JENT_FORCE_SECURE_MEM.
+      cryptoFor = pkgs:
+        let
+          backendFor = { name, external, dep }:
+            (toolsFor pkgs).overrideAttrs (old: {
+              pname = "jitterentropy-tools-${name}";
+              buildInputs = (old.buildInputs or [ ]) ++ [ dep ];
+              cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+                "-DEXTERNAL_CRYPTO=${external}"
+                "-DBUILD_SHARED_LIBS=ON"
+              ];
+            });
+        in {
+          crypto-openssl = backendFor {
+            name = "openssl";
+            external = "OPENSSL";
+            dep = pkgs.openssl;
+          };
+          crypto-awslc = backendFor {
+            name = "awslc";
+            external = "AWSLC";
+            dep = pkgs.aws-lc;
+          };
+          # libgcrypt's headers include <gpg-error.h>, which reaches the
+          # compile through libgcrypt's own propagated libgpg-error rather than
+          # being named here.
+          crypto-libgcrypt = backendFor {
+            name = "libgcrypt";
+            external = "LIBGCRYPT";
+            dep = pkgs.libgcrypt;
           };
         };
 
@@ -455,13 +715,18 @@
         in {
           default = toolsFor pkgs;
           jitterentropy-tools = toolsFor pkgs;
-        } // modulesFor pkgs
+          musl = muslFor pkgs;
+          musl-static = muslStaticFor pkgs;
+        } // cryptoFor pkgs
+          // modulesFor pkgs
+          // consumersFor pkgs
           // isosFor system pkgs
           # The SD images boot Raspberry Pi boards, which are aarch64.
           // lib.optionalAttrs (system == "aarch64-linux")
             (sdImagesFor system pkgs)
-          # The NDK host toolchain in nixpkgs is x86_64-linux only.
-          // lib.optionalAttrs (system == "x86_64-linux") {
+          # The NDK host toolchain in nixpkgs is x86_64-linux only. The cross
+          # toolchains are likewise only assembled for an x86_64-linux host.
+          // lib.optionalAttrs (system == "x86_64-linux") (crossTargets pkgs // {
             android = androidFor system;
             # 32-bit x86 build of the kernel module, compiled natively via the
             # pkgsi686Linux package set (x86_64 hosts execute i686 binaries
@@ -470,7 +735,7 @@
             # kernel does not provide.
             jitterentropy-module-i686 =
               moduleFor pkgs.pkgsi686Linux pkgs.pkgsi686Linux.linuxPackages_latest.kernel;
-          });
+          }));
 
       # `nix flake check` boots every VM and runs its assertions. Individual
       # VMs can be run with e.g. `nix build .#checks.x86_64-linux.vm-linux_6_6`.

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -169,6 +169,17 @@ extern "C" {
 				 automatically determine the memory size for the
 				 memory access? By default it is only the L1
 				 cache size. */
+#define JENT_FORCE_SECURE_MEM (1<<8) /* Require the memory of the entropy
+				   collector to be secure memory: fail the
+				   allocation when the platform does not grant
+				   it - a memory lock the operating system
+				   refuses, or a secure memory arena that the
+				   application did not configure (libgcrypt,
+				   OpenSSL) - instead of continuing with memory
+				   that may be written to swap. Secure memory
+				   is always attempted; this flag only turns a
+				   refusal into an error. It is implied by
+				   JENT_NTG1 and JENT_FORCE_FIPS. */
 
 #if defined(LINUX_KERNEL) && !defined(UINT32_C)
 #define UINT32_C(c)	c ## U

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -67,11 +67,6 @@
  * Compilation for OpenSSL    #define OPENSSL
  */
 
-/* used for sched_getaffinity and CPU_* macros */
-#ifdef __linux__
-	#define _GNU_SOURCE
-#endif
-
 #include <limits.h>
 #include <time.h>
 #include <stdint.h>
@@ -81,8 +76,31 @@
 #include <errno.h>
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
-# include <windows.h>
-typedef int64_t ssize_t;
+/*
+ * Note there is deliberately no <windows.h> here, for the same reason as the
+ * Mach/Apple note below: this is the installed public header, so everything it
+ * includes becomes part of every consumer's translation unit - and <windows.h>
+ * brings in the whole Win32 API along with its min()/max() macros, which
+ * collide with ordinary C++ and C identifiers unless the consumer thinks to
+ * define NOMINMAX first. Nothing in the API declared below needs it. The
+ * places that do call Win32 (the sources under arch/) include it themselves,
+ * each after selecting the API level it requires.
+ *
+ * ssize_t is the signed counterpart of size_t and has to match its width:
+ * intptr_t is that type on Windows (the same choice the SDK makes for its own
+ * SSIZE_T alias of LONG_PTR). A hard-coded int64_t was 64 bits wide even in
+ * 32-bit builds, where it made jent_read_entropy() derive its clamp by
+ * shifting a 32-bit size_t by 63 - undefined behavior, diagnosed by MSVC as
+ * C4293 and silently reduced to a shift by 31.
+ *
+ * The guard leaves an existing definition alone: MinGW's <sys/types.h>
+ * provides ssize_t as long / long long, which is a different type to the
+ * compiler even where it is the same width, so redefining it is an error.
+ */
+# ifndef _SSIZE_T_DEFINED
+#  define _SSIZE_T_DEFINED
+typedef intptr_t ssize_t;
+# endif
 #else
 # include <sys/types.h>
 # include <sys/stat.h>
@@ -90,13 +108,17 @@ typedef int64_t ssize_t;
 # include <unistd.h>
 #endif
 
-#ifdef __MACH__
-# include <assert.h>
-# include <CoreServices/CoreServices.h>
-# include <mach/mach.h>
-# include <mach/mach_time.h>
-# include <unistd.h>
-#endif
+/*
+ * Note there is deliberately no Mach/Apple block here. This is the installed
+ * public header, so anything pulled in becomes part of every consumer's
+ * translation unit. The Mach headers this used to include are not needed by
+ * the API declared below, <unistd.h> is already covered above, and
+ * <CoreServices/CoreServices.h> in particular is a large umbrella framework
+ * that no part of the library references - and one that does not exist in the
+ * iOS/tvOS/watchOS SDKs, all of which define __MACH__. The few places that do
+ * need Mach interfaces (arch/jitterentropy-arch-thread.c,
+ * arch/jitterentropy-arch-timer.c) include exactly what they use themselves.
+ */
 
 #endif /* LINUX_KERNEL */
 
@@ -206,15 +228,94 @@ extern "C" {
 # define JENT_PRIVATE_STATIC
 #else /* JENT_PRIVATE_COMPILE */
 #if defined(_WIN32)
-#define JENT_PRIVATE_STATIC __declspec(dllexport)
+/*
+ * Windows has no visibility attribute; the linkage is chosen per translation
+ * unit instead. This header is installed and therefore also read by consumers,
+ * so it must not unconditionally say "dllexport": that is only correct while
+ * the DLL itself is being compiled. A consumer that saw dllexport declared the
+ * imported functions as if it were defining them, which makes MSVC fall back to
+ * a thunked auto-import and makes MinGW warn outright.
+ *
+ * The build system defines JENT_BUILDING_DLL for the library's own translation
+ * units (see CMakeLists.txt); consumers of a shared build get dllimport, and
+ * consumers of a static build define JENT_STATIC_LIB to get neither.
+ */
+# if defined(JENT_STATIC_LIB)
+#  define JENT_PRIVATE_STATIC
+# elif defined(JENT_BUILDING_DLL)
+#  define JENT_PRIVATE_STATIC __declspec(dllexport)
+# else
+#  define JENT_PRIVATE_STATIC __declspec(dllimport)
+# endif
 #else
 #define JENT_PRIVATE_STATIC __attribute__((visibility("default")))
 #endif
 #endif
 
-#if defined(__MINGW32__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)
-#define JENT_PTHREAD
+/*
+ * Threading back-end for the internal timer.
+ */
+#if !defined(JENT_PTHREAD) && !defined(JENT_WIN_THREADS) && \
+    !defined(LINUX_KERNEL)
+# if defined(_MSC_VER) || defined(__MINGW32__)
+#  define JENT_WIN_THREADS
+# else
+#  define JENT_PTHREAD
+# endif
 #endif
+
+#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
+#if defined(__KERNEL__) || defined(LINUX_KERNEL)
+	/*
+	 * Match both the kernel's own __KERNEL__ and the build-system macro
+	 * LINUX_KERNEL used by every other arch file, so a TU compiled with
+	 * only one of them cannot pair the kernel memory backend with the
+	 * hosted thread backend.
+	 */
+# define JENT_ARCH_THREAD_LINUX_KERNEL
+#elif defined(_KERNEL) && defined(__FreeBSD__)
+# define JENT_ARCH_THREAD_FREEBSD_KERNEL
+#elif defined(JENT_BAREMETAL) || \
+      (defined(__STDC_HOSTED__) && (__STDC_HOSTED__ == 0))
+# define JENT_ARCH_THREAD_BAREMETAL
+#else
+# define JENT_ARCH_THREAD_HOSTED
+#endif
+
+#if defined(JENT_ARCH_THREAD_HOSTED)
+
+#if defined(JENT_PTHREAD)
+# include <pthread.h>
+typedef void *(*jent_notime_start_routine)(void *);
+#elif defined(JENT_WIN_THREADS)
+typedef int (*jent_notime_start_routine)(void *);
+#else
+# error "no threading back-end selected: build with -DJENT_PTHREAD or -DJENT_WIN_THREADS"
+#endif
+
+struct jent_notime_ctx {
+#if defined(JENT_PTHREAD)
+	pthread_attr_t notime_pthread_attr;	/* pthreads library */
+	pthread_t notime_thread_id;		/* pthreads thread ID */
+#else /* JENT_WIN_THREADS */
+	void *notime_thread_id;			/* Win32 thread HANDLE */
+	jent_notime_start_routine notime_routine; /* what the thread runs */
+	void *notime_arg;			/* its argument */
+#endif
+	unsigned long notime_cpu;		/* CPU the thread pins to */
+	int notime_thread_started;		/* thread successfully created? */
+};
+
+#else /* freestanding: LINUX_KERNEL / FREEBSD_KERNEL / BAREMETAL */
+
+struct jent_notime_ctx {
+	unsigned long notime_cpu;		/* CPU the thread pins to */
+};
+
+typedef int (*jent_notime_start_routine)(void *);
+
+#endif /* JENT_ARCH_THREAD_HOSTED */
+#endif /* JENT_CONF_ENABLE_INTERNAL_TIMER */
 
 /* Forward declaration of opaque value */
 struct rand_data;
@@ -335,6 +436,12 @@ int jent_entropy_switch_notime_impl(struct jent_notime_thread *new_thread);
  * When unset, the counting thread defaults to the highest-numbered online
  * CPU. Pinning itself is best-effort: an out-of-range index or a platform
  * without affinity support does not stop the internal timer from working.
+ *
+ * Not every platform can honour the CPU index. OpenBSD exposes no
+ * thread-to-CPU affinity API, and macOS only has affinity *tags*, which hint
+ * that threads should share an L2 cache rather than naming a CPU - on Apple
+ * Silicon even those are rejected by the kernel. On such systems the index is
+ * accepted and recorded but has no effect on placement.
  *
  * Returns 0 on success or a negative errno on failure.
  */

--- a/linux_kernel/Kbuild.source
+++ b/linux_kernel/Kbuild.source
@@ -51,6 +51,7 @@ jitter_rng-y += ../src/jitterentropy-base.o				       \
 		../src/jitterentropy-status.o				       \
 		../src/jitterentropy-timer.o				       \
 		../arch/jitterentropy-arch-memory.o			       \
+		../arch/jitterentropy-arch-timer.o			       \
 		../arch/jitterentropy-arch-sched.o			       \
 		../arch/jitterentropy-arch-cache.o			       \
 		../arch/jitterentropy-arch-fips.o			       \
@@ -69,6 +70,21 @@ CFLAGS_../src/jitterentropy-status.o = $(jitter_rng_c_args)
 CFLAGS_../src/jitterentropy-sha3.o = $(jitter_rng_c_args_zero)
 CFLAGS_../src/jitterentropy-timer.o = $(jitter_rng_c_args_zero)
 CFLAGS_../arch/jitterentropy-arch-memory.o = $(jitter_rng_c_args)
+# Deliberately not $(jitter_rng_c_args_zero), unlike the entropy core above.
+# This object is the one place <linux/timex.h> is included, and that header does
+# not compile at -O0 on current kernels: x86's random_get_entropy() reaches
+# _static_cpu_has(), whose asm goto needs a compile-time-constant feature
+# operand, and without optimization GCC cannot produce one ("impossible
+# constraint in 'asm'"). The -O0 requirement covers the measured loops in the
+# entropy core, not the counter read, so building just the timestamp accessor
+# with the kernel's normal flags costs a call per timestamp and nothing else.
+#
+# Only the architectures without a counter instruction of their own reach
+# <linux/timex.h> at all: x86, aarch64, s390x, powerpc, riscv, sparc64 and
+# loongarch64 read their counter with the instruction directly and would build
+# at -O0 as well. The flags are kept uniform for the object rather than made
+# conditional on the target architecture.
+CFLAGS_../arch/jitterentropy-arch-timer.o = $(jitter_rng_c_args)
 CFLAGS_../arch/jitterentropy-arch-sched.o = $(jitter_rng_c_args)
 CFLAGS_../arch/jitterentropy-arch-cache.o = $(jitter_rng_c_args)
 CFLAGS_../arch/jitterentropy-arch-fips.o = $(jitter_rng_c_args)

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -200,6 +200,28 @@ static inline unsigned int jent_update_hashloop(unsigned int flags,
 	return flags;
 }
 
+/*
+ * The compliance modes claim a protected entropy collector state, so they turn
+ * secure memory from a best effort into a requirement: with them the
+ * allocation fails rather than leaving the state in memory that may be swapped
+ * out. Every other caller keeps the default, where memory the platform does
+ * not protect is tolerated.
+ *
+ * This normalization belongs to the caller-provided flags and therefore not
+ * into jent_entropy_collector_alloc_internal(): jent_time_entropy_init() ORs
+ * JENT_FORCE_FIPS into its test instance to get the health tests run, which is
+ * not a compliance statement, and deriving the requirement there would make
+ * every default allocation demand secure memory. Same reasoning as the
+ * JENT_DISABLE_MEMORY_ACCESS check in _jent_entropy_collector_alloc().
+ */
+static inline unsigned int jent_update_secure_mem(unsigned int flags)
+{
+	if (flags & (JENT_NTG1 | JENT_FORCE_FIPS))
+		flags |= JENT_FORCE_SECURE_MEM;
+
+	return flags;
+}
+
 /***************************************************************************
  * Random Number Generation
  ***************************************************************************/
@@ -333,7 +355,7 @@ ssize_t jent_read_entropy(struct rand_data *ec, char *data, size_t len)
 	 * pros and cons considering that the SHA3 operation is not that
 	 * expensive.
 	 */
-	if (!jent_secure_memory_supported())
+	if (!jent_memory_is_secure(ec->flags))
 		jent_read_random_block(ec, NULL, 0);
 
 err:
@@ -628,7 +650,7 @@ static struct rand_data
 	if (jent_notime_forced() && (flags & JENT_DISABLE_INTERNAL_TIMER))
 		return NULL;
 
-	entropy_collector = jent_zalloc(sizeof(struct rand_data));
+	entropy_collector = jent_zalloc(sizeof(struct rand_data), flags);
 	if (NULL == entropy_collector)
 		return NULL;
 
@@ -646,7 +668,7 @@ static struct rand_data
 		flags = jent_update_memsize(flags, 0);
 		memsize = jent_memsize(flags);
 		entropy_collector->mem =
-			(unsigned char *)jent_zalloc(memsize);
+			(unsigned char *)jent_zalloc(memsize, flags);
 
 		if (entropy_collector->mem == NULL)
 			goto err;
@@ -663,7 +685,7 @@ static struct rand_data
 	flags = jent_update_hashloop(flags, 0);
 	entropy_collector->hashloopcnt = jent_hashloop_cnt(flags);
 
-	if (jent_sha3_alloc(&entropy_collector->hash_state))
+	if (jent_sha3_alloc(&entropy_collector->hash_state, flags))
 		goto err;
 
 	/*
@@ -754,6 +776,8 @@ static struct rand_data *_jent_entropy_collector_alloc(unsigned int osr,
 	if ((flags & JENT_DISABLE_MEMORY_ACCESS) &&
 	    ((flags & (JENT_NTG1 | JENT_FORCE_FIPS)) || jent_fips_enabled()))
 		return NULL;
+
+	flags = jent_update_secure_mem(flags);
 
 	ec = jent_entropy_collector_alloc_internal(osr, flags);
 
@@ -899,7 +923,7 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 	int i, time_backwards = 0, count_stuck = 0, ret = 0;
 	unsigned int health_test_result;
 
-	delta_history = jent_gcd_init(JENT_POWERUP_TESTLOOPCOUNT);
+	delta_history = jent_gcd_init(JENT_POWERUP_TESTLOOPCOUNT, flags);
 	if (!delta_history)
 		return EMEM;
 
@@ -1033,7 +1057,12 @@ out:
 	return ret;
 }
 
-static inline int jent_entropy_init_common_pre(void)
+/*
+ * The flags are only needed for the memory the GCD self test allocates:
+ * JENT_FORCE_SECURE_MEM must reach it as well, or the initialization would
+ * report success on memory the collector allocation is then going to reject.
+ */
+static inline int jent_entropy_init_common_pre(unsigned int flags)
 {
 	int ret;
 
@@ -1043,7 +1072,7 @@ static inline int jent_entropy_init_common_pre(void)
 	if (jent_sha3_tester())
 		return EHASH;
 
-	ret = jent_gcd_selftest();
+	ret = jent_gcd_selftest(flags);
 
 	jent_selftest_run = 1;
 
@@ -1069,7 +1098,7 @@ static inline int jent_entropy_init_common_post(int ret)
 JENT_PRIVATE_STATIC
 int jent_entropy_init(void)
 {
-	int ret = jent_entropy_init_common_pre();
+	int ret = jent_entropy_init_common_pre(0);
 
 	if (ret)
 		return ret;
@@ -1087,7 +1116,17 @@ int jent_entropy_init(void)
 JENT_PRIVATE_STATIC
 int jent_entropy_init_ex(unsigned int osr, unsigned int flags)
 {
-	int ret = jent_entropy_init_common_pre();
+	int ret;
+
+	/*
+	 * Apply the same requirement the collector allocation will apply, so
+	 * that a caller asking for a compliance mode is not told the
+	 * initialization succeeded on memory that the later allocation then
+	 * refuses to work with.
+	 */
+	flags = jent_update_secure_mem(flags);
+
+	ret = jent_entropy_init_common_pre(flags);
 
 	if (ret)
 		return ret;

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -159,6 +159,15 @@ static inline unsigned int jent_update_memsize(unsigned int flags,
 		/* Adjust offset */
 		max = (max > JENT_MAX_MEMSIZE_OFFSET) ?
 			max - JENT_MAX_MEMSIZE_OFFSET : 0;
+
+		/*
+		 * Bound the automatically derived size. This is a no-op on
+		 * 64-bit targets; on 32-bit ones it keeps a large host cache
+		 * from deriving a working set that cannot be mapped and locked.
+		 * See JENT_MAX_AUTO_MEMSIZE.
+		 */
+		if (max > JENT_MAX_AUTO_MEMSIZE)
+			max = JENT_MAX_AUTO_MEMSIZE;
 	} else {
 		max += inc;
 	}
@@ -229,14 +238,21 @@ JENT_PRIVATE_STATIC
 ssize_t jent_read_entropy(struct rand_data *ec, char *data, size_t len)
 {
 	/*
-	 * Maximum value representable by ssize_t. Use a portable
-	 * definition in case SSIZE_MAX is not available under strict
-	 * C standard modes. It is nevertheless available on POSIX systems.
+	 * Maximum value representable by ssize_t. Use a portable definition
+	 * in case SSIZE_MAX is not available under strict C standard modes.
+	 * It is nevertheless available on POSIX systems.
+	 *
+	 * Clearing the sign bit of SIZE_MAX relies on ssize_t being the
+	 * signed counterpart of size_t, which the build assertion below
+	 * enforces. Deriving the shift count from sizeof(ssize_t) instead
+	 * would be undefined behavior as soon as ssize_t is the wider type.
 	 */
-	static const size_t ssize_max = (size_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1);
+	static const size_t ssize_max = (size_t)-1 >> 1;
 	char *p = data;
 	size_t orig_len;
 	int ret = 0;
+
+	JENT_BUILD_BUG_ON(sizeof(ssize_t) != sizeof(size_t));
 
 	/* check obvious misuse of API */
 	if (!ec || (data == NULL && len > 0))
@@ -435,14 +451,21 @@ JENT_PRIVATE_STATIC
 ssize_t jent_read_entropy_safe(struct rand_data **ec, char *data, size_t len)
 {
 	/*
-	 * Maximum value representable by ssize_t. Use a portable
-	 * definition in case SSIZE_MAX is not available under strict
-	 * C standard modes. It is nevertheless available on POSIX systems.
+	 * Maximum value representable by ssize_t. Use a portable definition
+	 * in case SSIZE_MAX is not available under strict C standard modes.
+	 * It is nevertheless available on POSIX systems.
+	 *
+	 * Clearing the sign bit of SIZE_MAX relies on ssize_t being the
+	 * signed counterpart of size_t, which the build assertion below
+	 * enforces. Deriving the shift count from sizeof(ssize_t) instead
+	 * would be undefined behavior as soon as ssize_t is the wider type.
 	 */
-	static const size_t ssize_max = (size_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1);
+	static const size_t ssize_max = (size_t)-1 >> 1;
 	char *p = data;
 	size_t orig_len;
 	ssize_t ret = 0;
+
+	JENT_BUILD_BUG_ON(sizeof(ssize_t) != sizeof(size_t));
 
 	/* check obvious misuse of API */
 	if (!ec || (data == NULL && len > 0))
@@ -565,8 +588,8 @@ static struct rand_data
 	 * health-test lookup tables are indexed with osr - 1, and an empty
 	 * [JENT_MIN_OSR, JENT_MAX_OSR] range would make every allocation fail.
 	 */
-	BUILD_BUG_ON(JENT_MIN_OSR < 1);
-	BUILD_BUG_ON(JENT_MIN_OSR > JENT_MAX_OSR);
+	JENT_BUILD_BUG_ON(JENT_MIN_OSR < 1);
+	JENT_BUILD_BUG_ON(JENT_MIN_OSR > JENT_MAX_OSR);
 
 	/*
 	 * Requesting disabling and forcing of internal timer
@@ -624,6 +647,7 @@ static struct rand_data
 		memsize = jent_memsize(flags);
 		entropy_collector->mem =
 			(unsigned char *)jent_zalloc(memsize);
+
 		if (entropy_collector->mem == NULL)
 			goto err;
 
@@ -968,10 +992,11 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 
 	/*
 	 * we allow up to three times the time running backwards.
-	 * CLOCK_REALTIME is affected by adjtime and NTP operations. Thus,
-	 * if such an operation just happens to interfere with our test, it
-	 * should not fail. The value of 3 should cover the NTP case being
-	 * performed during our test run.
+	 * All timer backends are monotonic by construction, but a counter read
+	 * can still appear to go backwards once in a while, e.g. when the
+	 * thread migrates between CPUs whose counters are not perfectly in
+	 * sync. Such an event must not fail the test outright; the value of 3
+	 * covers the occasional occurrence during our test run.
 	 */
 	if (time_backwards > 3) {
 		ret = ENOMONOTONIC;

--- a/src/jitterentropy-gcd.c
+++ b/src/jitterentropy-gcd.c
@@ -130,11 +130,11 @@ out:
 	return ret;
 }
 
-uint64_t *jent_gcd_init(size_t nelem)
+uint64_t *jent_gcd_init(size_t nelem, unsigned int flags)
 {
 	uint64_t *delta_history;
 
-	delta_history = jent_zalloc(nelem * sizeof(uint64_t));
+	delta_history = jent_zalloc(nelem * sizeof(uint64_t), flags);
 	if (!delta_history)
 		return NULL;
 
@@ -156,11 +156,11 @@ int jent_gcd_get(uint64_t *value)
 	return 0;
 }
 
-int jent_gcd_selftest(void)
+int jent_gcd_selftest(unsigned int flags)
 {
 #define JENT_GCD_SELFTEST_ELEM 10
 #define JENT_GCD_SELFTEST_EXP 3ULL
-	uint64_t *gcd = jent_gcd_init(JENT_GCD_SELFTEST_ELEM);
+	uint64_t *gcd = jent_gcd_init(JENT_GCD_SELFTEST_ELEM, flags);
 	uint64_t running_gcd, delta_sum;
 	unsigned int i;
 	int ret = EGCD;

--- a/src/jitterentropy-gcd.h
+++ b/src/jitterentropy-gcd.h
@@ -30,13 +30,13 @@ extern "C"
 JENT_PRIVATE_STATIC
 int jent_gcd_analyze(uint64_t *delta_history, size_t nelem, size_t osr);
 JENT_PRIVATE_STATIC
-uint64_t *jent_gcd_init(size_t nelem);
+uint64_t *jent_gcd_init(size_t nelem, unsigned int flags);
 JENT_PRIVATE_STATIC
 void jent_gcd_fini(uint64_t *delta_history, size_t nelem);
 JENT_PRIVATE_STATIC
 int jent_gcd_get(uint64_t *value);
 JENT_PRIVATE_STATIC
-int jent_gcd_selftest(void);
+int jent_gcd_selftest(unsigned int flags);
 
 /* Watch for common adjacent GCD values */
 #define jent_gcd_add_value(delta_history, delta, idx)			\

--- a/src/jitterentropy-health.c
+++ b/src/jitterentropy-health.c
@@ -88,18 +88,18 @@ static void jent_lag_init(struct rand_data *ec, unsigned int osr)
 	 * entropy rate of 1/osr.
 	 */
 	/* TODO: add permanent health failure */
-	if (osr > ARRAY_SIZE(jent_lag_global_cutoff_lookup)) {
+	if (osr > JENT_ARRAY_SIZE(jent_lag_global_cutoff_lookup)) {
 		ec->lag_global_cutoff =
 			jent_lag_global_cutoff_lookup[
-				ARRAY_SIZE(jent_lag_global_cutoff_lookup) - 1];
+				JENT_ARRAY_SIZE(jent_lag_global_cutoff_lookup) - 1];
 	} else {
 		ec->lag_global_cutoff = jent_lag_global_cutoff_lookup[osr - 1];
 	}
 
-	if (osr > ARRAY_SIZE(jent_lag_local_cutoff_lookup)) {
+	if (osr > JENT_ARRAY_SIZE(jent_lag_local_cutoff_lookup)) {
 		ec->lag_local_cutoff =
 			jent_lag_local_cutoff_lookup[
-				ARRAY_SIZE(jent_lag_local_cutoff_lookup) - 1];
+				JENT_ARRAY_SIZE(jent_lag_local_cutoff_lookup) - 1];
 	} else {
 		ec->lag_local_cutoff = jent_lag_local_cutoff_lookup[osr - 1];
 	}
@@ -316,11 +316,11 @@ static void jent_apt_init(struct rand_data *ec)
 	 * Establish the apt_cutoff based on the presumed entropy rate of
 	 * 1/osr.
 	 */
-	if (ec->osr >= ARRAY_SIZE(jent_apt_cutoff_lookup)) {
+	if (ec->osr >= JENT_ARRAY_SIZE(jent_apt_cutoff_lookup)) {
 		ec->apt_cutoff = jent_apt_cutoff_lookup[
-			ARRAY_SIZE(jent_apt_cutoff_lookup) - 1];
+			JENT_ARRAY_SIZE(jent_apt_cutoff_lookup) - 1];
 		ec->apt_cutoff_permanent = jent_apt_cutoff_permanent_lookup[
-			ARRAY_SIZE(jent_apt_cutoff_permanent_lookup) - 1];
+			JENT_ARRAY_SIZE(jent_apt_cutoff_permanent_lookup) - 1];
 	} else {
 		ec->apt_cutoff = jent_apt_cutoff_lookup[ec->osr - 1];
 		ec->apt_cutoff_permanent =
@@ -345,12 +345,12 @@ static const unsigned int jent_apt_cutoff_permanent_lookup_ntg1[15]=
 
 static void jent_apt_init_ntg1(struct rand_data *ec)
 {
-	if (ec->osr >= ARRAY_SIZE(jent_apt_cutoff_lookup_ntg1)) {
+	if (ec->osr >= JENT_ARRAY_SIZE(jent_apt_cutoff_lookup_ntg1)) {
 		ec->apt_cutoff = jent_apt_cutoff_lookup_ntg1[
-			ARRAY_SIZE(jent_apt_cutoff_lookup_ntg1) - 1];
+			JENT_ARRAY_SIZE(jent_apt_cutoff_lookup_ntg1) - 1];
 		ec->apt_cutoff_permanent =
 			jent_apt_cutoff_permanent_lookup_ntg1[
-			ARRAY_SIZE(jent_apt_cutoff_permanent_lookup_ntg1) - 1];
+			JENT_ARRAY_SIZE(jent_apt_cutoff_permanent_lookup_ntg1) - 1];
 	} else {
 		ec->apt_cutoff = jent_apt_cutoff_lookup_ntg1[ec->osr - 1];
 		ec->apt_cutoff_permanent =
@@ -475,12 +475,12 @@ static const unsigned short jent_rct_mem_cutoff_permanent_lookup[] =
 
 static void jent_rct_mem_init(struct rand_data *ec)
 {
-	if (ec->osr >= ARRAY_SIZE(jent_rct_mem_cutoff_lookup)) {
+	if (ec->osr >= JENT_ARRAY_SIZE(jent_rct_mem_cutoff_lookup)) {
 		ec->rct_mem_cutoff = jent_rct_mem_cutoff_lookup[
-			ARRAY_SIZE(jent_rct_mem_cutoff_lookup) - 1];
+			JENT_ARRAY_SIZE(jent_rct_mem_cutoff_lookup) - 1];
 		ec->rct_mem_cutoff_permanent =
 			jent_rct_mem_cutoff_permanent_lookup[
-			ARRAY_SIZE(jent_rct_mem_cutoff_permanent_lookup) - 1];
+			JENT_ARRAY_SIZE(jent_rct_mem_cutoff_permanent_lookup) - 1];
 	} else {
 		ec->rct_mem_cutoff = jent_rct_mem_cutoff_lookup[ec->osr - 1];
 		ec->rct_mem_cutoff_permanent =
@@ -505,12 +505,12 @@ static const unsigned short jent_rct_mem_cutoff_permanent_lookup_ntg1[] =
 	  1178, 1285, 1392, 1499, 1606, 1713, 1820, 1927, 2034, 2141 };
 static void jent_rct_mem_init_ntg1(struct rand_data *ec)
 {
-	if (ec->osr >= ARRAY_SIZE(jent_rct_mem_cutoff_lookup_ntg1)) {
+	if (ec->osr >= JENT_ARRAY_SIZE(jent_rct_mem_cutoff_lookup_ntg1)) {
 		ec->rct_mem_cutoff = jent_rct_mem_cutoff_lookup_ntg1[
-			ARRAY_SIZE(jent_rct_mem_cutoff_lookup_ntg1) - 1];
+			JENT_ARRAY_SIZE(jent_rct_mem_cutoff_lookup_ntg1) - 1];
 		ec->rct_mem_cutoff_permanent =
 			jent_rct_mem_cutoff_permanent_lookup_ntg1[
-			ARRAY_SIZE(jent_rct_mem_cutoff_permanent_lookup_ntg1) - 1];
+			JENT_ARRAY_SIZE(jent_rct_mem_cutoff_permanent_lookup_ntg1) - 1];
 	} else {
 		ec->rct_mem_cutoff =
 			jent_rct_mem_cutoff_lookup_ntg1[ec->osr - 1];

--- a/src/jitterentropy-internal.h
+++ b/src/jitterentropy-internal.h
@@ -66,6 +66,25 @@
  * this file.
  */
 #include <linux/math64.h>	/* div64_u64(), div64_u64_rem() */
+/*
+ * memcpy()/memset() are used by the core itself (jitterentropy-base.c,
+ * jitterentropy-noise.c, jitterentropy-sha3.c). They used to arrive here by
+ * accident, dragged in behind <linux/timex.h> via the arch timer header; that
+ * header now lives in arch/jitterentropy-arch-timer.c and the core no longer
+ * sees it, so the dependency is stated where it is actually used. <linux/
+ * string.h> is itself fine at -O0 - it was already being compiled that way
+ * through the transitive path this replaces.
+ */
+#include <linux/string.h>	/* memcpy(), memset() */
+/*
+ * Reached the core the same accidental way: -EAGAIN is returned by
+ * jitterentropy-gcd.c and jitterentropy-health.c, and the kernel's
+ * fallthrough attribute backs JENT_FALLTHROUGH below for kernel builds. Both
+ * used to arrive behind <linux/timex.h> -> <linux/kernel.h>. Neither header is
+ * heavier than the ones above and both are safe for the -O0 core.
+ */
+#include <linux/errno.h>	/* EAGAIN */
+#include <linux/compiler.h>	/* fallthrough */
 #endif
 
 #ifdef __cplusplus
@@ -87,20 +106,8 @@ extern "C" {
 # endif
 #endif
 
-/*
- * jitterentropy.h intentionally does not pull in <linux/module.h> (and thus not
- * <linux/kernel.h>) to keep the -O0 core free of headers that do not compile at
- * -O0 on modern kernels. Provide ARRAY_SIZE()/BUILD_BUG_ON() here for the core.
- * The guards matter on older kernels where the arch headers included above
- * still drag in <linux/kernel.h> transitively (e.g. via <linux/timex.h>), which
- * defines these macros; there the kernel's definitions are used unchanged.
- */
-#ifndef BUILD_BUG_ON
-# define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-#endif
-#ifndef ARRAY_SIZE
-# define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
-#endif
+/* The kernel supplies a fallthrough macro of its own. */
+#define JENT_FALLTHROUGH	fallthrough
 
 /*
  * Test interface support (see jitterentropy-base.c): allocate an entropy
@@ -135,15 +142,28 @@ static inline uint64_t jent_umod64(uint64_t dividend, uint64_t divisor)
 
 #else /* LINUX_KERNEL */
 
-#if __has_attribute(__fallthrough__)
-# define fallthrough	__attribute__((__fallthrough__))
-#else
-# define fallthrough	do {} while (0)
+/*
+ * Deliberately JENT_-prefixed rather than the bare lowercase "fallthrough".
+ * This header is included before the platform headers in several translation
+ * units, and a macro by that name silently rewrites any system header that
+ * probes for the attribute - Apple's <os/base.h>, reached through
+ * <mach/mach.h>, does exactly that with __has_attribute(fallthrough) and
+ * fails to compile once the bare macro is in scope.
+ *
+ * __has_attribute() itself must be probed with defined() first: compilers
+ * that do not provide it (MSVC) replace the unknown identifier with 0 and
+ * then choke on the leftover "(__fallthrough__)" argument list - a constraint
+ * violation, which MSVC reports as warning C4067 in every translation unit
+ * including this header.
+ */
+#if defined(__has_attribute)
+# if __has_attribute(__fallthrough__)
+#  define JENT_FALLTHROUGH	__attribute__((__fallthrough__))
+# endif
 #endif
-
-#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#ifndef JENT_FALLTHROUGH
+# define JENT_FALLTHROUGH	do {} while (0)
+#endif
 
 /*
  * 64-bit division / modulo with a 64-bit divisor; see the kernel branch
@@ -161,6 +181,34 @@ static inline uint64_t jent_umod64(uint64_t dividend, uint64_t divisor)
 }
 
 #endif /* LINUX_KERNEL */
+
+/*
+ * JENT_-prefixed, and defined outside the LINUX_KERNEL split above, for the
+ * same reason JENT_FALLTHROUGH is: the bare names belong to the environment,
+ * not to this library.
+ *
+ * jitterentropy.h deliberately does not pull in <linux/module.h> (and so not
+ * <linux/kernel.h>), which keeps the -O0 entropy core free of headers that do
+ * not compile without optimisation - but it also means the kernel's
+ * ARRAY_SIZE()/BUILD_BUG_ON() are not available to the core, so equivalents
+ * have to be defined here.
+ *
+ * Spelling them with the kernel's names and an #ifndef guard is what this did
+ * before, and it only worked by accident: some other header had to define them
+ * first for the guard to suppress ours. That held while <linux/timex.h> pulled
+ * <linux/kernel.h> into every translation unit; once the timer backend moved
+ * out (see arch/jitterentropy-arch-timer.c) our definitions landed first
+ * instead, and every file that later included a kernel header got a
+ * "'ARRAY_SIZE' redefined" warning. A distinct name cannot collide in either
+ * order, on any kernel, so no guard is needed.
+ *
+ * linux_kernel/ is deliberately not converted: that layer includes
+ * <linux/kernel.h> itself and uses the kernel's own macros, as kernel code
+ * should.
+ */
+#define JENT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
+
+#define JENT_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 #ifndef JENT_STUCK_INIT_THRES
 /*
@@ -258,6 +306,31 @@ static inline uint64_t jent_umod64(uint64_t dividend, uint64_t divisor)
  */
 #ifndef JENT_CACHE_SHIFT_BITS
 #define JENT_CACHE_SHIFT_BITS 0
+#endif
+
+/*
+ * Ceiling for the memory size that jent_update_memsize() derives on its own
+ * from the discovered cache geometry. It does not constrain a size the caller
+ * requested explicitly with a JENT_MAX_MEMSIZE_* flag - that is the caller's
+ * decision to make - only the automatic one.
+ *
+ * On a 64-bit target this is JENT_MAX_MEMSIZE_MAX, i.e. no additional limit.
+ * On a 32-bit target the address space is the binding constraint rather than
+ * the cache: a two-socket machine with a large L3 makes JENT_CACHE_ALL derive
+ * the full 512 MB, which the collector then both maps and mlock()s. That is a
+ * sixth of the usable address space of a 32-bit process and well beyond a
+ * typical RLIMIT_MEMLOCK, so jent_zalloc() fails and the whole collector
+ * allocation fails with it. Capping the derived value at 64 MB keeps the
+ * automatic path working on i686, armv7, RV32 and 31-bit s390.
+ *
+ * UINTPTR_MAX is the pointer-width test; where it is unavailable (the Linux
+ * kernel build does not define it) the 64-bit branch is taken, which leaves
+ * that configuration's behaviour unchanged.
+ */
+#if defined(UINTPTR_MAX) && (UINTPTR_MAX <= 0xffffffffUL)
+# define JENT_MAX_AUTO_MEMSIZE JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_64MB)
+#else
+# define JENT_MAX_AUTO_MEMSIZE JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_MAX)
 #endif
 
 /*

--- a/src/jitterentropy-noise.c
+++ b/src/jitterentropy-noise.c
@@ -76,7 +76,7 @@ static void jent_hash_insert(struct rand_data *ec, uint64_t time_delta,
 	memcpy(intermediary + JENT_OFFSET_TIMEDELTA,
 	       (uint8_t *)&time_delta, sizeof(uint64_t));
 
-	BUILD_BUG_ON(JENT_SIZEOF_INTERMEDIARY < JENT_SIZEOF_INTERMEDIARY_DATA);
+	JENT_BUILD_BUG_ON(JENT_SIZEOF_INTERMEDIARY < JENT_SIZEOF_INTERMEDIARY_DATA);
 
 	/*
 	 * Inject the data from the intermediary buffer, including the hash we
@@ -122,8 +122,8 @@ static void jent_hash_loop(struct rand_data *ec,
 	 */
 	uint64_t hash_loop_cnt = loop_cnt ? loop_cnt : ec->hashloopcnt;
 
-	BUILD_BUG_ON(JENT_HASH_LOOP_DEFAULT < 1);
-	BUILD_BUG_ON(JENT_HASH_LOOP_INIT < 1);
+	JENT_BUILD_BUG_ON(JENT_HASH_LOOP_DEFAULT < 1);
+	JENT_BUILD_BUG_ON(JENT_HASH_LOOP_INIT < 1);
 
 	jent_sha3_256_init(&ctx);
 
@@ -626,7 +626,7 @@ void jent_random_data(struct rand_data *ec)
 				     jent_health_init_type_ntg1 :
 				     jent_health_init_type_common);
 
-		fallthrough;
+		JENT_FALLTHROUGH;
 	case jent_startup_sha3:
 		jent_random_data_one(ec, jent_measure_jitter_ntg1_sha3);
 		ec->startup_state = jent_startup_completed;

--- a/src/jitterentropy-sha3.c
+++ b/src/jitterentropy-sha3.c
@@ -54,12 +54,10 @@ static inline void le64_to_ptr(uint8_t *p, const uint64_t value)
 	le32_to_ptr(p,     (uint32_t)(value));
 }
 
-#ifndef LINUX_KERNEL
 static inline uint64_t rol64(uint64_t x, unsigned int n)
 {
 	return ( (x << (n&(64-1))) | (x >> ((64-n)&(64-1))) );
 }
-#endif
 
 /*********************************** Keccak ***********************************/
 /* state[x + y*5] */
@@ -372,8 +370,12 @@ void jent_sha3_final(struct jent_sha_ctx *ctx, uint8_t *digest)
 	 *   have a loop around the jent_keccakp_1600 / copy out loop below
 	 *
 	 * * the requested digest size must be multiples of uint64_t
+	 *
+	 * digestsize is a uint8_t, whose integral promotion makes the division
+	 * below a signed int; the cast keeps both sides of the comparison
+	 * unsigned (MSVC /W4 warns C4018 about the mismatch otherwise).
 	 */
-	for (i = 0; i < ctx->digestsize / 8; i++, digest += 8)
+	for (i = 0; i < (unsigned int)ctx->digestsize / 8; i++, digest += 8)
 		le64_to_ptr(digest, ctx->state[i]);
 
 	memset(ctx->partial, 0, ctx->r);
@@ -424,19 +426,19 @@ static void jent_xdrbg256_generate_block(struct jent_sha_ctx *ctx, uint8_t *dst,
 	uint8_t encode;
 
 	/* Checking the output size */
-	BUILD_BUG_ON(JENT_SHA3_256_SIZE_DIGEST != ((DATA_SIZE_BITS / 8)));
+	JENT_BUILD_BUG_ON(JENT_SHA3_256_SIZE_DIGEST != ((DATA_SIZE_BITS / 8)));
 	/*
 	 * The XOF implementation only allows the generation of up to one
 	 * rate-size block. See the comments in the squeeze operation for
 	 * details
 	 */
-	BUILD_BUG_ON(JENT_SHA3_256_SIZE_BLOCK < sizeof(jent_block_next_state));
+	JENT_BUILD_BUG_ON(JENT_SHA3_256_SIZE_BLOCK < sizeof(jent_block_next_state));
 	/*
 	 * The squeeze operation is limited to return multiples of uint64_t -
 	 * verify all set_digestsize values.
 	 */
-	BUILD_BUG_ON(JENT_XDRBG_SIZE_STATE % sizeof(uint64_t));
-	BUILD_BUG_ON(sizeof(jent_block_next_state) % sizeof(uint64_t));
+	JENT_BUILD_BUG_ON(JENT_XDRBG_SIZE_STATE % sizeof(uint64_t));
+	JENT_BUILD_BUG_ON(sizeof(jent_block_next_state) % sizeof(uint64_t));
 
 	/* The final operation automatically re-initializes the ->hash_state */
 
@@ -561,7 +563,7 @@ static int jent_xdrbg256_tester(void)
 	uint8_t act[sizeof(exp)] = { 0 };
 	unsigned int i;
 
-	BUILD_BUG_ON(JENT_SHA3_256_SIZE_DIGEST != sizeof(exp));
+	JENT_BUILD_BUG_ON(JENT_SHA3_256_SIZE_DIGEST != sizeof(exp));
 
 	jent_shake256_init(&ctx);
 	/* Initial seed */

--- a/src/jitterentropy-sha3.c
+++ b/src/jitterentropy-sha3.c
@@ -382,11 +382,11 @@ void jent_sha3_final(struct jent_sha_ctx *ctx, uint8_t *digest)
 	jent_sha3_init(ctx);
 }
 
-int jent_sha3_alloc(void **hash_state)
+int jent_sha3_alloc(void **hash_state, unsigned int flags)
 {
 	struct jent_sha_ctx *tmp;
 
-	tmp = jent_zalloc(JENT_SHA_MAX_CTX_SIZE);
+	tmp = jent_zalloc(JENT_SHA_MAX_CTX_SIZE, flags);
 	if (!tmp)
 		return 1;
 

--- a/src/jitterentropy-sha3.h
+++ b/src/jitterentropy-sha3.h
@@ -64,7 +64,7 @@ void jent_sha3_256_init(struct jent_sha_ctx *ctx);
 void jent_sha3_update(struct jent_sha_ctx *ctx, const uint8_t *in,
 		      size_t inlen);
 void jent_sha3_final(struct jent_sha_ctx *ctx, uint8_t *digest);
-int jent_sha3_alloc(void **hash_state);
+int jent_sha3_alloc(void **hash_state, unsigned int flags);
 void jent_sha3_dealloc(void *hash_state);
 int jent_sha3_tester(void);
 

--- a/src/jitterentropy-status.c
+++ b/src/jitterentropy-status.c
@@ -160,7 +160,7 @@ int jent_status(const struct rand_data *ec, char *buf, size_t buflen)
 	jent_add_to_status("\t\t\t\"initialization\": %u\n", ec->memaccessloops * JENT_MEM_ACC_LOOP_INIT);
 	jent_add_to_status("\t\t},\n");
 
-	jent_add_to_status("\t\t\"secureMemory\": %s,\n", jent_secure_memory_supported() ? "true" : "false");
+	jent_add_to_status("\t\t\"secureMemory\": %s,\n", jent_memory_is_secure(ec->flags) ? "true" : "false");
 	jent_add_to_status("\t\t\"internalTimer\": %s,\n", ec->enable_notime ? "true" : "false");
 	jent_add_to_status("\t\t\"fipsMode\": %s,\n", ec->is_fips_enabled ? "true" : "false");
 	jent_add_to_status("\t\t\"ntg1Mode\": %s,\n", !!(ec->flags & JENT_NTG1) ? "true" : "false");
@@ -176,8 +176,10 @@ int jent_status(const struct rand_data *ec, char *buf, size_t buflen)
 		 !!(ec->flags & JENT_FORCE_FIPS) ? "true" : "false");
 	jent_add_to_status("\t\t\t\"JENT_NTG1\": %s,\n",
 		 !!(ec->flags & JENT_NTG1) ? "true" : "false");
-	jent_add_to_status("\t\t\t\"JENT_CACHE_ALL\": %s\n",
+	jent_add_to_status("\t\t\t\"JENT_CACHE_ALL\": %s,\n",
 		 !!(ec->flags & JENT_CACHE_ALL) ? "true" : "false");
+	jent_add_to_status("\t\t\t\"JENT_FORCE_SECURE_MEM\": %s\n",
+		 !!(ec->flags & JENT_FORCE_SECURE_MEM) ? "true" : "false");
 	jent_add_to_status("\t\t}\n");
 	jent_add_to_status("\t}\n");
 

--- a/src/jitterentropy-timer.c
+++ b/src/jitterentropy-timer.c
@@ -37,8 +37,7 @@
 static int jent_notime_cpu_configured = 0;
 static unsigned long jent_notime_cpu = 0;
 
-JENT_PRIVATE_STATIC
-int jent_notime_init(void **ctx)
+static int jent_notime_init_flags(void **ctx, unsigned int flags)
 {
 	struct jent_notime_ctx *thread_ctx;
 	long ncpu = jent_ncpu();
@@ -50,7 +49,7 @@ int jent_notime_init(void **ctx)
 	if (ncpu < 2)
 		return -ENOENT;
 
-	thread_ctx = jent_zalloc(sizeof(struct jent_notime_ctx));
+	thread_ctx = jent_zalloc(sizeof(struct jent_notime_ctx), flags);
 	if (!thread_ctx)
 		return -ENOMEM;
 
@@ -74,6 +73,20 @@ int jent_notime_init(void **ctx)
 	*ctx = thread_ctx;
 
 	return 0;
+}
+
+/*
+ * The registered-handler interface (struct jent_notime_thread) passes nothing
+ * but the context pointer, so this entry point - the one an external handler
+ * replaces - cannot know the collector flags and allocates its context with
+ * the default ones. The builtin handler is not called through it but through
+ * jent_notime_init_flags() above, which does see them (see
+ * jent_notime_enable_thread()).
+ */
+JENT_PRIVATE_STATIC
+int jent_notime_init(void **ctx)
+{
+	return jent_notime_init_flags(ctx, 0);
 }
 
 JENT_PRIVATE_STATIC
@@ -245,11 +258,23 @@ void jent_get_nstime_internal(struct rand_data *ec, uint64_t *out)
 	}
 }
 
-static inline int jent_notime_enable_thread(struct rand_data *ec)
+static inline int jent_notime_enable_thread(struct rand_data *ec,
+					    unsigned int flags)
 {
-	if (notime_thread)
-		return notime_thread->jent_notime_init(&ec->notime_thread_ctx);
-	return 0;
+	if (!notime_thread)
+		return 0;
+
+	/*
+	 * Reach the builtin handler through the variant that takes the flags:
+	 * it allocates its context with jent_zalloc() and therefore has to
+	 * honor JENT_FORCE_SECURE_MEM like every other allocation of this
+	 * collector. An externally registered handler is reached through the
+	 * documented interface, which has no room for them.
+	 */
+	if (notime_thread == &jent_notime_thread_builtin)
+		return jent_notime_init_flags(&ec->notime_thread_ctx, flags);
+
+	return notime_thread->jent_notime_init(&ec->notime_thread_ctx);
 }
 
 void jent_notime_disable(struct rand_data *ec)
@@ -269,7 +294,7 @@ int jent_notime_enable(struct rand_data *ec, unsigned int flags)
 			return EHEALTH;
 
 		ec->enable_notime = 1;
-		return jent_notime_enable_thread(ec);
+		return jent_notime_enable_thread(ec, flags);
 	}
 
 	return 0;

--- a/src/jitterentropy-timer.c
+++ b/src/jitterentropy-timer.c
@@ -60,6 +60,11 @@ int jent_notime_init(void **ctx)
 	 * thread is left unpinned, so on the >= 2 CPUs guaranteed above the
 	 * scheduler keeps the two on separate cores and the counter keeps
 	 * ticking while the consumer busy-waits.
+	 *
+	 * Pinning is advisory: jent_thread_pin_to_cpu() reports -ENOTSUP on
+	 * platforms without an affinity API (OpenBSD, and macOS on Apple
+	 * Silicon). There the two threads are merely left to the scheduler,
+	 * which the >= 2 CPU requirement above still makes workable.
 	 */
 	if (jent_notime_cpu_configured)
 		thread_ctx->notime_cpu = jent_notime_cpu;

--- a/tests/gcd/gcd.c
+++ b/tests/gcd/gcd.c
@@ -46,7 +46,7 @@
 #define EXP_GCD 50ULL
 int main(int argc, char *argv[])
 {
-	uint64_t *gcd = jent_gcd_init(ELEM);
+	uint64_t *gcd = jent_gcd_init(ELEM, 0);
 	uint64_t val;
 	unsigned int i;
 

--- a/tests/raw-entropy/extractlsb.c
+++ b/tests/raw-entropy/extractlsb.c
@@ -43,6 +43,19 @@
 #include <unistd.h>
 #endif
 
+/*
+ * Windows opens file descriptors in text mode unless O_BINARY is requested:
+ * every 0x0A byte of the extracted sample stream would be written out as
+ * 0x0D 0x0A, silently corrupting (and inflating) the SP800-90B input data.
+ * POSIX makes no such distinction and has no O_BINARY.
+ */
+#if !defined(O_BINARY) && defined(_O_BINARY)
+# define O_BINARY _O_BINARY
+#endif
+#ifndef O_BINARY
+# define O_BINARY 0
+#endif
+
 #define BITS_PER_SAMPLE 64
 
 /*
@@ -203,7 +216,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	fd = open(argv[2], O_CREAT|O_WRONLY|O_EXCL, 0777);
+	fd = open(argv[2], O_CREAT|O_WRONLY|O_EXCL|O_BINARY, 0777);
 	if (fd < 0) {
 		fprintf(stderr, "File %s cannot be opened for write: %s\n",
 			argv[2], strerror(errno));

--- a/tests/raw-entropy/recording_userspace/CMakeLists.txt
+++ b/tests/raw-entropy/recording_userspace/CMakeLists.txt
@@ -3,19 +3,92 @@ cmake_minimum_required(VERSION 3.14)
 project(jitterentropy C)
 set(CMAKE_C_STANDARD 11)
 
-find_library(MATH_LIBRARY m)
+# jitterentropy-osr.c calls floor() and ceil(). Whether those need an explicit
+# -lm depends on the C library: glibc before 2.34 and musl keep them in libm,
+# newer glibc, macOS and mingw-w64 resolve them from the default libraries.
+#
+# This is deliberately not find_library(MATH_LIBRARY m). That searches library
+# *paths* and never sees CMAKE_C_FLAGS, so under a flag-selected target - most
+# obviously -m32 - it fails to turn up a usable libm, reports NOTFOUND, and the
+# guard below then silently drops -lm from the link. The result was a link that
+# died on "undefined reference to floor". check_symbol_exists() compiles and
+# links a probe with the real compiler and the real flags, so it answers for the
+# target actually being built.
+include(CheckSymbolExists)
+check_symbol_exists(floor "math.h" JENT_FLOOR_IN_DEFAULT_LIBS)
+if(NOT JENT_FLOOR_IN_DEFAULT_LIBS)
+    set(CMAKE_REQUIRED_LIBRARIES m)
+    check_symbol_exists(floor "math.h" JENT_FLOOR_IN_LIBM)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(JENT_FLOOR_IN_LIBM)
+        set(MATH_LIBRARY m)
+    else()
+        message(FATAL_ERROR
+            "floor() is available neither by default nor with -lm")
+    endif()
+endif()
 
+# Two kinds of program are built here.
+#
+# Most are ordinary consumers of the library and link it like any other user
+# would. The exception is marked AMALGAMATED: that program #includes every
+# library .c file directly (see the include block at the top of the source) so
+# that it can instrument internals the installed library does not export. It is
+# therefore already a complete copy of the library and must NOT also link it -
+# on Windows the defining and the importing copy collide outright ("multiple
+# definition of jent_read_entropy"), while on ELF the duplicate was merely
+# masked by -fvisibility=hidden letting the local copy win. It also has to
+# satisfy the dependencies of the sources it absorbed, and to build against the
+# public header as the library does rather than as a consumer.
 function(testprogram name)
+    cmake_parse_arguments(TP "AMALGAMATED" "" "" ${ARGN})
     add_executable(${name} ${name}.c)
-    target_link_libraries(${name} ${PROJECT_NAME})
+
+    if(TP_AMALGAMATED)
+        target_compile_definitions(${name} PRIVATE JENT_STATIC_LIB)
+        # arch/ is normally supplied by the library target's interface, which
+        # this program deliberately does not use.
+        target_include_directories(${name} PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../arch>)
+        if(WIN32)
+            # Carries its own copy of arch/jitterentropy-arch-uuid.c and so its
+            # own BCryptGenRandom() call to resolve.
+            target_link_libraries(${name} "bcrypt")
+        endif()
+        # Likewise its own copy of the internal timer, so its own
+        # pthread_create(). The library target carries this dependency in its
+        # link interface, but that interface is reached by linking the library,
+        # which this program deliberately does not do. See the definition of
+        # JITTER_THREAD_LIBRARIES in the top-level CMakeLists.txt.
+        target_link_libraries(${name} ${JITTER_THREAD_LIBRARIES})
+        # And for the same reason its own external crypto dependency: with
+        # EXTERNAL_CRYPTO set, the sources absorbed here compile against
+        # <openssl/evp.h> or <gcrypt.h> and call into that library, while the
+        # header and library locations the top-level CMakeLists.txt found are
+        # attached to the library target this program does not link. Without
+        # these two lines an EXTERNAL_CRYPTO build fails on the include and,
+        # once that is satisfied, on OPENSSL_secure_malloc() at link time.
+        # Empty and harmless in the default build, where EXTERNAL_CRYPTO is off.
+        if(EXTERNAL_CRYPTO)
+            target_include_directories(${name} PRIVATE ${LIBCRYPTO_INCLUDE_DIR})
+            target_link_libraries(${name} ${LIBCRYPTO_LIBRARY})
+        endif()
+        # The stack protector needs no equivalent line: the top-level
+        # CMakeLists.txt puts its flag on every target's link command with
+        # add_link_options(), precisely because relying on the library's link
+        # interface for it does not survive a shared build.
+    else()
+        target_link_libraries(${name} ${PROJECT_NAME})
+    endif()
+
     if(MATH_LIBRARY)
         target_link_libraries(${name} ${MATH_LIBRARY})
     endif()
-    if(MINGW AND INTERNAL_TIMER)
-        target_link_libraries(${name} "pthread")
-    endif()
-    target_link_directories(${name} PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../build>)
+    # No target_link_directories() here: the library is linked through the
+    # ${PROJECT_NAME} target above, which carries its own location. The
+    # hard-coded ../../../build path this used to add does not exist for any
+    # out-of-tree build directory, and Apple's ld64 warns about every missing
+    # search path ("ld: warning: search path ... not found").
     target_include_directories(${name} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../..>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../src>)
@@ -24,6 +97,6 @@ function(testprogram name)
     install(TARGETS ${name})
 endfunction()
 
-testprogram(jitterentropy-hashtime)
+testprogram(jitterentropy-hashtime AMALGAMATED)
 testprogram(jitterentropy-osr)
 testprogram(jitterentropy-rng)

--- a/tests/raw-entropy/recording_userspace/Makefile.osr
+++ b/tests/raw-entropy/recording_userspace/Makefile.osr
@@ -4,7 +4,11 @@ CC ?= gcc
 CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0
 #Hardening
 CFLAGS +=-fwrapv --param ssp-buffer-size=4
-LDFLAGS +=-Wl,-z,relro,-z,now -lm
+LDFLAGS +=-lm
+# ld64 supports neither -z relro nor -z now.
+ifneq (Darwin,$(shell uname))
+LDFLAGS +=-Wl,-z,relro,-z,now
+endif
 
 GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | sed 's/\./\n/g' | wc -l`)
 ifeq "$(GCCVERSIONFORMAT)" "3"
@@ -37,7 +41,12 @@ vpath %.c $(JENT_DIR)/src $(JENT_DIR)/arch
 
 INCLUDE_DIRS := $(JENT_DIR) $(JENT_DIR)/src
 LIBRARY_DIRS :=
+# macOS has no librt; the clock/timer functions live in libSystem.
+ifeq (Darwin,$(shell uname))
+LIBRARIES := pthread
+else
 LIBRARIES := rt pthread
+endif
 
 CFLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir))

--- a/tests/raw-entropy/recording_userspace/Makefile.rng
+++ b/tests/raw-entropy/recording_userspace/Makefile.rng
@@ -39,7 +39,12 @@ vpath %.c $(JENT_DIR)/src $(JENT_DIR)/arch
 
 INCLUDE_DIRS := $(JENT_DIR) $(JENT_DIR)/src
 LIBRARY_DIRS :=
+# macOS has no librt; the clock/timer functions live in libSystem.
+ifeq (Darwin,$(shell uname))
+LIBRARIES := pthread
+else
 LIBRARIES := rt pthread
+endif
 
 CFLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir))

--- a/tests/raw-entropy/recording_userspace/README.md
+++ b/tests/raw-entropy/recording_userspace/README.md
@@ -58,6 +58,18 @@ noise data to be analyzed with the tool set given in `validation-runtime`:
   permissions as it attempts to allocate up to 512MB of mlock'ed memory (which
   typically exceeds the ulimit for a normal user).
 
+The `JENT_NTG1` and `JENT_FORCE_FIPS` modes require the memory of the entropy
+collector to be locked into RAM, i.e. the allocation fails when the operating
+system refuses the lock. How much memory may be locked is not set by the library
+but bounded per process by the operating system: `RLIMIT_MEMLOCK` on POSIX
+systems and the process working set quota on Windows. For these two modes the
+recording tools raise that limit as far as the process is allowed to - see
+`jitterentropy-memlock.h`. Raising the `RLIMIT_MEMLOCK` *hard* limit requires
+privileges, so the large memory sizes (see the notes on root permissions above)
+still need the tool to be invoked as root, whereas the smaller ones now work as
+a normal user; where the limit is not sufficient, the tool reports that the
+Jitter RNG handle cannot be allocated.
+
 ## Recording of Raw Entropy Data
 
 If the `invoke_testing.sh` is not helpful for performing the test, the following

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -51,6 +51,7 @@
 #include "jitterentropy-arch-ncpu.c"
 #include "jitterentropy-arch-sched.c"
 #include "jitterentropy-arch-thread.c"
+#include "jitterentropy-arch-timer.c"
 #include "jitterentropy-arch-uuid.c"
 
 #ifndef REPORT_COUNTER_TICKS
@@ -168,7 +169,16 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 
 	printf("Processing %s\n", pathname);
 
+	/*
+	 * "wb" for the binary variant: Windows opens streams in text mode
+	 * otherwise and would expand every 0x0A byte of the recorded
+	 * timestamps to 0x0D 0x0A, corrupting the sample file.
+	 */
+#ifdef JENT_TEST_BINARY_OUTPUT
+	out = fopen(pathname, "wb");
+#else
 	out = fopen(pathname, "w");
+#endif
 	if (!out) {
 		ret = 1;
 		goto out;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -122,7 +122,7 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 		goto out;
 	}
 #else
-	jent_entropy_init_common_pre();
+	jent_entropy_init_common_pre(flags);
 #endif
 
 	/*

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -54,6 +54,8 @@
 #include "jitterentropy-arch-timer.c"
 #include "jitterentropy-arch-uuid.c"
 
+#include "jitterentropy-memlock.h"
+
 #ifndef REPORT_COUNTER_TICKS
 #define REPORT_COUNTER_TICKS 1
 #endif
@@ -507,6 +509,25 @@ int main(int argc, char * argv[])
 		argc--;
 		argv++;
 	}
+
+	/*
+	 * The compliance modes require the collector memory to be locked into
+	 * RAM, which the operating system permits only within a per-process
+	 * limit. Raised once here rather than per repeat below, as the limit is
+	 * process-wide state. See jitterentropy-memlock.h.
+	 */
+	if (jent_raise_memlock_limit(flags))
+		fprintf(stderr,
+			"Cannot raise the memory lock limit, allocating the entropy collector may fail\n");
+
+	/*
+	 * Likewise the secure memory arena of the external crypto backends,
+	 * which is created once for the process and is what the library
+	 * allocates the collector from. See jitterentropy-memlock.h.
+	 */
+	if (jent_init_secure_memory(flags))
+		fprintf(stderr,
+			"Cannot create the secure memory arena, allocating the entropy collector will fail\n");
 
 	for (i = 1; i <= repeats; i++) {
 		int len;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-memlock.h
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-memlock.h
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) 2019 - 2026, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * Memory lock limit handling and secure memory arena setup for the recording
+ * tools.
+ *
+ * In the compliance modes - JENT_NTG1 and JENT_FORCE_FIPS, which imply
+ * JENT_FORCE_SECURE_MEM - the memory of the entropy collector must be locked
+ * into RAM: a lock the operating system refuses fails the allocation instead
+ * of leaving the state in memory that may be swapped out. How much memory a
+ * process may lock is bounded by the operating system, and the bound is well
+ * below the memory block the collector maps:
+ *
+ *   - POSIX: RLIMIT_MEMLOCK, commonly 8 MB (and only 64 kB on older systems),
+ *     which is why the raw entropy recording with large memory blocks has
+ *     traditionally been run as root (see README.md).
+ *
+ *   - Windows: the process minimum working set. VirtualLock() charges its
+ *     pages against it - "the maximum number of pages a process can lock is
+ *     equal to the number of pages in its minimum working set minus a small
+ *     overhead" - and fails with ERROR_WORKING_SET_QUOTA once that budget is
+ *     exhausted.
+ *
+ * Both are process-wide state, which is why the library does not touch them:
+ * raising them affects the whole host application - on Windows it evicts the
+ * working set the application has reserved for itself - and neither can be
+ * restored on free, as another thread may have locked memory against the
+ * raised limit in the meantime. That decision belongs to the application -
+ * here, to these test tools, which own their process.
+ *
+ * The same holds for the secure memory arena the library allocates from when
+ * it is built with EXTERNAL_CRYPTO=LIBGCRYPT or EXTERNAL_CRYPTO=OPENSSL:
+ * libgcrypt's secmem pool and OpenSSL's secure heap are each created once per
+ * process, in a size that cannot be changed afterwards and that every other
+ * user of those libraries in the process then shares. The library only checks
+ * that the arena is there (see arch/jitterentropy-arch-memory.c); creating and
+ * sizing it is done here, in the tool that owns the process.
+ */
+
+#ifndef _JITTERENTROPY_MEMLOCK_H
+#define _JITTERENTROPY_MEMLOCK_H
+
+/*
+ * GetProcessWorkingSetSizeEx() and SetProcessWorkingSetSizeEx() are declared by
+ * the Windows SDK only from Windows Vista onwards. mingw-w64 has defaulted to
+ * older values across its releases, so the minimum is stated here rather than
+ * left to the toolchain; it has to precede every system header, including the
+ * <windows.h> included below. An externally supplied, higher value is left
+ * alone. Same reasoning as in the sources under arch/, which is also why this
+ * header is included before the Windows headers by its users.
+ */
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
+#include "jitterentropy.h"
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+# include <windows.h>
+#else
+# include <sys/types.h>
+# include <sys/time.h>
+# include <sys/resource.h>
+#endif
+
+/*
+ * The backend macros are the ones the library is compiled with: CMake puts
+ * -D${EXTERNAL_CRYPTO} into JITTER_C_FLAGS, which every test program is built
+ * with as well, so the arena configured below is exactly the one the library
+ * then allocates from. AWS-LC needs no entry: it wipes its allocations but
+ * keeps no arena to configure.
+ */
+#if defined(LIBGCRYPT)
+# include <gcrypt.h>
+#elif defined(OPENSSL)
+# include <openssl/crypto.h>
+#endif
+
+/*
+ * Amount of lockable memory requested when the tool does not pin the size of
+ * the memory access block with JENT_MAX_MEMSIZE_*: the collector then derives
+ * it from the cache geometry at runtime, which this code cannot predict. 64 MB
+ * covers the derived size on ordinary hardware, including --all-caches on a
+ * desktop; where it does not - the summed caches of a large server - the
+ * request is simply larger than needed, and a limit the system refuses to
+ * grant is handled as a partial raise below.
+ */
+#define JENT_MEMLOCK_DEFAULT	(64ULL << 20)
+
+/*
+ * Slack added to that block: the collector makes further (small) allocations
+ * which are locked as well.
+ */
+#define JENT_MEMLOCK_SLACK	(1ULL << 20)
+
+/*
+ * Bytes the entropy collector instantiated with @flags may need to lock.
+ *
+ * The result is bounded by JENT_MAX_MEMSIZE_MAX plus the slack above, i.e. it
+ * fits into a size_t (and into a SIZE_T / rlim_t) on every supported target,
+ * 32-bit ones included.
+ */
+static inline unsigned long long jent_memlock_size(unsigned int flags)
+{
+	unsigned int memsize = JENT_FLAGS_TO_MAX_MEMSIZE(flags &
+							 JENT_MAX_MEMSIZE_MASK);
+	unsigned long long want;
+
+	/*
+	 * The memory size field is wider than the sizes the library defines,
+	 * so an out-of-range value cannot make the shift below overflow.
+	 */
+	if (memsize > JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_MAX))
+		memsize = JENT_FLAGS_TO_MAX_MEMSIZE(JENT_MAX_MEMSIZE_MAX);
+
+	if (flags & JENT_DISABLE_MEMORY_ACCESS)
+		want = 0;
+	else if (memsize)
+		want = 1ULL << (memsize + JENT_MAX_MEMSIZE_OFFSET);
+	else
+		want = JENT_MEMLOCK_DEFAULT;
+
+	return want + JENT_MEMLOCK_SLACK;
+}
+
+/* Whether @flags ask for memory that is guaranteed to be locked. */
+static inline int jent_memlock_required(unsigned int flags)
+{
+#if defined(LIBGCRYPT) || defined(OPENSSL)
+	/*
+	 * These backends lock their whole arena when it is created, before any
+	 * collector exists and whatever the collector flags say, so the limit
+	 * has to be raised for every run - not only for the compliance modes.
+	 */
+	(void)flags;
+	return 1;
+#else
+	return !!(flags &
+		  (JENT_NTG1 | JENT_FORCE_FIPS | JENT_FORCE_SECURE_MEM));
+#endif
+}
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+
+/*
+ * Slack kept between the process minimum and maximum working set: the maximum
+ * has to stay strictly greater than the minimum, otherwise
+ * SetProcessWorkingSetSizeEx() rejects the call with ERROR_INVALID_PARAMETER.
+ */
+#define JENT_WS_HEADROOM	((SIZE_T)1 << 20)
+
+/* Floor of the fallback in jent_raise_memlock_limit(). */
+#define JENT_WS_MIN		((SIZE_T)1 << 20)
+
+/*
+ * Extend the process working set limits by @want bytes. Returns 0 on success.
+ *
+ * The limits are read and extended rather than set to a fixed size, so that
+ * the raise adds to whatever the process was already granted instead of
+ * replacing it. The same applies to the quota flags, which are read back with
+ * GetProcessWorkingSetSizeEx() and handed to SetProcessWorkingSetSizeEx()
+ * unchanged: raising the minimum is what lifts the lock quota, making that
+ * minimum a *hard* limit (QUOTA_LIMITS_HARDWS_MIN_ENABLE) is not required for
+ * it and would replace the quota policy the process may have established.
+ */
+static inline int jent_set_working_set(SIZE_T want)
+{
+	SIZE_T minWS = 0, maxWS = 0, want_min, want_max;
+	DWORD ws_flags = 0;
+
+	if (!GetProcessWorkingSetSizeEx(GetCurrentProcess(), &minWS, &maxWS,
+					&ws_flags))
+		return -1;
+
+	/*
+	 * A process that has never had its quota configured reports
+	 * QUOTA_LIMITS_HARDWS_MIN_DISABLE | QUOTA_LIMITS_HARDWS_MAX_DISABLE,
+	 * i.e. soft limits on both ends - which is all VirtualLock() needs.
+	 * Should an implementation ever answer with no flags at all, name the
+	 * documented default explicitly rather than forwarding a zero the
+	 * setter may reject with ERROR_INVALID_PARAMETER.
+	 */
+	if (!ws_flags)
+		ws_flags = QUOTA_LIMITS_HARDWS_MIN_DISABLE |
+			   QUOTA_LIMITS_HARDWS_MAX_DISABLE;
+
+	/* Headroom above the new minimum, and the guard against wrapping. */
+	if (want > (SIZE_T)-1 - minWS)
+		return -1;
+	want_min = minWS + want;
+	if (want_min > (SIZE_T)-1 - JENT_WS_HEADROOM)
+		return -1;
+	want_max = (maxWS > want_min + JENT_WS_HEADROOM) ?
+		   maxWS : want_min + JENT_WS_HEADROOM;
+
+	return SetProcessWorkingSetSizeEx(GetCurrentProcess(), want_min,
+					  want_max, ws_flags) ? 0 : -1;
+}
+
+/*
+ * Raise the process working set so that the entropy collector instantiated
+ * with @flags can lock its memory. Best effort: the size requested is an upper
+ * bound on what the collector may map, and the caller goes on to allocate it
+ * either way. Returns 0 once the quota has been raised as far as this process
+ * can raise it, and 1 only when the working set could not be changed at all.
+ *
+ * A request the system does not grant - it fails as the values approach the
+ * physical memory available - is retried with half the size, down to
+ * JENT_WS_MIN, so that an over-estimated request still leaves the process with
+ * the largest quota the machine does allow.
+ */
+static inline int jent_raise_memlock_limit(unsigned int flags)
+{
+	SIZE_T want;
+
+	if (!jent_memlock_required(flags))
+		return 0;
+
+	want = (SIZE_T)jent_memlock_size(flags);
+
+	if (!jent_set_working_set(want))
+		return 0;
+
+	for (want /= 2; want >= JENT_WS_MIN; want /= 2) {
+		if (!jent_set_working_set(want))
+			return 0;
+	}
+
+	return 1;
+}
+
+#else /* !Windows */
+
+/*
+ * Raise RLIMIT_MEMLOCK so that the entropy collector instantiated with @flags
+ * can lock its memory. Best effort: the size requested is an upper bound on
+ * what the collector may map - the size it derives from the cache geometry is
+ * not knowable here - and the caller goes on to allocate it either way.
+ * Returns 0 once the limit has been raised as far as this process can raise
+ * it, and 1 only when it could not be read or changed at all.
+ *
+ * Any process may raise its soft limit up to its hard limit; raising the hard
+ * limit requires privilege (CAP_SYS_RESOURCE on Linux, root elsewhere). Both
+ * are therefore requested in one call, and a rejected call is retried with the
+ * hard limit left alone - which is what an unprivileged process gets, and all
+ * it can get. Ending up at a hard limit below the requested size is not
+ * reported as an error: the request is an upper bound, so the collector may
+ * well fit under it, and where it does not the allocation failure the caller
+ * reports is the accurate message. That is the case the recording README
+ * describes as needing root.
+ */
+static inline int jent_raise_memlock_limit(unsigned int flags)
+{
+#ifdef RLIMIT_MEMLOCK
+	unsigned long long want;
+	struct rlimit lim;
+
+	if (!jent_memlock_required(flags))
+		return 0;
+
+	want = jent_memlock_size(flags);
+
+	if (getrlimit(RLIMIT_MEMLOCK, &lim))
+		return 1;
+
+	/* Nothing to do - the limit already covers the collector. */
+	if (lim.rlim_cur == RLIM_INFINITY || (unsigned long long)lim.rlim_cur >= want)
+		return 0;
+
+	lim.rlim_cur = (rlim_t)want;
+	if (lim.rlim_max != RLIM_INFINITY &&
+	    (unsigned long long)lim.rlim_max < want)
+		lim.rlim_max = (rlim_t)want;
+
+	if (!setrlimit(RLIMIT_MEMLOCK, &lim))
+		return 0;
+
+	/*
+	 * Unprivileged: take the soft limit up to the hard limit, which is as
+	 * far as this process can go and is what allows the smaller memory
+	 * sizes to be recorded without root.
+	 */
+	if (getrlimit(RLIMIT_MEMLOCK, &lim))
+		return 1;
+	if (lim.rlim_cur >= lim.rlim_max)
+		return 0;
+
+	lim.rlim_cur = lim.rlim_max;
+
+	return setrlimit(RLIMIT_MEMLOCK, &lim) ? 1 : 0;
+#else
+	/*
+	 * The platform has no per-process memory lock limit to raise (Solaris,
+	 * for one, bounds the locked memory per project instead).
+	 */
+	(void)flags;
+	return 0;
+#endif /* RLIMIT_MEMLOCK */
+}
+
+#endif /* Windows */
+
+/*
+ * Floor and ceiling of the secure memory arena created below. The floor is the
+ * size the library used to reserve itself and is what a run with no memory
+ * access (JENT_DISABLE_MEMORY_ACCESS) still needs for the collector state and
+ * the small allocations around it. The ceiling bounds the largest request -
+ * JENT_MAX_MEMSIZE_MAX rounded up - to a value that still fits the unsigned
+ * int libgcrypt takes for GCRYCTL_INIT_SECMEM.
+ */
+#define JENT_SECMEM_MIN		(2ULL << 20)
+#define JENT_SECMEM_MAX		(1ULL << 30)
+
+/*
+ * Size of the arena for a collector instantiated with @flags: the memory the
+ * collector may lock, rounded up to a power of two because OpenSSL's secure
+ * heap requires that of its size.
+ */
+static inline unsigned long long jent_secmem_size(unsigned int flags)
+{
+	unsigned long long want = jent_memlock_size(flags);
+	unsigned long long size = JENT_SECMEM_MIN;
+
+	while (size < want && size < JENT_SECMEM_MAX)
+		size <<= 1;
+
+	return size;
+}
+
+/*
+ * Create the secure memory arena the library allocates the entropy collector
+ * from when it is built against libgcrypt or OpenSSL. Returns 0 on success and
+ * when the build has no arena to configure; 1 when the arena could not be
+ * created, in which case the allocation of the collector is what fails later
+ * on - the library refuses to hand out memory that did not come from the
+ * arena.
+ *
+ * Call this after jent_raise_memlock_limit(): both libraries lock the arena
+ * into RAM as they create it, and only the raised limit lets them.
+ */
+static inline int jent_init_secure_memory(unsigned int flags)
+{
+#if defined(LIBGCRYPT)
+
+	/*
+	 * The initialization sequence libgcrypt documents. An application that
+	 * has already run it, which is what GCRYCTL_INITIALIZATION_FINISHED
+	 * records, is left alone: its arena is sized the way it wants it, and
+	 * the size cannot be changed after the fact anyway.
+	 *
+	 * The secmem warning is suspended around the pool creation only, where
+	 * libgcrypt would otherwise announce the yet-unlocked pool on stderr,
+	 * and is resumed right after so that a genuinely insecure pool - one
+	 * whose lock the system refused - is still reported.
+	 */
+	if (!gcry_check_version(GCRYPT_VERSION))
+		return 1;
+
+	if (gcry_control(GCRYCTL_INITIALIZATION_FINISHED_P))
+		return 0;
+
+	gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
+	if (gcry_control(GCRYCTL_INIT_SECMEM,
+			 (unsigned int)jent_secmem_size(flags), 0)) {
+		gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
+		return 1;
+	}
+	gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
+	gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+
+	return 0;
+
+#elif defined(OPENSSL)
+
+	/*
+	 * Both sizes must be powers of two and the minimum allocation must be
+	 * smaller than the arena; 32 bytes is the granularity the library's own
+	 * allocations are happy with. An arena another part of the process has
+	 * already created is kept, as it cannot be resized either.
+	 */
+	if (CRYPTO_secure_malloc_initialized())
+		return 0;
+
+	return CRYPTO_secure_malloc_init((size_t)jent_secmem_size(flags), 32) ?
+	       0 : 1;
+
+#else
+
+	(void)flags;
+
+	return 0;
+
+#endif
+}
+
+#endif /* _JITTERENTROPY_MEMLOCK_H */

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -31,6 +31,51 @@
 #include <assert.h>
 #include <time.h>
 
+#if defined(_MSC_VER) || defined(__MINGW32__)
+# include <windows.h>
+#endif
+
+/*
+ * Monotonic timestamp in nanoseconds. Returns 0 on success.
+ *
+ * The measured interval feeds the search invariants below, so a wall-clock
+ * step (NTP, DST, manual adjustment) during a measurement must not be able to
+ * corrupt or even negate the runtime.
+ *
+ * Windows has no clock_gettime(): QueryPerformanceCounter() is the monotonic
+ * source there and its ticks are rescaled with the counter frequency.
+ */
+static int monotonic_nstime(uint64_t *out)
+{
+#if defined(_MSC_VER) || defined(__MINGW32__)
+	LARGE_INTEGER freq, ticks;
+
+	if (!QueryPerformanceFrequency(&freq) || freq.QuadPart <= 0)
+		return 1;
+	if (!QueryPerformanceCounter(&ticks) || ticks.QuadPart < 0)
+		return 1;
+
+	/*
+	 * Whole seconds and remainder are scaled separately: a single
+	 * ticks * 1000000000 overflows 64 bits after a few seconds of uptime
+	 * with the usual 10 MHz performance counter.
+	 */
+	*out = (uint64_t)(ticks.QuadPart / freq.QuadPart) *
+	       UINT64_C(1000000000) +
+	       (uint64_t)(ticks.QuadPart % freq.QuadPart) *
+	       UINT64_C(1000000000) / (uint64_t)freq.QuadPart;
+	return 0;
+#else
+	struct timespec time;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &time) != 0)
+		return 1;
+	*out = (uint64_t)time.tv_sec * UINT64_C(1000000000) +
+	       (uint64_t)time.tv_nsec;
+	return 0;
+#endif
+}
+
 /*
  * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
  * a typo (or a follow-up option consumed as value) into 0 and the tool would
@@ -78,7 +123,7 @@ double linearInverse(double y, double x1, double y1, double x2, double y2) {
 uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 {
 	struct rand_data *ec_nostir;
-	struct timespec start, finish;
+	uint64_t start, finish;
 	uint64_t runtime;
 	int ret;
 
@@ -102,12 +147,7 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 		exit(1);
 	}
 
-	/*
-	 * Use a monotonic clock: the measured interval feeds the search
-	 * invariants, and a wall-clock step (NTP, DST, manual adjustment)
-	 * during a measurement would corrupt or even negate the runtime.
-	 */
-	if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+	if (monotonic_nstime(&start)) {
 		fprintf(stderr, "Unable to get start time\n");
 		exit(1);
 	}
@@ -121,11 +161,11 @@ uint64_t jent_output_time(uint64_t rounds, unsigned int osr, unsigned int flags)
 		}
 	}
 
-	if (clock_gettime(CLOCK_MONOTONIC, &finish) != 0) {
+	if (monotonic_nstime(&finish)) {
 		fprintf(stderr, "Unable to get finish time\n");
 		exit(1);
 	}
-	runtime = ((uint64_t)finish.tv_sec * UINT64_C(1000000000) + (uint64_t)finish.tv_nsec) - ((uint64_t)start.tv_sec * UINT64_C(1000000000) + (uint64_t)start.tv_nsec);
+	runtime = finish - start;
 
 	jent_entropy_collector_free(ec_nostir);
 

--- a/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-osr.c
@@ -19,6 +19,11 @@
 
 #include "jitterentropy.h"
 #include "jitterentropy-internal.h"
+/*
+ * Before the <windows.h> below: the header selects the API level it needs,
+ * which has to precede the first inclusion of the Windows headers.
+ */
+#include "jitterentropy-memlock.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -350,6 +355,24 @@ int main(int argc, char * argv[])
 		argc--;
 		argv++;
 	}
+
+	/*
+	 * The compliance modes require the collector memory to be locked into
+	 * RAM, which the operating system permits only within a per-process
+	 * limit. See jitterentropy-memlock.h.
+	 */
+	if (jent_raise_memlock_limit(flags))
+		fprintf(stderr,
+			"Cannot raise the memory lock limit, allocating the entropy collector may fail\n");
+
+	/*
+	 * Likewise the secure memory arena of the external crypto backends,
+	 * which is created once for the process and is what the library
+	 * allocates the collector from. See jitterentropy-memlock.h.
+	 */
+	if (jent_init_secure_memory(flags))
+		fprintf(stderr,
+			"Cannot create the secure memory arena, allocating the entropy collector will fail\n");
 
 	/* We don't start with a maxBound. */
 	maxBound = 0;

--- a/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
@@ -18,6 +18,7 @@
  */
 
 #include "jitterentropy.h"
+#include "jitterentropy-memlock.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -233,6 +234,28 @@ int main(int argc, char * argv[])
 		argc--;
 		argv++;
 	}
+
+	/*
+	 * The compliance modes require the collector memory to be locked into
+	 * RAM, which the operating system permits only within a per-process
+	 * limit. See jitterentropy-memlock.h.
+	 */
+	if (jent_raise_memlock_limit(flags))
+		fprintf(stderr,
+			"Cannot raise the memory lock limit, allocating the entropy collector may fail\n");
+
+	/*
+	 * Likewise the secure memory arena of the external crypto backends,
+	 * which is created once for the process and is what the library
+	 * allocates the collector from. See jitterentropy-memlock.h.
+	 *
+	 * Both precede jent_entropy_init_ex(): the initialization creates a
+	 * collector of its own, with the very same flags, so it allocates from
+	 * the arena and locks its memory just like the instance below.
+	 */
+	if (jent_init_secure_memory(flags))
+		fprintf(stderr,
+			"Cannot create the secure memory arena, allocating the entropy collector will fail\n");
 
 	ret = jent_entropy_init_ex(osr, flags);
 	if (ret) {

--- a/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-rng.c
@@ -25,6 +25,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(_MSC_VER) || defined(__MINGW32__)
+# include <fcntl.h>
+# include <io.h>
+#endif
+
 /*
  * Parse a complete numeric option value. A plain strtoul(str, NULL, 10) turns
  * a typo (or a follow-up option consumed as value) into 0 and the tool would
@@ -248,6 +253,21 @@ int main(int argc, char * argv[])
 	}
 
 	fprintf(stderr, "%s", status);
+
+	/*
+	 * Windows opens stdout in text mode: every 0x0A byte of the random
+	 * stream would be written out as 0x0D 0x0A, corrupting and inflating
+	 * the data as soon as it is redirected into a file or a pipe - which
+	 * is the only way this tool is used. The hex encoding below emits no
+	 * 0x0A at all and is therefore left alone.
+	 */
+#if defined(_MSC_VER) || defined(__MINGW32__)
+	if (!hex && _setmode(_fileno(stdout), _O_BINARY) == -1) {
+		fprintf(stderr, "Cannot switch stdout to binary mode\n");
+		ret = 1;
+		goto out;
+	}
+#endif
 
 	for (size = 0; size < rounds; size++) {
 		uint8_t tmp[32];


### PR DESCRIPTION
Hi Stephan,

I'm currently in the process of testing on different platforms (MacOS, Windows, Linux).

I saw, that hybrid CPUs (e.g. Intels P + E Cores) report wrong cache sizes in the all_caches case.
I'm currently fixing this by reading over all cores and keeping the max (and cache it).

This is still WIP, I'll ping you, when ready.

BR
Markus