### PR TITLE
Extract only 1000 events from restart data

### DIFF
--- a/tests/raw-entropy/validation-restart/processdata_helper.sh
+++ b/tests/raw-entropy/validation-restart/processdata_helper.sh
@@ -37,7 +37,7 @@ MASK_LIST="FF:8"
 #MASK_LIST="FF:4,8 7F8:4,8"
 
 # Maximum number of entries to be extracted from the original file
-MAX_EVENTS=1000000
+MAX_EVENTS=1000
 
 ############################################################
 # Code only after this line -- do not change               #


### PR DESCRIPTION
The restart data may contain more events per file. Ensure that processdata_helpers.sh only extracts at most 1000.