### PR TITLE
tests: support measurements per core on hybrid CPUs

### DIFF
--- a/.github/scripts/vm-build-and-test.sh
+++ b/.github/scripts/vm-build-and-test.sh
@@ -86,6 +86,18 @@ for shared in OFF ON; do
 
 	"$build/tests/gcd/gcd"
 
+	# The CPU information tool. These guests are what compiles its generic
+	# backend at all - the BSDs its sysctl half, Solaris, Haiku and Cygwin
+	# the half without. It describes the machine rather than testing it, so
+	# the output is shown and a failure here is a defect in that backend.
+	echo "==> jitterentropy-cpuinfo"
+	cpuinfo="$build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo"
+	"$cpuinfo"
+	# The JSON form as well: these guests carry the null values and the
+	# backend note the writer has to escape. Only that it runs is checked -
+	# no guest is guaranteed a JSON parser, so Linux validates the output.
+	"$cpuinfo" --json > /dev/null
+
 	rng="$build/tests/raw-entropy/recording_userspace/jitterentropy-rng"
 	for opt in "" --all-caches --force-internal-timer; do
 		echo "==> jitterentropy-rng 256 $opt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1632,6 +1632,66 @@ jobs:
               echo "::warning::jitterentropy-rng $opt failed on this machine"
           done
 
+  # clang-cl is the one compiler this workflow builds that is Clang and MSVC at
+  # once: CMAKE_C_COMPILER_ID reports Clang, so CMakeLists.txt sets CLANG, while
+  # CMake also sets MSVC because the driver takes cl's command line. Every other
+  # job sets at most one of the two, so the branches that test them together are
+  # reached here and nowhere else - and one of them was wrong until this job
+  # existed, handing a GCC-style -fstack-protector-strong to a driver that
+  # ignores it.
+  #
+  # It is also Clang's codegen against the Windows headers and the MSVC ABI,
+  # which no other entry covers: the MinGW jobs are Clang-free, and the Linux
+  # and macOS Clang jobs compile entirely different back-ends in
+  # arch/. Diagnostics differ as well - /W4 selects clang's own analyses, not
+  # cl's - so this is the job that would notice a Windows-only construct only
+  # Clang objects to.
+  #
+  # -T ClangCL selects the toolset Visual Studio ships, so the generator, the
+  # --config Release build and the per-config binary layout stay identical to
+  # the MSVC job above and nothing has to set up an MSVC environment by hand.
+  # x64 alone: what is distinct here is the front end, and windows-msvc already
+  # covers both architectures with the same sources.
+  windows-clang-cl:
+    name: Windows / clang-cl
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Which Clang the toolset resolved to is not pinned here and need not be:
+      # configure prints it as "The C compiler identification is Clang <version>
+      # with MSVC-like command-line", so a failure that turns out to be
+      # version-specific can be read off this step's log.
+      - name: Configure
+        run: cmake -S . -B build -T ClangCL
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Run tests
+        run: |
+          ./build/tests/gcd/Release/gcd.exe
+          ./build/tests/raw-entropy/recording_userspace/Release/jitterentropy-cpuinfo.exe
+          rng=./build/tests/raw-entropy/recording_userspace/Release/jitterentropy-rng.exe
+          for opt in "" "--all-caches" "--force-internal-timer"; do
+            "$rng" 256 $opt > /dev/null
+          done
+
+          # The two compliance modes are run as well but not gated on. They imply
+          # JENT_FORCE_SECURE_MEM, so they are what reaches the mlock path in
+          # arch/jitterentropy-arch-memory.c and, before it, the limit raising the
+          # recording tools do for exactly these modes
+          # (tests/raw-entropy/recording_userspace/jitterentropy-memlock.h). They can
+          # also fail for reasons that are properties of the machine rather than
+          # defects in the code: a memory lock limit lower than the collector needs,
+          # or a startup whose health tests do not converge on the block size derived
+          # from this CPU's caches. Such a failure is reported as a warning so it
+          # stays visible without turning the run red.
+          for opt in "--force-fips" "--ntg1"; do
+            "$rng" 256 $opt > /dev/null ||
+              echo "::warning::jitterentropy-rng $opt failed on this machine"
+          done
+
   # MinGW is a distinct Windows target rather than a variation of MSVC: it is
   # the GCC side of the Win32 thread back-end (__stdcall on a GCC front end,
   # _beginthreadex() out of the mingw-w64 CRT rather than the UCRT), and it has

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1322,6 +1322,284 @@ jobs:
           cc -std=c11 -I. smoke.c libjitterentropy.a $LIBS -o smoke
           ./smoke
 
+      # The Makefile is also the only build system here that produces a
+      # versioned shared object with a soname and the two symlinks that point
+      # at it, and install-shared is the only place those are created. Linking
+      # against the installed tree is what says they name each other correctly:
+      # -ljitterentropy resolves through libjitterentropy.so, and the loader
+      # then has to find the SONAME recorded in the binary.
+      #
+      # install-static is a separate target that "make install" deliberately
+      # does not pull in, so both are named here.
+      - name: Link and run against the installed library
+        run: |
+          # Rebuilt rather than installed on top of the step above, because on
+          # macOS PREFIX is baked into the library at link time: SONAME_FLAGS
+          # passes it to -install_name, which is the absolute path the loader
+          # will later look the dylib up by. Installing a library linked
+          # against the default /usr/local into some other prefix leaves it
+          # answering to a path that holds nothing.
+          make clean
+          make -j 4 PREFIX="$PWD/prefix"
+          make install install-static PREFIX="$PWD/prefix"
+          ls -l prefix/lib
+          # Same split as the step above: librt only exists on Linux.
+          case "${{ runner.os }}" in
+            Linux) LIBS="-pthread -lrt" ;;
+            *)     LIBS="-pthread" ;;
+          esac
+          # Shared: -l prefers the shared object over the archive beside it.
+          # The rpath is what makes the run independent of the loader
+          # environment variables, which macOS strips under system integrity
+          # protection.
+          cc -std=c11 -Iprefix/include \
+            tests/linking/jitterentropy-linktest.c \
+            -Lprefix/lib -ljitterentropy $LIBS \
+            -Wl,-rpath,"$PWD/prefix/lib" -o linktest-shared
+          ./linktest-shared
+          # Static: the archive is named directly, because -l would keep
+          # choosing the shared object.
+          cc -std=c11 -Iprefix/include \
+            tests/linking/jitterentropy-linktest.c \
+            prefix/lib/libjitterentropy.a $LIBS -o linktest-static
+          ./linktest-static
+
+  # Every other job here builds this repository and runs binaries out of its
+  # own build tree, where the library is a CMake target and the public header
+  # is reached through the source directory. A consumer sees none of that. It
+  # gets an install tree, and its link succeeds or fails on the installed
+  # header, on the set of symbols the library still exports, and on what the
+  # CMake package and the .pc file say the link needs. nix-consumers answers
+  # that for two real downstream projects, but only on Linux, only through
+  # nixpkgs' packaging of this library, and it never runs what it builds.
+  #
+  # This job installs the library with "cmake --install" and builds
+  # tests/linking/jitterentropy-linktest.c against the result - once resolved
+  # with find_package(), once with pkg-config - and runs it. That program calls
+  # every function jitterentropy.h declares, so a symbol that stops being
+  # exported fails the link here instead of in somebody's build.
+  #
+  # Both linkages are built because they break in different places. Only the
+  # shared one exercises the dllexport/dllimport split in the public header and
+  # the ELF/Mach-O visibility, where a declaration that lost its
+  # JENT_PRIVATE_STATIC is simply not in the library. Only the static one makes
+  # the consumer name the transitive dependencies - bcrypt, pthread, the
+  # stack-protector runtime - on its own link line, and on Windows it is the
+  # one that has to reach the header with JENT_STATIC_LIB set, or every
+  # declaration in it says dllimport and the archive has no __imp_ symbols to
+  # satisfy it.
+  linking:
+    name: Linking / ${{ matrix.os }} / shared=${{ matrix.shared }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest ]
+        shared: [ 'ON', 'OFF' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      # CMAKE_INSTALL_LIBDIR is pinned so that the steps below can name the
+      # install tree. GNUInstallDirs otherwise derives it from the
+      # distribution - lib, lib64, or a multiarch lib/<triple> - and what is
+      # under test here is the linkage, not rediscovering where files landed.
+      #
+      # The prefix is converted to a native path on Windows: cmake there is a
+      # Windows program and does not understand the /d/... form Git bash
+      # reports. It is carried to the later steps in the environment, while
+      # PATH and the loader variables keep using the bash form, which is the
+      # one those need.
+      #
+      # CMAKE_BUILD_TYPE has to name the configuration the install below asks
+      # for, or the package installs without the half of it that says where the
+      # library is. install(EXPORT) writes the target definitions in two files:
+      # jitterentropyTargets.cmake, installed unconditionally, and a per-
+      # configuration jitterentropyTargets-<config>.cmake carrying
+      # IMPORTED_LOCATION, whose install rule is guarded on the configuration
+      # being installed. A single-config generator with no CMAKE_BUILD_TYPE
+      # builds the "noconfig" one, which "cmake --install --config Release" then
+      # does not match, leaving find_package() with an imported target that has
+      # no file behind it - "IMPORTED_LOCATION or IMPORTED_IMPLIB not set". The
+      # macOS and Linux runners default to such a generator; Windows uses the
+      # multi-config Visual Studio one, where the build type comes from --config
+      # and this variable is ignored.
+      - name: Build and install the library
+        run: |
+          prefix="$PWD/prefix"
+          case "${{ runner.os }}" in
+          Windows) prefix=$(cygpath -m "$prefix") ;;
+          esac
+          echo "JENT_PREFIX=$prefix" >> "$GITHUB_ENV"
+          cmake -S . -B build \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$prefix" \
+            -DCMAKE_INSTALL_LIBDIR=lib
+          cmake --build build --config Release --parallel 4
+          cmake --install build --config Release
+
+      # tests/linking is a project of its own rather than a target of this
+      # build: configured from inside this tree it would resolve the library
+      # directly and say nothing about the installed package.
+      - name: Link and run through the CMake package
+        run: |
+          cmake -S tests/linking -B build-cmake -DCMAKE_PREFIX_PATH="$JENT_PREFIX"
+          cmake --build build-cmake --config Release --parallel 4
+          # The Visual Studio generator is multi-config and puts the binary in
+          # a per-config subdirectory; the single-config generators used
+          # elsewhere put it in the build directory.
+          case "${{ runner.os }}" in
+          Windows)
+            # The import library sits in lib/ but the DLL is installed to
+            # bin/, and Windows resolves it from PATH.
+            export PATH="$PWD/prefix/bin:$PATH"
+            ./build-cmake/Release/jitterentropy-linktest.exe
+            ;;
+          *)
+            export LD_LIBRARY_PATH="$PWD/prefix/lib:$LD_LIBRARY_PATH"
+            export DYLD_LIBRARY_PATH="$PWD/prefix/lib:$DYLD_LIBRARY_PATH"
+            ./build-cmake/jitterentropy-linktest
+            ;;
+          esac
+
+      # Whether the two configurations really produced two different linkages,
+      # rather than both quietly ending up the same way. Without this, a build
+      # in which BUILD_SHARED_LIBS stopped being honoured would run one linkage
+      # twice and still report a green matrix.
+      #
+      # Windows is left out because nothing there could differ: a static
+      # configuration produces no DLL and a shared one produces no archive, so
+      # the linkage is settled by which file exists.
+      - name: Check the linkage
+        if: runner.os != 'Windows'
+        run: |
+          bin=./build-cmake/jitterentropy-linktest
+          case "${{ runner.os }}" in
+          macOS) deps=$(otool -L "$bin") ;;
+          *)     deps=$(ldd "$bin") ;;
+          esac
+          echo "$deps"
+          if [ "${{ matrix.shared }}" = ON ]; then
+            if ! grep -q libjitterentropy <<<"$deps"; then
+              echo "::error::shared build has no libjitterentropy dependency"
+              exit 1
+            fi
+          elif grep -q libjitterentropy <<<"$deps"; then
+            echo "::error::static build has a libjitterentropy dependency"
+            exit 1
+          else
+            echo "no libjitterentropy dependency, as expected of a static link"
+          fi
+
+      # MSVC ships no pkg-config and would not understand the flags one prints.
+      # The MinGW half of Windows, which does have both, is covered by
+      # linking-mingw below.
+      - name: Link and run through pkg-config
+        if: runner.os != 'Windows'
+        run: |
+          # The macOS images do not always carry pkg-config; the Linux ones do.
+          command -v pkg-config > /dev/null || brew install pkg-config
+          export PKG_CONFIG_PATH="$PWD/prefix/lib/pkgconfig"
+          pkg-config --exists jitterentropy || {
+            echo "::error::no jitterentropy.pc under $PKG_CONFIG_PATH"
+            exit 1
+          }
+          echo "modversion: $(pkg-config --modversion jitterentropy)"
+          # A static build names the library and its private dependencies on
+          # the Libs.private line, which only --static prints. Without it the
+          # answer is a bare -L with nothing to link.
+          if [ "${{ matrix.shared }}" = ON ]; then
+            libs=$(pkg-config --libs jitterentropy)
+          else
+            libs=$(pkg-config --static --libs jitterentropy)
+          fi
+          cflags=$(pkg-config --cflags jitterentropy)
+          echo "cflags: $cflags"
+          echo "libs:   $libs"
+          # The -L in there only affects the link. The run needs the directory
+          # recorded in the binary as well, because macOS' system integrity
+          # protection strips DYLD_LIBRARY_PATH from the environment of
+          # anything /bin/sh starts. Harmless in the static case, where the
+          # binary has nothing to look up.
+          cc -std=c11 $cflags tests/linking/jitterentropy-linktest.c $libs \
+            -Wl,-rpath,"$PWD/prefix/lib" -o linktest-pc
+          ./linktest-pc
+
+  # The MinGW half of Windows, which the job above cannot fold into its matrix:
+  # it needs a different shell, and that is a job-level setting.
+  #
+  # It is also the only Windows toolchain with a pkg-config, which makes it the
+  # only place the .pc file's Windows-specific entries are exercised. Both
+  # exist because the exported CMake target carries things the .pc file does
+  # not inherit: -lbcrypt, without which a static consumer is left with an
+  # undefined BCryptGenRandom, and -DJENT_STATIC_LIB, without which the
+  # installed header declares every function __declspec(dllimport) while the
+  # archive defines them undecorated.
+  linking-mingw:
+    name: Linking / MinGW-w64 / shared=${{ matrix.shared }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shared: [ 'ON', 'OFF' ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      # UCRT64 alone: windows-mingw already builds both environments, and what
+      # is distinct here is the consumer side, which they share.
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-pkgconf
+
+      # cmake and pkgconf are both native Windows programs here, so paths
+      # handed to them go through cygpath; PATH stays in the MSYS form, which
+      # is what MSYS2 translates for the processes it starts.
+      - name: Build and install the library
+        run: |
+          prefix=$(cygpath -m "$PWD/prefix")
+          echo "JENT_PREFIX=$prefix" >> "$GITHUB_ENV"
+          cmake -S . -B build -G Ninja \
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }} \
+            -DCMAKE_INSTALL_PREFIX="$prefix" \
+            -DCMAKE_INSTALL_LIBDIR=lib
+          cmake --build build --parallel 4
+          cmake --install build
+
+      - name: Link and run through the CMake package
+        run: |
+          cmake -S tests/linking -B build-cmake -G Ninja \
+            -DCMAKE_PREFIX_PATH="$JENT_PREFIX"
+          cmake --build build-cmake --parallel 4
+          PATH="$PWD/prefix/bin:$PATH" ./build-cmake/jitterentropy-linktest.exe
+
+      - name: Link and run through pkg-config
+        run: |
+          export PKG_CONFIG_PATH="$JENT_PREFIX/lib/pkgconfig"
+          pkg-config --exists jitterentropy || {
+            echo "::error::no jitterentropy.pc under $PKG_CONFIG_PATH"
+            exit 1
+          }
+          if [ "${{ matrix.shared }}" = ON ]; then
+            libs=$(pkg-config --libs jitterentropy)
+          else
+            libs=$(pkg-config --static --libs jitterentropy)
+          fi
+          cflags=$(pkg-config --cflags jitterentropy)
+          echo "cflags: $cflags"
+          echo "libs:   $libs"
+          gcc -std=c11 $cflags tests/linking/jitterentropy-linktest.c $libs \
+            -o linktest-pc.exe
+          PATH="$PWD/prefix/bin:$PATH" ./linktest-pc.exe
+
   # Both macOS architectures: they select different jent_get_nstime() back-ends
   # (cntvct_el0 on Apple Silicon, rdtsc on Intel) and different cache sysctls
   # (the hw.perflevel0.* names exist only on Apple Silicon).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
         run: |
           echo "RLIMIT_MEMLOCK soft=$(ulimit -Sl) hard=$(ulimit -Hl)"
           ./build/tests/gcd/gcd
+          cpuinfo=./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo
+          "$cpuinfo"
+          # The machine-readable form of the same data has to parse. The writer
+          # is platform-independent, so one job checking it covers all of them;
+          # the others only run it.
+          "$cpuinfo" --json | python3 -c 'import json,sys; json.load(sys.stdin)'
+          # The summary of the same machine, which is a second table writer.
+          "$cpuinfo" --summary
           export LD_LIBRARY_PATH="$PWD/build:$LD_LIBRARY_PATH"
           for opt in "" "--all-caches" "--force-internal-timer"; do
             ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
@@ -105,6 +113,7 @@ jobs:
         run: |
           file build/tests/gcd/gcd | grep -q '32-bit' || { echo "not a 32-bit build"; exit 1; }
           ./build/tests/gcd/gcd
+          ./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo
           for opt in "--all-caches" "--force-internal-timer"; do
             ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
           done
@@ -219,6 +228,7 @@ jobs:
           }
 
           ./build/tests/gcd/gcd
+          ./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo
           for opt in "" "--all-caches" "--force-internal-timer"; do
             ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
           done
@@ -1100,6 +1110,7 @@ jobs:
           }
 
           ./build/tests/gcd/gcd
+          "$bin/jitterentropy-cpuinfo"
           for opt in "" "--all-caches" "--force-internal-timer"; do
             "$bin/jitterentropy-rng" 256 $opt > /dev/null
           done
@@ -1256,6 +1267,16 @@ jobs:
       - name: Build
         run: make -j 4
 
+      # The recording tools have one Makefile each, which no other job builds.
+      # jitterentropy-cpuinfo can also be run here: it links nothing and
+      # describes the runner, so it needs neither the library nor a tolerated
+      # failure path.
+      - name: Build and run the CPU information tool
+        working-directory: tests/raw-entropy/recording_userspace
+        run: |
+          make -f Makefile.cpuinfo
+          ./jitterentropy-cpuinfo
+
       - name: Link and run against the built library
         run: |
           cat > smoke.c <<'EOF'
@@ -1324,6 +1345,8 @@ jobs:
       - name: Run tests
         run: |
           ./build/tests/gcd/gcd
+          ./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo
+          ./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo --json > /dev/null
           export DYLD_LIBRARY_PATH="$PWD/build:$DYLD_LIBRARY_PATH"
           for opt in "" "--all-caches" "--force-internal-timer"; do
             ./build/tests/raw-entropy/recording_userspace/jitterentropy-rng 256 $opt > /dev/null
@@ -1588,6 +1611,7 @@ jobs:
           # PATH.
           export PATH="$PWD/build/Release:$PATH"
           ./build/tests/gcd/Release/gcd.exe
+          ./build/tests/raw-entropy/recording_userspace/Release/jitterentropy-cpuinfo.exe
           rng=./build/tests/raw-entropy/recording_userspace/Release/jitterentropy-rng.exe
           for opt in "" "--all-caches" "--force-internal-timer"; do
             "$rng" 256 $opt > /dev/null
@@ -1654,6 +1678,7 @@ jobs:
       - name: Run tests
         run: |
           ./build/tests/gcd/gcd.exe
+          ./build/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo.exe
           rng=./build/tests/raw-entropy/recording_userspace/jitterentropy-rng.exe
           for opt in "" "--all-caches" "--force-internal-timer"; do
             "$rng" 256 $opt > /dev/null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ else()
   set(JITTER_PC_LIBS_PRIVATE "-l${CMAKE_PROJECT_NAME}")
 endif()
 
+# Appended to the Cflags line of the .pc file. Only the Windows static build
+# has anything to put here; see the JENT_STATIC_LIB branch further down.
+set(JITTER_PC_CFLAGS "")
+
 if(WIN32)
     if(MSVC)
         # _CRT_SECURE_NO_WARNINGS: MSVC deprecates the standard C library in
@@ -326,6 +330,15 @@ if(WIN32)
         target_compile_definitions(${PROJECT_NAME} PRIVATE JENT_BUILDING_DLL)
     else()
         target_compile_definitions(${PROJECT_NAME} PUBLIC JENT_STATIC_LIB)
+
+        # The same for pkg-config consumers. PUBLIC above covers the exported
+        # CMake target - the definition is carried in its
+        # INTERFACE_COMPILE_DEFINITIONS - but nothing propagates it into the
+        # .pc file, and without it the public header declares the functions
+        # __declspec(dllimport) while the archive defines them undecorated, so
+        # a MinGW consumer building through pkg-config was left looking for
+        # __imp_ symbols that a static library never has.
+        set(JITTER_PC_CFLAGS " -DJENT_STATIC_LIB")
     endif()
 endif()
 # Only jitterentropy.h is installed (as PUBLIC_HEADER below). The arch/ headers
@@ -340,10 +353,16 @@ install(TARGETS ${PROJECT_NAME}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+# The package subdirectory in the destination is not cosmetic. find_package()
+# in config mode searches <prefix>/<lib|share>/cmake/<name>*/ under every entry
+# of CMAKE_PREFIX_PATH; a bare lib/cmake/ is not one of the places it looks, so
+# a package installed directly there was only findable by pointing
+# CMAKE_PREFIX_PATH at lib/cmake itself. tests/linking is the consumer that
+# would have to do that.
 install(EXPORT jitterentropyTargets
   FILE jitterentropyTargets.cmake
   NAMESPACE jitterentropy::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -429,6 +448,17 @@ endif()
 set(JITTER_THREAD_LIBRARIES "")
 if(INTERNAL_TIMER AND NOT ANDROID AND NOT WIN32)
     set(JITTER_THREAD_LIBRARIES -pthread)
+
+    # And once more for pkg-config consumers of the static library, for the
+    # same reason -lbcrypt is added to this variable on Windows: the exported
+    # CMake target carries the dependency as $<LINK_ONLY:pthread>, while the
+    # .pc file inherits nothing. The omission stays invisible wherever the
+    # pthread symbols live in the C library - glibc 2.34 and later, Apple's
+    # libSystem, bionic - and surfaces on everything older, which is most of
+    # the enterprise distributions still in support.
+    if(NOT BUILD_SHARED_LIBS)
+        set(JITTER_PC_LIBS_PRIVATE "${JITTER_PC_LIBS_PRIVATE} -pthread")
+    endif()
 endif()
 
 # testing/validation tools
@@ -454,10 +484,13 @@ install(FILES
 )
 
 # cmake
+#
+# Same destination as the targets file above - the config file includes it by
+# CMAKE_CURRENT_LIST_DIR, so the two have to stay together.
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/jitterentropyConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/jitterentropyConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/jitterentropyConfigVersion.cmake
@@ -467,7 +500,7 @@ write_basic_package_version_file(
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/jitterentropyConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/jitterentropyConfigVersion.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 # man page(s)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,19 @@ if(STACK_PROTECTOR)
         else()
             set(JITTER_SSP_FLAG -fstack-protector-all)
         endif()
-    elseif(CLANG)
+    # "NOT MSVC" excludes clang-cl, which is Clang - CMAKE_C_COMPILER_ID says so
+    # and CLANG is set for it - behind a cl-compatible driver that does not take
+    # GCC-style spellings. It answers -fstack-protector-strong with "unknown
+    # argument ignored in clang-cl" and carries on, which the probe below reads
+    # as success: the flag would be added to every compile and link command, be
+    # dropped by each of them, and leave a build that reports hardening it does
+    # not have. cl itself never reached here - neither GCC nor CLANG is set for
+    # it - so this only ever concerned the one compiler that is both.
+    #
+    # Nothing is substituted for it. The equivalent is /GS, which clang-cl
+    # enables by default exactly as cl does, so the MSVC builds already have the
+    # protection this branch would otherwise ask for.
+    elseif(CLANG AND NOT MSVC)
         set(JITTER_SSP_FLAG -fstack-protector-strong)
     endif()
 

--- a/arch/jitterentropy-arch-ncpu.c
+++ b/arch/jitterentropy-arch-ncpu.c
@@ -99,6 +99,59 @@
 
 #endif /* LINUX_KERNEL */
 
+#ifdef JENT_ARCH_NCPU_LINUX_AFFINITY
+/*
+ * Read the affinity mask of the calling thread and report both questions asked
+ * of it: @count how many CPUs it holds, @highest the largest number among them
+ * (-1 for an empty mask). Returns 0 or a negative errno.
+ *
+ * The set grows on retry: sched_getaffinity(2) fails with EINVAL when it is
+ * smaller than the CPU mask of the kernel, as on a machine with more CPUs than
+ * CPU_SETSIZE. A fixed set would not merely lose the highest CPU there, it
+ * would answer neither question - which is why both callers read the mask
+ * through here rather than each with a set of its own.
+ */
+static int jent_affinity_mask(long *count, long *highest)
+{
+	unsigned int ncpu_set;
+
+	for (ncpu_set = CPU_SETSIZE; ncpu_set <= JENT_NCPU_SET_MAX;
+	     ncpu_set *= 2) {
+		size_t size = CPU_ALLOC_SIZE(ncpu_set);
+		cpu_set_t *set = CPU_ALLOC(ncpu_set);
+		int ret;
+
+		if (!set)
+			return -ENOMEM;
+
+		ret = sched_getaffinity(0, size, set) ? errno : 0;
+		if (!ret) {
+			unsigned int i = ncpu_set;
+
+			*count = CPU_COUNT_S(size, set);
+			*highest = -1;
+			while (i-- > 0) {
+				if (CPU_ISSET_S(i, size, set)) {
+					*highest = (long)i;
+					break;
+				}
+			}
+		}
+
+		CPU_FREE(set);
+
+		if (ret == EINVAL)
+			continue;	/* set too small - try a larger one */
+		if (ret)
+			return -ret;
+
+		return 0;
+	}
+
+	return -EINVAL;
+}
+#endif /* JENT_ARCH_NCPU_LINUX_AFFINITY */
+
 #ifdef JENT_ARCH_NCPU_LINUX_SYSFS
 /*
  * Parse /sys/devices/system/cpu/online and return the number of online
@@ -176,25 +229,10 @@ long jent_ncpu(void)
 #elif defined(JENT_ARCH_NCPU_POSIX)
 # ifdef JENT_ARCH_NCPU_LINUX_AFFINITY
 	{
-		size_t cpu_set_alloc_size = CPU_ALLOC_SIZE(CPU_SETSIZE);
-		cpu_set_t *cpu_set = CPU_ALLOC(CPU_SETSIZE);
-		long count = 0;
+		long count = 0, highest = -1;
 
-		/* only get affinity if allocation was successful */
-		if (cpu_set &&
-		    sched_getaffinity(0,
-				      cpu_set_alloc_size,
-				      cpu_set) == 0) {
-			count = CPU_COUNT_S(cpu_set_alloc_size, cpu_set);
-		}
-
-		if (cpu_set) {
-			CPU_FREE(cpu_set);
-		}
-
-		if (count > 0) {
+		if (!jent_affinity_mask(&count, &highest) && count > 0)
 			return count;
-		}
 		/* fall through to sysfs / sysconf */
 	}
 # endif
@@ -238,4 +276,39 @@ long jent_ncpu(void)
 	 */
 	return 1;
 #endif
+}
+
+long jent_cpu_highest(void)
+{
+#ifdef JENT_ARCH_NCPU_LINUX_AFFINITY
+	/*
+	 * The mask is a set, not a range - counting its members and naming the
+	 * last of them are different questions, and only the latter yields a
+	 * CPU a thread can be pinned to.
+	 */
+	{
+		long count = 0, highest = -1;
+
+		if (!jent_affinity_mask(&count, &highest) && highest >= 0)
+			return highest;
+		/* fall through to the count below */
+	}
+#endif
+
+	/*
+	 * Everywhere else the count is all there is, and the CPU numbers are
+	 * taken to be the dense range it describes - true for the flat Windows
+	 * numbering, which jent_thread_pin_to_cpu() resolves in the same order,
+	 * and unavoidable without an affinity API.
+	 */
+	{
+		long ncpu = jent_ncpu();
+
+		if (ncpu < 0)
+			return ncpu;
+		if (ncpu == 0)
+			return -EFAULT;
+
+		return ncpu - 1;
+	}
 }

--- a/arch/jitterentropy-arch-ncpu.h
+++ b/arch/jitterentropy-arch-ncpu.h
@@ -57,11 +57,31 @@
  *     Cygwin)
  *   - Linux Kernel                   -> 1 (we do not need a timer thread)
  *   - other (e.g. baremetal)         -> 1 (timer thread will be disabled)
+ *
+ * Provides jent_cpu_highest() returning the highest of those CPU numbers - the
+ * one a thread may be pinned to - or a negative errno. Not the count minus
+ * one: the CPUs a thread may run on are a set, and one confined to a cpuset
+ * need not hold the numbers the count would name. Only Linux can tell the two
+ * apart; elsewhere the count minus one is all there is.
  */
 
 #ifndef _JITTERENTROPY_ARCH_NCPU_H
 #define _JITTERENTROPY_ARCH_NCPU_H
 
+/*
+ * Largest CPU set the Linux affinity paths grow to, in CPUs; the highest CPU
+ * number handled is therefore one below it. The bound is shared by
+ * jent_cpu_highest() and jent_thread_pin_to_cpu(), so every CPU the first can
+ * name is one the second can pin to - held to a fixed cpu_set_t the second
+ * refuses everything from CPU_SETSIZE (1024 on glibc) up, on precisely the
+ * machines where naming the highest CPU rather than the count differs at all.
+ *
+ * Far above the CONFIG_NR_CPUS of any kernel built today, and a set of this
+ * size is a short-lived 8 KiB allocation.
+ */
+#define JENT_NCPU_SET_MAX	(1U << 16)
+
 long jent_ncpu(void);
+long jent_cpu_highest(void);
 
 #endif /* _JITTERENTROPY_ARCH_NCPU_H */

--- a/arch/jitterentropy-arch-thread.c
+++ b/arch/jitterentropy-arch-thread.c
@@ -87,6 +87,8 @@
 # define JENT_ARCH_THREAD_PIN_WINDOWS
 #elif defined(__linux__)
 # include <sched.h>
+/* CPU_ALLOC() below is __sched_cpualloc() on glibc, but calloc() on musl. */
+# include <stdlib.h>
 # define JENT_ARCH_THREAD_PIN_LINUX
 #elif defined(__APPLE__)
 # include <mach/mach.h>
@@ -227,15 +229,51 @@ int jent_thread_pin_to_cpu(unsigned long cpu)
 	free(buffer);
 	return ret;
 #elif defined(JENT_ARCH_THREAD_PIN_LINUX)
-	cpu_set_t set;
+	/*
+	 * A cpu_set_t holds CPU_SETSIZE bits - 1024 on glibc - which is a
+	 * smaller machine than jent_cpu_highest() can name a CPU of: it grows
+	 * its own mask up to JENT_NCPU_SET_MAX, and refusing those CPUs here
+	 * would drop the pinning on exactly the machines large enough for the
+	 * distinction it draws to matter. Above CPU_SETSIZE the set is
+	 * therefore allocated wide enough for @cpu, which is also what
+	 * sched_setaffinity(2) wants of a kernel with a larger CPU mask.
+	 *
+	 * The fixed set below stays for the common case, so the counting
+	 * thread - started and stopped on every entropy request - does not
+	 * allocate on its way to a CPU.
+	 */
+	if (cpu < (unsigned long)CPU_SETSIZE) {
+		cpu_set_t set;
 
-	if (cpu >= (unsigned long)CPU_SETSIZE)
-		return -EINVAL;
-	CPU_ZERO(&set);
-	CPU_SET((size_t)cpu, &set);
-	if (sched_setaffinity(0, sizeof(set), &set))
-		return -errno;
-	return 0;
+		CPU_ZERO(&set);
+		CPU_SET((size_t)cpu, &set);
+		if (sched_setaffinity(0, sizeof(set), &set))
+			return -errno;
+		return 0;
+	} else {
+		unsigned int ncpu_set = CPU_SETSIZE;
+		cpu_set_t *set;
+		size_t size;
+		int ret;
+
+		if (cpu >= JENT_NCPU_SET_MAX)
+			return -EINVAL;
+
+		while ((unsigned long)ncpu_set <= cpu)
+			ncpu_set *= 2;
+
+		size = CPU_ALLOC_SIZE(ncpu_set);
+		set = CPU_ALLOC(ncpu_set);
+		if (!set)
+			return -ENOMEM;
+
+		CPU_ZERO_S(size, set);
+		CPU_SET_S((size_t)cpu, size, set);
+		ret = sched_setaffinity(0, size, set) ? -errno : 0;
+		CPU_FREE(set);
+
+		return ret;
+	}
 #elif defined(JENT_ARCH_THREAD_PIN_MACOS)
 	/*
 	 * macOS exposes no CPU pinning API at all. THREAD_AFFINITY_POLICY is

--- a/cmake/jitterentropy.pc.in
+++ b/cmake/jitterentropy.pc.in
@@ -11,4 +11,4 @@ Libs: -L${libdir} @JITTER_PC_LIBS@
 Libs.private: @JITTER_PC_LIBS_PRIVATE@
 Requires: @JITTER_PC_REQUIRES@
 Requires.private: @JITTER_PC_REQUIRES_PRIVATE@
-Cflags: -I${includedir}
+Cflags: -I${includedir}@JITTER_PC_CFLAGS@

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       forAllSystems = f: lib.genAttrs systems (system: f system);
 
       # Userspace library and tools, built with the project's CMake build.
-      # Installs jitterentropy-{hashtime,osr,rng}, gcd, extractlsb,
+      # Installs jitterentropy-{cpuinfo,hashtime,osr,rng}, gcd, extractlsb,
       # getrawentropy and jitterentropy-chardev-status into bin.
       toolsFor = pkgs:
         pkgs.stdenv.mkDerivation {
@@ -594,8 +594,9 @@
 
             # The CMake-built userspace tools are on PATH.
             for tool in ("jitterentropy-rng", "jitterentropy-osr",
-                         "jitterentropy-hashtime", "gcd", "extractlsb",
-                         "getrawentropy", "jitterentropy-chardev-status"):
+                         "jitterentropy-hashtime", "jitterentropy-cpuinfo",
+                         "gcd", "extractlsb", "getrawentropy",
+                         "jitterentropy-chardev-status"):
                 machine.succeed(f"command -v {tool}")
           '';
         };

--- a/src/jitterentropy-timer.c
+++ b/src/jitterentropy-timer.c
@@ -32,7 +32,7 @@
 /*
  * CPU the counting thread pins itself to. When the caller has not set one
  * via jent_notime_set_cpu(), jent_notime_init() defaults to the
- * highest-numbered online CPU.
+ * highest-numbered CPU the caller may run on.
  */
 static int jent_notime_cpu_configured = 0;
 static unsigned long jent_notime_cpu = 0;
@@ -55,7 +55,8 @@ static int jent_notime_init_flags(void **ctx, unsigned int flags)
 
 	/*
 	 * Pin the counting thread to a dedicated CPU - the caller-configured
-	 * one, or by default the highest-numbered online CPU. The consumer
+	 * one, or by default the highest-numbered CPU this thread may run on
+	 * and can therefore place the counting thread on as well. The consumer
 	 * thread is left unpinned, so on the >= 2 CPUs guaranteed above the
 	 * scheduler keeps the two on separate cores and the counter keeps
 	 * ticking while the consumer busy-waits.
@@ -65,10 +66,21 @@ static int jent_notime_init_flags(void **ctx, unsigned int flags)
 	 * Silicon). There the two threads are merely left to the scheduler,
 	 * which the >= 2 CPU requirement above still makes workable.
 	 */
-	if (jent_notime_cpu_configured)
+	if (jent_notime_cpu_configured) {
 		thread_ctx->notime_cpu = jent_notime_cpu;
-	else
-		thread_ctx->notime_cpu = (unsigned long)(ncpu - 1);
+	} else {
+		/*
+		 * The highest CPU the thread may run on, not the count minus
+		 * one: those CPUs are a set and need not start at zero, so
+		 * under a cpuset the count names a CPU pinning is refused for.
+		 * See jent_cpu_highest().
+		 */
+		long highest = jent_cpu_highest();
+
+		thread_ctx->notime_cpu = (highest >= 0) ?
+					 (unsigned long)highest :
+					 (unsigned long)(ncpu - 1);
+	}
 
 	*ctx = thread_ctx;
 

--- a/tests/linking/CMakeLists.txt
+++ b/tests/linking/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Consumer of the installed library, deliberately not part of the build in the
+# root CMakeLists.txt: it resolves the library with find_package() out of an
+# install tree, which is the thing under test. Building it from inside this
+# project would resolve the target directly and prove nothing about the
+# installed CMake package.
+#
+# Configure it against an install prefix:
+#
+#   cmake -S tests/linking -B build-linktest -DCMAKE_PREFIX_PATH=<prefix>
+#
+# The imported target is what carries everything a consumer needs and is
+# therefore the whole point of linking against it rather than against a bare
+# -ljitterentropy: the installed include directory, JENT_STATIC_LIB on a static
+# Windows build so the public header stops saying dllimport, and the transitive
+# link libraries (bcrypt, pthread) that a static link has to name itself.
+cmake_minimum_required(VERSION 3.14)
+project(jitterentropy-linktest C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# CONFIG mode explicitly: there is no FindJitterentropy module to fall back to,
+# and without it a missing package config would be reported as a missing module
+# instead of as the package this project actually failed to find.
+find_package(jitterentropy REQUIRED CONFIG)
+
+add_executable(jitterentropy-linktest jitterentropy-linktest.c)
+target_link_libraries(jitterentropy-linktest PRIVATE jitterentropy::jitterentropy)

--- a/tests/linking/jitterentropy-linktest.c
+++ b/tests/linking/jitterentropy-linktest.c
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Test tool calling every function that jitterentropy.h declares.
+ *
+ * Copyright (C) 2026, Stephan Mueller <smueller@chronox.de>
+ *
+ * This program is built against an *installed* library rather than from
+ * inside this tree: it includes <jitterentropy.h> and links the library, and
+ * nothing else. That is what makes it a linkage test - it fails when the
+ * installed header, the exported symbols and the link dependencies recorded
+ * in the CMake package and the pkg-config file do not add up to something a
+ * consumer can build.
+ *
+ * It is built twice, once against the shared library and once against the
+ * static one, because the two differ in exactly the places that break
+ * quietly: the dllimport/dllexport decoration the public header selects on
+ * Windows, the symbol visibility on ELF and Mach-O (the library is compiled
+ * with -fvisibility=hidden, so a declaration that lost its JENT_PRIVATE_STATIC
+ * links in the static case and not in the shared one), and the transitive
+ * dependencies - bcrypt, pthread, the stack-protector runtime - that only a
+ * static link has to name for itself.
+ *
+ * Every declared function is called, so that a symbol dropped from the export
+ * set fails the link rather than going unnoticed until a consumer hits it.
+ * Only outcomes that are properties of the machine rather than of the linkage
+ * are tolerated; each of those is commented where it is allowed.
+ *
+ * Usage: jitterentropy-linktest
+ */
+
+#include <jitterentropy.h>
+
+/*
+ * jitterentropy.h happens to include these itself, but a consumer does not get
+ * to rely on that, and this program is written the way a consumer would be.
+ */
+#include <stdio.h>
+#include <string.h>
+
+/* Set by the callback registered with jent_set_fips_failure_callback(). */
+static unsigned int fips_failure_seen;
+
+static void fips_failure(struct rand_data *ec, unsigned int health_failure)
+{
+	(void)ec;
+	fips_failure_seen = health_failure;
+}
+
+#define FAIL(...)						\
+	do {							\
+		fprintf(stderr, "FAILED: " __VA_ARGS__);	\
+		fputc('\n', stderr);				\
+		return 1;					\
+	} while (0)
+
+int main(void)
+{
+	struct rand_data *ec;
+	void *notime_ctx = NULL;
+	char status[4096];
+	char uuid[JENT_UUID_STRLEN];
+	char data[32];
+	unsigned int version;
+	ssize_t rc;
+	int ret;
+
+	version = jent_version();
+	printf("jent_version: %u\n", version);
+
+	/*
+	 * The header this was compiled against and the library it was linked
+	 * against must be the same release. Only an installed tree can get
+	 * this wrong - a header left behind by a previous install, or a
+	 * library resolved from a different prefix at run time - which is why
+	 * the check lives here and not in a tool built inside this tree.
+	 */
+	if (version != JENT_VERSION)
+		FAIL("jent_version reports %u, the header says %u",
+		     version, (unsigned int)JENT_VERSION);
+
+	/*
+	 * The three configuration calls below have to come before
+	 * jent_entropy_init*(), which blocks any further switching.
+	 *
+	 * A null handler is rejected rather than installed: the point here is
+	 * to call the symbol, and a handler assembled out of the two thread
+	 * helpers this header exports would still be missing the start and
+	 * stop callbacks, so installing one would leave the internal timer
+	 * without a counting thread. The documented rejection is what is
+	 * checked instead.
+	 */
+	ret = jent_entropy_switch_notime_impl(NULL);
+	printf("jent_entropy_switch_notime_impl(NULL): %d\n", ret);
+	if (!ret)
+		FAIL("jent_entropy_switch_notime_impl accepted a null handler");
+
+	/*
+	 * Pinning is best-effort and the return value is not gated on: a build
+	 * without the internal timer has nothing to pin, and several platforms
+	 * (OpenBSD, macOS) accept the index without being able to honour it.
+	 */
+	ret = jent_entropy_set_notime_cpu(0);
+	printf("jent_entropy_set_notime_cpu(0): %d\n", ret);
+
+	ret = jent_set_fips_failure_callback(fips_failure);
+	if (ret)
+		FAIL("jent_set_fips_failure_callback: %d", ret);
+
+	/* Reports the memory backend of this build; both answers are valid. */
+	printf("jent_secure_memory_supported: %d\n",
+	       jent_secure_memory_supported());
+
+	ret = jent_entropy_init();
+	if (ret)
+		FAIL("jent_entropy_init: %d", ret);
+
+	ret = jent_entropy_init_ex(0, 0);
+	if (ret)
+		FAIL("jent_entropy_init_ex: %d", ret);
+
+	/*
+	 * The thread helpers are exported so that an external handler can
+	 * reuse them instead of duplicating them. The builtin implementation
+	 * needs two CPUs and returns -ENOENT below that, and a build without
+	 * the internal timer succeeds without producing a context at all, so
+	 * only the call itself is checked. jent_notime_fini() tolerates the
+	 * null context that leaves.
+	 */
+	ret = jent_notime_init(&notime_ctx);
+	printf("jent_notime_init: %d\n", ret);
+	if (!ret)
+		jent_notime_fini(notime_ctx);
+
+	ec = jent_entropy_collector_alloc(0, 0);
+	if (!ec)
+		FAIL("jent_entropy_collector_alloc returned NULL");
+
+	rc = jent_read_entropy(ec, data, sizeof(data));
+	if (rc != (ssize_t)sizeof(data))
+		FAIL("jent_read_entropy: %ld", (long)rc);
+
+	/*
+	 * The safe variant reallocates the collector on a health failure, so
+	 * it takes the collector by pointer and may replace it.
+	 */
+	rc = jent_read_entropy_safe(&ec, data, sizeof(data));
+	if (rc != (ssize_t)sizeof(data))
+		FAIL("jent_read_entropy_safe: %ld", (long)rc);
+
+	if (jent_status(ec, status, sizeof(status)))
+		FAIL("jent_status");
+	printf("jent_status:\n%s\n", status);
+
+	if (jent_uuid(ec, uuid, sizeof(uuid)))
+		FAIL("jent_uuid");
+	if (strlen(uuid) != (size_t)(JENT_UUID_STRLEN - 1))
+		FAIL("jent_uuid returned %u characters, expected %u",
+		     (unsigned int)strlen(uuid),
+		     (unsigned int)(JENT_UUID_STRLEN - 1));
+	printf("jent_uuid: %s\n", uuid);
+
+	jent_entropy_collector_free(ec);
+
+	/*
+	 * Nothing above forces a health failure, so the callback is expected
+	 * not to have fired. It is reported rather than asserted: what this
+	 * program is here to prove is that registering it linked and that the
+	 * library holds a usable pointer to it.
+	 */
+	printf("FIPS failure callback: %u\n", fips_failure_seen);
+
+	printf("all public functions called successfully\n");
+	return 0;
+}

--- a/tests/raw-entropy/recording_userspace/CMakeLists.txt
+++ b/tests/raw-entropy/recording_userspace/CMakeLists.txt
@@ -100,3 +100,14 @@ endfunction()
 testprogram(jitterentropy-hashtime AMALGAMATED)
 testprogram(jitterentropy-osr)
 testprogram(jitterentropy-rng)
+
+# The CPU information tool only queries the operating system about the CPUs -
+# it does not link against the library.
+add_executable(jitterentropy-cpuinfo jitterentropy-cpuinfo.c)
+target_compile_options(jitterentropy-cpuinfo PRIVATE ${JITTER_C_FLAGS})
+if(WIN32)
+    # The model of each CPU is read from the registry with RegGetValueA(), which
+    # MSVC pulls in through its default libraries but MinGW does not.
+    target_link_libraries(jitterentropy-cpuinfo "advapi32")
+endif()
+install(TARGETS jitterentropy-cpuinfo)

--- a/tests/raw-entropy/recording_userspace/Makefile.cpuinfo
+++ b/tests/raw-entropy/recording_userspace/Makefile.cpuinfo
@@ -1,0 +1,43 @@
+# Compile the CPU information tool
+#
+# The tool only queries the operating system about the CPUs; it does not use
+# any Jitter RNG code and therefore needs neither the library nor its headers.
+
+CC ?= gcc
+CFLAGS +=-Wextra -Wall -pedantic -fPIC -O0
+#Hardening
+CFLAGS +=-fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -Wcast-align -Wmissing-field-initializers -Wshadow -Wswitch-enum
+ifneq (Darwin,$(shell uname))
+LDFLAGS +=-Wl,-z,relro,-z,now
+endif
+
+GCCVERSIONFORMAT := $(shell echo `$(CC) -dumpversion | sed 's/\./\n/g' | wc -l`)
+ifeq "$(GCCVERSIONFORMAT)" "3"
+  GCC_GTEQ_490 := $(shell expr `$(CC) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
+else
+  GCC_GTEQ_490 := $(shell expr `$(CC) -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
+endif
+
+ifeq "$(GCC_GTEQ_490)" "1"
+  CFLAGS += -fstack-protector-strong
+else
+  CFLAGS += -fstack-protector-all
+endif
+
+program_NAME := jitterentropy-cpuinfo
+program_C_SRCS := jitterentropy-cpuinfo.c
+program_C_OBJS := ${program_C_SRCS:.c=.o}
+program_OBJS := $(program_C_OBJS)
+
+.PHONY: all clean distclean
+
+all: $(program_NAME)
+
+$(program_NAME): $(program_OBJS)
+	$(CC) $(program_OBJS) -o $(program_NAME) $(LDFLAGS)
+
+clean:
+	@- $(RM) $(program_NAME)
+	@- $(RM) $(program_OBJS)
+
+distclean: clean

--- a/tests/raw-entropy/recording_userspace/README.md
+++ b/tests/raw-entropy/recording_userspace/README.md
@@ -70,6 +70,165 @@ still need the tool to be invoked as root, whereas the smaller ones now work as
 a normal user; where the limit is not sufficient, the tool reports that the
 Jitter RNG handle cannot be allocated.
 
+## Core Selection on Hybrid CPUs
+
+On hybrid CPUs - Intel P/E cores, ARM big.LITTLE - the core types differ in
+their micro-architecture and their caches. The Jitter RNG therefore shows a
+different timing behavior on each of them. A raw noise recording thus only
+characterizes the core type it was taken on, which means each core type has to
+be recorded and analyzed separately.
+
+The tool `jitterentropy-cpuinfo` lists the cores to choose from:
+
+	make -f Makefile.cpuinfo
+	./jitterentropy-cpuinfo
+
+For every CPU it reports the vendor and the model, the core type as reported
+by the system, the topology and the data cache sizes together with the number
+of CPUs sharing each cache. The sharing separates the core types as well - on
+hybrid Intel CPUs, each P-core has an L2 cache of its own whereas a cluster of
+E-cores shares one - and it is also what identifies the SMT siblings, which
+are two CPU numbers for one physical core rather than two cores to measure.
+
+The core type is whatever the system offers: the hybrid information of CPUID
+on Intel, the efficiency class on Windows and the performance level on macOS.
+ARM reports no core type at all; what is shown there instead is the compute
+capacity the scheduler works with, normalized so that the most capable core of
+the system is 1024 - it is what separates the big from the LITTLE cores, and on
+a uniform system every core reports 1024 and the value says only that they are
+equivalent.
+
+AMD reports no core type either - its dense cores are the same
+micro-architecture with a smaller cache and a lower clock, which the cache and
+frequency columns show - so where the amd-pstate driver is in use, the per-core
+performance ranking of the firmware is reported instead.
+
+Intel's low-power efficiency cores (Meteor Lake and later) are reported as
+`LP-E-core`. Note that this is derived rather than read: CPUID knows the two
+core types Atom and Core only, and an LP E-core is an Atom core like any other
+efficiency core. What identifies it is that it sits outside the L3 domain, so
+an efficiency core seeing no L3 on a system whose other cores do is taken to be
+one. All three types have to be recorded separately.
+
+How much of this is available differs per operating system. Linux, Windows and
+FreeBSD describe every CPU individually. macOS has no per-CPU interface and
+describes the cores per performance level, which is how Apple Silicon exposes
+its P and E cores. The remaining systems have neither that nor a way to place
+the tool on a chosen CPU, so only the CPU it happens to run on is described -
+run it repeatedly to see the other core types.
+
+The nominal base frequency and the rate of the counter the Jitter RNG takes
+its timings from are reported as well. The base frequency is the second value
+that separates the core types - on the hybrid parts it differs where the model
+name cannot - and the counter rate is the resolution every measurement is
+bounded by. That counter is the timestamp counter on x86 and the architected
+generic timer on ARM, where it commonly runs at a far lower rate.
+
+Its properties are stated below the table, in the terms Linux uses for them:
+`invariant` is a counter that ticks at a constant rate whatever the P-state,
+`nonstop` one that keeps ticking in the deep C-states, and `known rate` says
+that the rate above was enumerated rather than calibrated by the operating
+system against another timer. On Linux these come
+from what the kernel concluded (the `constant_tsc`, `nonstop_tsc` and
+`tsc_known_freq` flags of `/proc/cpuinfo`), elsewhere from CPUID or, on ARM,
+from what the architecture guarantees for the generic timer.
+
+Where a value is unknown, the reason is given below the table rather than left
+to a dash. AMD enumerates neither its base frequency nor its counter rate in
+CPUID: the base frequency is taken from the nominal frequency of the CPPC
+tables there, and the counter rate stays unknown. On a machine that has
+neither cpufreq nor those tables - a virtual machine, typically - no frequency
+is reported at all.
+
+With `--summary` the listing holds one row per kind of CPU rather than one per
+CPU, naming the CPUs of each kind. On a machine with a hundred CPUs that says
+in a few lines what the full listing repeats a hundred times, which is what
+the question "how many core types are there, and which CPU do I record for
+each" wants:
+
+	 CPUs Type      BaseMHz  MaxMHz  TmrMHz        L1d ...
+	    4 P-core       1700    5000    2611      48K/2 ...
+	      CPUs 0-3
+	    8 E-core       1200    3700    2611      32K/1 ...
+	      CPUs 4-11
+
+Two CPUs count as of one kind when everything a recording depends on matches:
+the core type, the frequencies, the counter and the caches. The package and
+core numbers are not part of that - they name a CPU rather than describe it.
+
+With `--json` the same data is written as JSON, one entry per CPU, for scripts
+that drive one recording per core type. Values the system does not report are `null`,
+`backend` names where the data comes from (`linux`, `windows`, `macos` or
+`generic`, which is what says how complete the listing is), and `pinning`
+states whether the `--cpu` option below can be used at all:
+
+	./jitterentropy-cpuinfo --json |
+		jq -r '.processors[] | select(.coreType == "E-core") | .cpu'
+
+A `macos` backend reports `"pinning": false` although a core type can still be
+selected there - with `--e-cores` rather than with `--cpu`, as described below.
+
+The recording is confined to one of the listed CPUs with the `--cpu` option of
+`jitterentropy-hashtime`:
+
+	./jitterentropy-hashtime 1000000 1 jent-raw-noise --cpu 4
+
+The configuration a recording is made with is shown with:
+
+	./jitterentropy-hashtime 1 1 unused --cpu 4 --status
+
+The same effect is achieved for the recording scripts listed above by invoking
+them under `taskset -c <CPU>`.
+
+The size of the memory block used for the memory access loop does not follow
+the selected core: the library derives it from the largest data cache found in
+the system, which is the one of the performance cores. To record an efficiency
+core with a memory size that matches its own cache instead, pass the size with
+`--max-mem` - the cache sizes of that core are reported by
+`jitterentropy-cpuinfo`.
+
+Note that the internal timer cannot be used together with `--cpu`: its
+counting thread requires a CPU of its own, whereas `--cpu` leaves a single CPU
+in the affinity mask. OpenBSD offers no thread affinity API at all, so `--cpu`
+is unavailable there; `jitterentropy-cpuinfo` says so in its output.
+
+`jitterentropy-hashtime` offers `--cpu` only where it can place the
+measurement, which is Linux, Windows, FreeBSD and NetBSD - and Linux alone when
+the library is built without its internal timer, whose pinning primitive the
+option uses. Passing it elsewhere is answered with the reason it cannot be
+honored rather than with an unknown-option error.
+
+### Selecting a core type on macOS
+
+macOS offers no thread-to-CPU pinning either, so `--cpu` cannot be used there.
+The efficiency cores can still be recorded on their own: macOS schedules the
+lowest quality-of-service class on them alone, which is what `--e-cores` asks
+for:
+
+	./jitterentropy-hashtime 1000000 1 jent-raw-noise --e-cores
+
+Without that option the recording is made on the performance cores, as that is
+where the system runs a thread that asks for nothing. `--cpu`, `--e-cores` and
+`--p-cores` are mutually exclusive, and the last two are rejected on every
+other system.
+
+The counterpart, `--p-cores`, asks for the performance cores. A command started
+from a shell already carries the class those are given first, so it changes
+nothing there. What it is for is a recording made from a process that was put
+in the background - `taskpolicy -b`, a launchd job marked as such - which macOS
+holds on the efficiency cores through a policy of the task that the class of a
+thread does not lift; `--p-cores` clears that policy. Measured on an M1 Pro, the
+same recording under `taskpolicy -b` takes 3.02 s of CPU time and shows a mean
+timing delta of 795 ticks - an efficiency-core recording, unasked for - and with
+`--p-cores` 0.54 s and 130 ticks, which are the values of a recording made in
+the foreground. It remains a request: a process started through `posix_spawn()`
+with a background QoS attribute is not brought back by it.
+
+The efficiency cores are recorded as macOS runs background work on them, which
+includes the lower clock it gives that class - not the same core at its own
+maximum frequency, a combination no interface exposes. The note on `--max-mem`
+above applies here as well.
+
 ## Recording of Raw Entropy Data
 
 If the `invoke_testing.sh` is not helpful for performing the test, the following

--- a/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-cpuinfo.c
@@ -1,0 +1,2775 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Test tool listing the identification and cache layout of every CPU.
+ *
+ * Copyright (C) 2026, Stephan Mueller <smueller@chronox.de>
+ *
+ * On hybrid CPUs (Intel P/E cores, ARM big.LITTLE) the timing of both noise
+ * sources depends on the micro-architecture and the caches of the core the
+ * Jitter RNG runs on, so a recording only characterizes that core type. This
+ * tool names the CPUs and their caches, and the measurement is then pinned to
+ * one of them with "jitterentropy-hashtime --cpu <CPU>".
+ *
+ * Coverage per system:
+ *
+ *   Linux    Complete, from sysfs plus CPUID/MIDR read on each core.
+ *   Windows  Complete, from GetLogicalProcessorInformationEx() and the registry.
+ *   macOS    Complete, but per performance level (hw.perflevel<N>.*) rather
+ *            than per CPU - which is how Apple Silicon exposes P and E cores.
+ *   Others   Only the CPU this tool runs on, its caches only on x86: nothing
+ *            there enumerates the caches of the other CPUs.
+ *
+ * Usage: jitterentropy-cpuinfo [--summary] [--json]
+ */
+
+/*
+ * Both of these must precede every system header, so they are stated here
+ * rather than next to the backend that needs them: _GNU_SOURCE exposes the
+ * CPU-affinity interfaces of glibc, and _WIN32_WINNT the Windows 7 APIs a
+ * toolchain targeting an older Windows hides - the same guard the library's
+ * own Win32 backends carry. An externally supplied, higher value is left
+ * alone.
+ */
+#ifdef __linux__
+# define _GNU_SOURCE
+#endif
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && !defined(_WIN32_WINNT)
+# define _WIN32_WINNT 0x0601
+#endif
+
+/* Backend selection */
+#if defined(_WIN32) || defined(_WIN64)
+# define JENT_CPUINFO_WINDOWS
+#elif defined(__linux__)
+# define JENT_CPUINFO_LINUX
+#elif defined(__APPLE__)
+# define JENT_CPUINFO_MACOS
+#elif defined(__unix__) || defined(__unix) || defined(__HAIKU__) || \
+      defined(_AIX)
+# define JENT_CPUINFO_GENERIC
+#endif
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__x86_64__) || defined(__i386__) || \
+    defined(_M_X64)     || defined(_M_IX86)
+# define JENT_CPUINFO_X86
+#elif defined(__aarch64__) || defined(_M_ARM64)
+# define JENT_CPUINFO_ARM64
+#endif
+
+#ifdef JENT_CPUINFO_X86
+# ifdef _MSC_VER
+#  include <intrin.h>
+# else
+#  include <cpuid.h>
+# endif
+#endif
+
+#define JENT_MAX_CPUS		1024
+#define JENT_IDENT_LEN		160
+#define JENT_TYPE_LEN		16
+
+struct jent_cache_info {
+	unsigned long size;	/* cache size in bytes, 0 if unknown */
+	unsigned long shared;	/* number of CPUs sharing this cache */
+};
+
+struct jent_cpu_info {
+	unsigned long cpu;
+	int cpu_valid;		/* is the CPU number known? */
+	long pkg;		/* physical package ID, -1 if unknown */
+	long core;		/* core ID, -1 if unknown */
+	unsigned long max_khz;	/* maximum CPU frequency, 0 if unknown */
+	unsigned long base_khz;	/* nominal base frequency, 0 if unknown */
+	unsigned long tsc_khz;	/* nominal timestamp counter rate, 0 if unknown */
+	/* Timestamp counter properties, each 1 yes, 0 no, -1 not reported */
+	int tsc_invariant;	/* constant rate across P-states (constant_tsc) */
+	int tsc_nonstop;	/* keeps ticking in deep C-states (nonstop_tsc) */
+	int tsc_known_freq;	/* rate is enumerated, not calibrated */
+	struct jent_cache_info l1d, l1i, l2, l3;
+	/* Vendor and model as one string, empty if the CPU is not identified */
+	char ident[JENT_IDENT_LEN];
+	/*
+	 * Core type as reported by the system ("P-core"/"E-core") or the
+	 * relative compute capacity known to the scheduler ("cap <N>").
+	 */
+	char type[JENT_TYPE_LEN];
+};
+
+struct jent_cpu_list {
+	struct jent_cpu_info cpu[JENT_MAX_CPUS];
+	long entries;		/* number of CPUs described below */
+	long ncpu;		/* number of CPUs in the system */
+	int pinning;		/* does the system offer CPU pinning? */
+	/* Source of the data, and what a JSON consumer branches on. */
+	const char *backend;
+	/* The same in prose, printed as a note below the table; NULL if none. */
+	const char *note;
+	/*
+	 * How a recording is confined to one core type without CPU pinning,
+	 * NULL where there is no way to. Printed in place of the --cpu line.
+	 */
+	const char *select;
+};
+
+/*
+ * Set the model of @info to "<vendor> <model>", padding removed: CPUID pads
+ * the AMD brand string with blanks that /proc/cpuinfo and the Windows registry
+ * do not, and left in, the two spellings list one machine as two models.
+ */
+static void jent_set_ident(struct jent_cpu_info *info, const char *vendor,
+			   const char *model)
+{
+	size_t len;
+
+	if (!vendor)
+		vendor = "";
+	if (!model)
+		model = "";
+
+	while (*vendor == ' ' || *vendor == '\t')
+		vendor++;
+	while (*model == ' ' || *model == '\t')
+		model++;
+
+	snprintf(info->ident, sizeof(info->ident), "%s%s%s", vendor,
+		 (*vendor && *model) ? " " : "", model);
+
+	len = strlen(info->ident);
+	while (len && (info->ident[len - 1] == ' ' ||
+		       info->ident[len - 1] == '\t'))
+		info->ident[--len] = '\0';
+}
+
+/* Set the fields whose "unknown" value is not zero. */
+static void jent_cpu_info_init(struct jent_cpu_info *info)
+{
+	info->pkg = -1;
+	info->core = -1;
+	info->tsc_invariant = -1;
+	info->tsc_nonstop = -1;
+	info->tsc_known_freq = -1;
+}
+
+/* Defined by the backend for the operating system in use. */
+static int jent_get_cpus(struct jent_cpu_list *list);
+
+/***************************************************************************
+ * x86 identification via CPUID
+ *
+ * - leaf 0 holds the vendor string in EBX, EDX, ECX,
+ * - leaves 0x80000002 - 0x80000004 hold the processor brand string,
+ * - leaf 0x1A (Intel SDM Vol. 2A, "Hybrid Information") reports the core type
+ *   in EAX[31:24]: 0x20 Atom (efficiency), 0x40 Core (performance), zero on a
+ *   non-hybrid CPU. Those two are all it knows - the low-power E-cores are
+ *   Atoms as well, so jent_mark_lp_cores() tells them apart afterwards.
+ *
+ * CPUID describes the core executing it, so the caller has to pin itself to
+ * the CPU it wants identified first.
+ ***************************************************************************/
+
+#if defined(JENT_CPUINFO_X86) && !defined(JENT_CPUINFO_MACOS)
+
+/*
+ * Execute CPUID for @leaf/@subleaf into @regs (EAX, EBX, ECX, EDX). Returns
+ * zero when the leaf is beyond what the CPU implements - the check the GCC and
+ * clang helper does, spelled out for the MSVC intrinsics, which do not.
+ */
+static int jent_cpuid(unsigned int leaf, unsigned int subleaf,
+		      unsigned int regs[4]);
+
+/* Issue CPUID without asking whether the leaf is implemented. */
+static void jent_cpuid_raw(unsigned int leaf, unsigned int subleaf,
+			   unsigned int regs[4])
+{
+#ifdef _MSC_VER
+	int out[4];
+
+	__cpuidex(out, (int)leaf, (int)subleaf);
+	regs[0] = (unsigned int)out[0];
+	regs[1] = (unsigned int)out[1];
+	regs[2] = (unsigned int)out[2];
+	regs[3] = (unsigned int)out[3];
+#else
+	__cpuid_count(leaf, subleaf, regs[0], regs[1], regs[2], regs[3]);
+#endif
+}
+
+/*
+ * The leaves at 0x40000000 and up fall under neither the standard nor the
+ * extended maximum, so they need two checks of their own: CPUID.1 ECX[31],
+ * which only a hypervisor sets, and the leaf range its own 0x40000000 EAX
+ * states. Unchecked, an unimplemented leaf answers with the highest standard
+ * one instead of zeroes - plausible-looking nonsense.
+ */
+static int jent_cpuid_hypervisor(unsigned int leaf, unsigned int subleaf,
+				 unsigned int regs[4])
+{
+	unsigned int r[4];
+
+	if (!jent_cpuid(1, 0, r) || !(r[2] & (1U << 31)))
+		return 0;
+
+	jent_cpuid_raw(0x40000000, 0, r);
+	if (leaf > r[0])
+		return 0;
+
+	jent_cpuid_raw(leaf, subleaf, regs);
+
+	return 1;
+}
+
+static int jent_cpuid(unsigned int leaf, unsigned int subleaf,
+		      unsigned int regs[4])
+{
+	unsigned int max;
+
+	if ((leaf & 0xFF000000U) == 0x40000000U)
+		return jent_cpuid_hypervisor(leaf, subleaf, regs);
+
+	/* The standard and the extended leaves have a maximum of their own. */
+#ifdef _MSC_VER
+	{
+		int out[4];
+
+		__cpuid(out, (int)(leaf & 0x80000000U));
+		max = (unsigned int)out[0];
+	}
+#else
+	/*
+	 * Not __get_cpuid_count(): it appeared in GCC 4.9, while the
+	 * distributions this is built on still carry 4.8. The two calls it is
+	 * made of have been there all along.
+	 */
+	max = __get_cpuid_max(leaf & 0x80000000U, NULL);
+#endif
+
+	if (leaf > max)
+		return 0;
+
+	jent_cpuid_raw(leaf, subleaf, regs);
+
+	return 1;
+}
+
+/* Windows names its CPUs from the registry and needs none of this. */
+#if defined(JENT_CPUINFO_LINUX) || defined(JENT_CPUINFO_GENERIC)
+
+static void jent_ident_x86(struct jent_cpu_info *info)
+{
+	unsigned int r[4];
+	char vendor[13] = { 0 }, brand[49] = { 0 };
+	const char *model = brand;
+
+	if (!jent_cpuid(0, 0, r))
+		return;
+	memcpy(vendor,     &r[1], 4);
+	memcpy(vendor + 4, &r[3], 4);
+	memcpy(vendor + 8, &r[2], 4);
+
+	{
+		unsigned int regs[12], i;
+
+		for (i = 0; i < 3; i++) {
+			if (!jent_cpuid(0x80000002 + i, 0, &regs[i * 4]))
+				break;
+		}
+		if (i == 3) {
+			memcpy(brand, regs, sizeof(regs));
+			/* The brand string is padded with leading blanks. */
+			while (*model == ' ')
+				model++;
+		}
+	}
+
+	jent_set_ident(info, vendor, model);
+
+	if (jent_cpuid(0x1A, 0, r) && r[0]) {
+		switch (r[0] >> 24) {
+		case 0x20:
+			snprintf(info->type, sizeof(info->type), "E-core");
+			break;
+		case 0x40:
+			snprintf(info->type, sizeof(info->type), "P-core");
+			break;
+		default:
+			snprintf(info->type, sizeof(info->type), "0x%02x",
+				 r[0] >> 24);
+			break;
+		}
+	}
+}
+
+#endif /* JENT_CPUINFO_LINUX || JENT_CPUINFO_GENERIC */
+
+/*
+ * The nominal frequency some brand strings end in ("... CPU @ 2.40GHz"), in
+ * kHz, or 0 when there is none. Only a trailing "@ <number><unit>Hz" is taken,
+ * so that a model number containing a digit cannot pass for a frequency.
+ */
+static unsigned long jent_brand_khz(const char *brand)
+{
+	const char *at = strrchr(brand, '@');
+	unsigned long value = 0, scale = 0, frac_digits = 0;
+	int seen_digit = 0, in_frac = 0;
+
+	if (!at)
+		return 0;
+
+	for (at++; *at == ' '; at++)
+		;
+
+	for (; *at; at++) {
+		if (*at >= '0' && *at <= '9') {
+			value = value * 10 + (unsigned long)(*at - '0');
+			if (in_frac)
+				frac_digits++;
+			seen_digit = 1;
+		} else if (*at == '.' && !in_frac) {
+			in_frac = 1;
+		} else {
+			break;
+		}
+	}
+
+	if (!seen_digit)
+		return 0;
+
+	if (*at == 'G')
+		scale = 1000000;	/* GHz -> kHz */
+	else if (*at == 'M')
+		scale = 1000;		/* MHz -> kHz */
+	else if (*at == 'k' || *at == 'K')
+		scale = 1;
+	else
+		return 0;
+
+	if (strncmp(at + 1, "Hz", 2))
+		return 0;
+
+	/* Undo the decimal point: "2.40GHz" parsed 240 with two digits. */
+	for (; frac_digits; frac_digits--) {
+		if (scale < 10)
+			return 0;
+		scale /= 10;
+	}
+
+	return value * scale;
+}
+
+/*
+ * Frequencies and timestamp counter of the core this runs on.
+ *
+ * Leaf 0x16 (Intel SDM Vol. 2A, "Processor Frequency Information") gives the
+ * base in EAX[15:0] and the maximum in EBX[15:0], in MHz. Only EBX follows the
+ * core executing it; EAX stays package-wide even where the P and E cores differ
+ * - so Linux and Windows prefer their per-CPU base frequency and reach this
+ * leaf only where that is unavailable.
+ *
+ * Leaf 0x15 gives the TSC rate as ECX (crystal clock in Hz) * EBX / EAX. That
+ * counter is what the Jitter RNG times with, so its rate bounds the resolution
+ * of every measurement. 0x80000007 EDX[8] marks it invariant - constant across
+ * P-states, not stopping in deep C-states - which is what makes it usable.
+ *
+ * AMD implements neither 0x15 nor 0x16, so there the values stay unknown and
+ * the rate comes from cpufreq or the registry instead.
+ */
+static void jent_freq_x86(struct jent_cpu_info *info)
+{
+	unsigned int r[4];
+
+	if (jent_cpuid(0x16, 0, r)) {
+		if (!info->base_khz && (r[0] & 0xFFFF))
+			info->base_khz = (unsigned long)(r[0] & 0xFFFF) * 1000;
+		if (!info->max_khz && (r[1] & 0xFFFF))
+			info->max_khz = (unsigned long)(r[1] & 0xFFFF) * 1000;
+	}
+
+	/*
+	 * Last resort: the frequency the brand string ends in is the base one.
+	 * Without 0x16 and without cpufreq, it is all there is.
+	 */
+	if (!info->base_khz)
+		info->base_khz = jent_brand_khz(info->ident);
+
+	if (jent_cpuid(0x15, 0, r) && r[0] && r[1] && r[2])
+		info->tsc_khz = (unsigned long)((uint64_t)r[2] * r[1] /
+						r[0] / 1000);
+
+	/*
+	 * Leaf 0x40000010, in kHz: the timing leaf VMware defined and others
+	 * adopted. On an AMD host it is one of the few places a guest can learn
+	 * the rate at all. Not every hypervisor has it, and the leaf-range check
+	 * in jent_cpuid() then leaves the rate unknown rather than guessing.
+	 */
+	if (!info->tsc_khz && jent_cpuid(0x40000010, 0, r) && r[0])
+		info->tsc_khz = r[0];
+
+	/*
+	 * An enumerated rate is a known one; without it the operating system
+	 * calibrates against another timer and arrives at its own number.
+	 */
+	info->tsc_known_freq = info->tsc_khz ? 1 : 0;
+
+	if (jent_cpuid(0x80000007, 0, r)) {
+		/*
+		 * The one invariant-TSC bit covers both properties. Linux
+		 * splits them into constant_tsc and nonstop_tsc, which it also
+		 * sets from model checks on the parts predating the bit - hence
+		 * the Linux backend overriding these afterwards.
+		 */
+		info->tsc_invariant = (r[3] & (1U << 8)) ? 1 : 0;
+		info->tsc_nonstop = info->tsc_invariant;
+	}
+}
+
+#endif /* JENT_CPUINFO_X86 && !JENT_CPUINFO_MACOS */
+
+/*
+ * The data cache geometry from CPUID, needed only where the operating system
+ * has no interface of its own for it.
+ *
+ * Intel leaf 4 and the identically laid out AMD leaf 0x8000001D enumerate one
+ * cache per sub-leaf (Intel SDM Vol. 2A, "Deterministic Cache Parameters";
+ * AMD APM Vol. 3, "Cache Topology Information"):
+ *
+ *   EAX[ 4: 0]  cache type (0 = none/end, 1 = data, 2 = instruction, 3 = unified)
+ *   EAX[ 7: 5]  cache level
+ *   EBX[11: 0]  system coherency line size - 1
+ *   EBX[21:12]  physical line partitions - 1
+ *   EBX[31:22]  ways of associativity - 1
+ *   ECX         number of sets - 1
+ * Total size = (ways + 1) * (partitions + 1) * (line size + 1) * (sets + 1).
+ *
+ * The sharing count is deliberately not taken from EAX[25:14]: that field is
+ * rounded up to a power of two and describes what the encoding allows, not the
+ * topology - on a 12-CPU part it claims 64 CPUs share the L3. The column stays
+ * empty rather than carrying a wrong number.
+ */
+#if defined(JENT_CPUINFO_X86) && defined(JENT_CPUINFO_GENERIC)
+
+/* Walk the sub-leaves of @leaf; returns non-zero if any cache was found. */
+static int jent_caches_x86_leaf(struct jent_cpu_info *info, unsigned int leaf)
+{
+	unsigned int sub;
+	int found = 0;
+
+	for (sub = 0; sub < 16; sub++) {
+		unsigned int type, level, ways, partitions, line, sets;
+		struct jent_cache_info *cache;
+		unsigned int r[4], eax, ebx, ecx;
+
+		if (!jent_cpuid(leaf, sub, r))
+			break;
+		eax = r[0];
+		ebx = r[1];
+		ecx = r[2];
+
+		type = eax & 0x1F;
+		if (type == 0)
+			break;
+
+		level      = (eax >> 5) & 0x7;
+		ways       = ((ebx >> 22) & 0x3FF) + 1;
+		partitions = ((ebx >> 12) & 0x3FF) + 1;
+		line       = (ebx & 0xFFF) + 1;
+		sets       = ecx + 1;
+
+		if (level == 1 && type == 2)
+			cache = &info->l1i;
+		else if (level == 1 && (type == 1 || type == 3))
+			cache = &info->l1d;
+		else if (level == 2 && type != 2)
+			cache = &info->l2;
+		else if (level == 3 && type != 2)
+			cache = &info->l3;
+		else
+			continue;
+
+		cache->size = (unsigned long)ways * partitions * line * sets;
+		found = 1;
+	}
+
+	return found;
+}
+
+static void jent_caches_x86(struct jent_cpu_info *info)
+{
+	/*
+	 * Leaf 4 is Intel's; AMD and Hygon leave it empty (cache type 0) and
+	 * carry the identical structure in the extended leaf. Both are probed
+	 * rather than dispatching on the vendor ID, as the library itself does
+	 * in arch/jitterentropy-arch-cache.c.
+	 */
+	if (jent_caches_x86_leaf(info, 0x00000004))
+		return;
+
+	jent_caches_x86_leaf(info, 0x8000001D);
+}
+
+#endif /* JENT_CPUINFO_X86 && JENT_CPUINFO_GENERIC */
+
+/***************************************************************************
+ * AArch64 timer
+ *
+ * Shared by the Linux and the macOS backend. The BSDs are left out
+ * deliberately: nothing there is verified to enable the EL0 access this needs,
+ * and a read that traps would take the tool down with SIGILL.
+ ***************************************************************************/
+
+#if defined(JENT_CPUINFO_ARM64) && \
+    (defined(JENT_CPUINFO_LINUX) || defined(JENT_CPUINFO_MACOS))
+
+/*
+ * The rate of the architected generic timer: the Jitter RNG times with
+ * CNTVCT_EL0 here, and CNTFRQ_EL0 states its frequency. The architecture
+ * requires that counter to be constant, independent of the CPU clock and
+ * always on (Arm ARM (DDI 0487)), so the three properties below follow from
+ * the architecture rather than a feature bit. Rates are commonly tens of MHz -
+ * far coarser than an x86 TSC, and that is what bounds the measurements.
+ */
+static void jent_timer_arm64(struct jent_cpu_info *info)
+{
+	uint64_t freq;
+
+	__asm__ __volatile__("mrs %0, cntfrq_el0" : "=r" (freq));
+
+	/* Firmware that leaves the register at zero has not set it up. */
+	if (!freq)
+		return;
+
+	info->tsc_khz = (unsigned long)(freq / 1000);
+	info->tsc_invariant = 1;
+	info->tsc_nonstop = 1;
+	info->tsc_known_freq = 1;
+}
+
+#endif /* JENT_CPUINFO_ARM64 && (JENT_CPUINFO_LINUX || JENT_CPUINFO_MACOS) */
+
+/***************************************************************************
+ * Linux backend
+ *
+ * sysfs describes the caches and the topology of every CPU without any
+ * privileges. Only the identification has to be read on the CPU itself, which
+ * the affinity API allows.
+ ***************************************************************************/
+
+#ifdef JENT_CPUINFO_LINUX
+
+#include <sched.h>
+
+#define JENT_SYSFS_CPU		"/sys/devices/system/cpu"
+
+/* Number of cache levels exposed per CPU in sysfs that are looked at. */
+#define JENT_MAX_CACHE_INDEX	10
+
+static int read_file_str(const char *path, char *buf, size_t buflen)
+{
+	FILE *f = fopen(path, "r");
+	size_t len;
+
+	if (!f)
+		return -errno;
+
+	if (!fgets(buf, (int)buflen, f)) {
+		fclose(f);
+		return -EIO;
+	}
+	fclose(f);
+
+	/* Strip the trailing newline sysfs adds to every attribute. */
+	len = strlen(buf);
+	while (len && (buf[len - 1] == '\n' || buf[len - 1] == ' '))
+		buf[--len] = '\0';
+
+	return len ? 0 : -ENODATA;
+}
+
+static int read_cpu_str(unsigned long cpu, const char *attr,
+			char *buf, size_t buflen)
+{
+	char path[256];
+
+	snprintf(path, sizeof(path), JENT_SYSFS_CPU "/cpu%lu/%s", cpu, attr);
+	return read_file_str(path, buf, buflen);
+}
+
+/* Numeric sysfs attribute. Base 0, as midr_el1 is given as 0x... */
+static int read_cpu_val(unsigned long cpu, const char *attr,
+			unsigned long *val)
+{
+	char buf[64], *endptr;
+	int ret = read_cpu_str(cpu, attr, buf, sizeof(buf));
+
+	if (ret)
+		return ret;
+
+	errno = 0;
+	*val = strtoul(buf, &endptr, 0);
+	if (endptr == buf || errno != 0)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int read_cpu_signed(unsigned long cpu, const char *attr, long *val)
+{
+	char buf[64], *endptr;
+	int ret = read_cpu_str(cpu, attr, buf, sizeof(buf));
+
+	if (ret)
+		return ret;
+
+	errno = 0;
+	*val = strtol(buf, &endptr, 10);
+	if (endptr == buf || errno != 0)
+		return -EINVAL;
+
+	return 0;
+}
+
+/*
+ * Parse a kernel CPU list like "0-3,8" (/sys/.../online, shared_cpu_list) into
+ * @cpus, at most @max of them. Returns the length of the list or a negative
+ * errno - a count above @max reports the truncation to the caller.
+ */
+static long parse_cpu_list(const char *str, unsigned long *cpus, size_t max)
+{
+	const char *p = str;
+	long count = 0;
+
+	while (*p && *p != '\n') {
+		char *endptr;
+		unsigned long start, end, i;
+
+		errno = 0;
+		start = strtoul(p, &endptr, 10);
+		if (endptr == p || errno != 0)
+			return -EINVAL;
+		p = endptr;
+
+		if (*p == '-') {
+			p++;
+			errno = 0;
+			end = strtoul(p, &endptr, 10);
+			if (endptr == p || errno != 0 || end < start)
+				return -EINVAL;
+			p = endptr;
+		} else {
+			end = start;
+		}
+
+		for (i = start; i <= end; i++, count++) {
+			if (cpus && (size_t)count < max)
+				cpus[count] = i;
+		}
+
+		if (*p == ',')
+			p++;
+		else
+			break;
+	}
+
+	return count ? count : -EINVAL;
+}
+
+/* Convert a sysfs cache size like "48K" or "32M" into bytes. */
+static unsigned long parse_cache_size(const char *str)
+{
+	char *endptr;
+	unsigned long val;
+
+	errno = 0;
+	val = strtoul(str, &endptr, 10);
+	if (endptr == str || errno != 0)
+		return 0;
+
+	switch (*endptr) {
+	case 'K':
+		return val * 1024;
+	case 'M':
+		return val * 1024 * 1024;
+	case 'G':
+		return val * 1024 * 1024 * 1024;
+	default:
+		return val;
+	}
+}
+
+static void jent_caches_linux(struct jent_cpu_info *info)
+{
+	unsigned int idx;
+
+	for (idx = 0; idx < JENT_MAX_CACHE_INDEX; idx++) {
+		char attr[64], type[32], size[32], list[512];
+		struct jent_cache_info *cache;
+		unsigned long level;
+		long shared;
+
+		snprintf(attr, sizeof(attr), "cache/index%u/level", idx);
+		if (read_cpu_val(info->cpu, attr, &level))
+			break;
+
+		snprintf(attr, sizeof(attr), "cache/index%u/type", idx);
+		if (read_cpu_str(info->cpu, attr, type, sizeof(type)))
+			continue;
+
+		/*
+		 * The Jitter RNG only accesses data; the L1i is kept just to
+		 * document the split. L2 and L3 are commonly unified.
+		 */
+		if (level == 1 && !strncmp(type, "Instruction", 11))
+			cache = &info->l1i;
+		else if (level == 1)
+			cache = &info->l1d;
+		else if (level == 2 && strncmp(type, "Instruction", 11))
+			cache = &info->l2;
+		else if (level == 3 && strncmp(type, "Instruction", 11))
+			cache = &info->l3;
+		else
+			continue;
+
+		snprintf(attr, sizeof(attr), "cache/index%u/size", idx);
+		if (read_cpu_str(info->cpu, attr, size, sizeof(size)))
+			continue;
+		cache->size = parse_cache_size(size);
+
+		/*
+		 * The sharing count separates P-cores from E-core clusters: a
+		 * P-core owns its L2, a group of E-cores shares one.
+		 */
+		snprintf(attr, sizeof(attr), "cache/index%u/shared_cpu_list",
+			 idx);
+		if (read_cpu_str(info->cpu, attr, list, sizeof(list)))
+			continue;
+		shared = parse_cpu_list(list, NULL, 0);
+		if (shared > 0)
+			cache->shared = (unsigned long)shared;
+	}
+}
+
+#ifdef JENT_CPUINFO_ARM64
+
+static const struct {
+	unsigned long id;
+	const char *name;
+} arm_implementers[] = {
+	{ 0x41, "ARM" },	{ 0x42, "Broadcom" },	{ 0x43, "Cavium" },
+	{ 0x46, "Fujitsu" },	{ 0x48, "HiSilicon" },	{ 0x4e, "NVIDIA" },
+	{ 0x50, "APM" },	{ 0x51, "Qualcomm" },	{ 0x53, "Samsung" },
+	{ 0x56, "Marvell" },	{ 0x61, "Apple" },	{ 0x69, "Intel" },
+	{ 0x6d, "Microsoft" },	{ 0x70, "Phytium" },	{ 0xc0, "Ampere" },
+}, arm_parts[] = {
+	/* Parts of the ARM implementer (0x41) */
+	{ 0xd03, "Cortex-A53" },	{ 0xd04, "Cortex-A35" },
+	{ 0xd05, "Cortex-A55" },	{ 0xd06, "Cortex-A65" },
+	{ 0xd07, "Cortex-A57" },	{ 0xd08, "Cortex-A72" },
+	{ 0xd09, "Cortex-A73" },	{ 0xd0a, "Cortex-A75" },
+	{ 0xd0b, "Cortex-A76" },	{ 0xd0c, "Neoverse-N1" },
+	{ 0xd0d, "Cortex-A77" },	{ 0xd40, "Neoverse-V1" },
+	{ 0xd41, "Cortex-A78" },	{ 0xd44, "Cortex-X1" },
+	{ 0xd46, "Cortex-A510" },	{ 0xd47, "Cortex-A710" },
+	{ 0xd48, "Cortex-X2" },		{ 0xd49, "Neoverse-N2" },
+	{ 0xd4a, "Neoverse-E1" },	{ 0xd4d, "Cortex-A715" },
+	{ 0xd4e, "Cortex-X3" },		{ 0xd4f, "Neoverse-V2" },
+	{ 0xd80, "Cortex-A520" },	{ 0xd81, "Cortex-A720" },
+	{ 0xd82, "Cortex-X4" },		{ 0xd84, "Neoverse-V3" },
+	{ 0xd85, "Cortex-X925" },	{ 0xd87, "Cortex-A725" },
+	{ 0xd8e, "Neoverse-N3" },
+};
+
+static const char *arm_lookup(unsigned long id, int implementer)
+{
+	size_t i, entries = implementer ?
+		sizeof(arm_implementers) / sizeof(arm_implementers[0]) :
+		sizeof(arm_parts) / sizeof(arm_parts[0]);
+	const char *name = NULL;
+
+	for (i = 0; i < entries; i++) {
+		if (implementer && arm_implementers[i].id == id) {
+			name = arm_implementers[i].name;
+			break;
+		} else if (!implementer && arm_parts[i].id == id) {
+			name = arm_parts[i].name;
+			break;
+		}
+	}
+
+	return name;
+}
+
+/* What has to be read on the CPU itself - see jent_ident_sysfs() below. */
+static void jent_ident_local(struct jent_cpu_info *info)
+{
+	jent_timer_arm64(info);
+}
+
+/*
+ * AArch64 identification from MIDR_EL1, which sysfs exposes per CPU: the
+ * implementer in bits[31:24] and the part number in bits[15:4] (Arm ARM
+ * (DDI 0487)). The part number is what tells big from LITTLE.
+ */
+static void jent_ident_sysfs(struct jent_cpu_info *info)
+{
+	unsigned long midr, impl, part, variant, revision, capacity;
+	const char *impl_name, *part_name;
+	char part_buf[16];
+
+	if (read_cpu_val(info->cpu, "regs/identification/midr_el1", &midr))
+		return;
+
+	impl     = (midr >> 24) & 0xff;
+	part     = (midr >>  4) & 0xfff;
+	variant  = (midr >> 20) & 0xf;
+	revision =  midr        & 0xf;
+
+	impl_name = arm_lookup(impl, 1);
+	/* The part number space is implementer-specific. */
+	part_name = (impl == 0x41) ? arm_lookup(part, 0) : NULL;
+	if (!part_name) {
+		snprintf(part_buf, sizeof(part_buf), "part 0x%03lx", part);
+		part_name = part_buf;
+	}
+
+	if (impl_name)
+		snprintf(info->ident, sizeof(info->ident), "%s %s r%lup%lu",
+			 impl_name, part_name, variant, revision);
+	else
+		snprintf(info->ident, sizeof(info->ident),
+			 "implementer 0x%02lx %s r%lup%lu", impl, part_name,
+			 variant, revision);
+
+	/*
+	 * ARM reports no core type; what stands in for it is the scheduler's
+	 * capacity, normalized to 1024 for the most capable core. It separates
+	 * big from LITTLE - on a uniform system every core reports 1024 and the
+	 * value says only that they are equivalent.
+	 */
+	if (!read_cpu_val(info->cpu, "cpu_capacity", &capacity))
+		snprintf(info->type, sizeof(info->type), "cap %lu", capacity);
+}
+
+#elif defined(JENT_CPUINFO_X86)
+
+/* CPUID answers for the core executing it, so this has to run on that core. */
+static void jent_ident_local(struct jent_cpu_info *info)
+{
+	jent_ident_x86(info);
+	jent_freq_x86(info);
+}
+
+static void jent_ident_sysfs(struct jent_cpu_info *info)
+{
+	unsigned long perf;
+
+	/*
+	 * AMD reports no core type - its dense cores are the same
+	 * micro-architecture, and CPUID has no hybrid leaf. Under amd-pstate
+	 * the firmware's highest performance level ranks the cores instead.
+	 * Read from sysfs, so it covers the CPUs this tool cannot visit too.
+	 */
+	if (!info->type[0] &&
+	    !read_cpu_val(info->cpu, "cpufreq/amd_pstate_highest_perf", &perf))
+		snprintf(info->type, sizeof(info->type), "perf %lu", perf);
+}
+
+#else /* neither x86 nor AArch64 */
+
+/* Nothing is read from the CPU itself; /proc/cpuinfo names it below. */
+static void jent_ident_local(struct jent_cpu_info *info)
+{
+	(void)info;
+}
+
+static void jent_ident_sysfs(struct jent_cpu_info *info)
+{
+	(void)info;
+}
+
+#endif /* JENT_CPUINFO_ARM64 */
+
+/* The CPU the kernel numbers @cpu, or NULL if the listing has no such entry. */
+static struct jent_cpu_info *jent_cpu_by_id(struct jent_cpu_list *list,
+					    long cpu)
+{
+	long i;
+
+	if (cpu < 0)
+		return NULL;
+
+	for (i = 0; i < list->entries; i++) {
+		struct jent_cpu_info *info = &list->cpu[i];
+
+		if (info->cpu_valid && info->cpu == (unsigned long)cpu)
+			return info;
+	}
+
+	return NULL;
+}
+
+#ifdef JENT_CPUINFO_X86
+
+/* Is @name one of the space separated words of @flags? */
+static int has_flag(const char *flags, const char *name)
+{
+	size_t len = strlen(name);
+	const char *p = flags;
+
+	while ((p = strstr(p, name))) {
+		if ((p == flags || p[-1] == ' ') &&
+		    (p[len] == '\0' || p[len] == ' '))
+			return 1;
+		p += len;
+	}
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_X86 */
+
+/*
+ * What the kernel publishes per CPU in /proc/cpuinfo: names for the CPUs still
+ * unnamed, and on x86 its own view of the timestamp counter.
+ *
+ * The names cover the CPUs the tool could not visit, and are the only
+ * identification where there is neither CPUID nor a MIDR - the key differs per
+ * architecture (RISC-V "uarch", POWER "cpu", s390 "machine"). On x86 the vendor
+ * is prepended so that a name from here and one from CPUID match.
+ *
+ * The flags line says more about the counter than CPUID does: Linux sets
+ * constant_tsc and nonstop_tsc from model checks as well, and tsc_known_freq
+ * states that the rate was enumerated rather than calibrated.
+ *
+ * The file holds a block per CPU and is walked once for both - reading it per
+ * CPU would be quadratic on exactly the machines where that hurts.
+ */
+static void jent_cpuinfo_linux(struct jent_cpu_list *list)
+{
+	static const char *keys[] = { "model name", "uarch", "cpu model",
+				      "cpu", "machine" };
+	FILE *f = fopen("/proc/cpuinfo", "r");
+	/* Sized for the flags line, which is by far the longest one here. */
+	char line[4096], vendor[64] = "";
+	long cur = -1;
+
+	if (!f)
+		return;
+
+	while (fgets(line, sizeof(line), f)) {
+		struct jent_cpu_info *info;
+		char *val = strchr(line, ':');
+		size_t k, keylen;
+
+		if (!val)
+			continue;
+		*val++ = '\0';
+		while (*val == ' ' || *val == '\t')
+			val++;
+		val[strcspn(val, "\n")] = '\0';
+
+		/* Strip the padding the file uses between key and colon. */
+		keylen = strlen(line);
+		while (keylen && (line[keylen - 1] == ' ' ||
+				  line[keylen - 1] == '\t'))
+			line[--keylen] = '\0';
+
+		/* Opens the block of a CPU; everything below belongs to it. */
+		if (!strcmp(line, "processor")) {
+			cur = strtol(val, NULL, 10);
+			vendor[0] = '\0';
+			continue;
+		}
+
+		info = jent_cpu_by_id(list, cur);
+		if (!info)
+			continue;
+
+		/* Precedes the model name in the block. */
+		if (!strcmp(line, "vendor_id")) {
+			snprintf(vendor, sizeof(vendor), "%s", val);
+			continue;
+		}
+
+#ifdef JENT_CPUINFO_X86
+		if (!strcmp(line, "flags")) {
+			info->tsc_invariant = has_flag(val, "constant_tsc");
+			info->tsc_nonstop = has_flag(val, "nonstop_tsc");
+			info->tsc_known_freq = has_flag(val, "tsc_known_freq");
+			continue;
+		}
+#endif
+
+		/* A CPU named on the core itself keeps that name. */
+		if (info->ident[0])
+			continue;
+
+		for (k = 0; k < sizeof(keys) / sizeof(keys[0]); k++) {
+			if (!strcmp(line, keys[k])) {
+				jent_set_ident(info, vendor, val);
+				break;
+			}
+		}
+	}
+
+	fclose(f);
+}
+
+/*
+ * Move the calling thread to @cpu: on a hybrid CPU the identification is only
+ * meaningful when read on the core in question.
+ */
+static int pin_to_cpu(unsigned long cpu)
+{
+	cpu_set_t set;
+
+	if (cpu >= (unsigned long)CPU_SETSIZE)
+		return -EINVAL;
+
+	CPU_ZERO(&set);
+	CPU_SET((size_t)cpu, &set);
+	if (sched_setaffinity(0, sizeof(set), &set))
+		return -errno;
+
+	/*
+	 * sched_setaffinity() migrates before it returns, but a CPU that went
+	 * offline meanwhile leaves the thread elsewhere - and the
+	 * identification would then describe the wrong core.
+	 */
+	if (sched_getcpu() != (int)cpu)
+		return -EAGAIN;
+
+	return 0;
+}
+
+static int jent_get_cpus(struct jent_cpu_list *list)
+{
+	static char unreachable_note[512];
+	unsigned long cpu_ids[JENT_MAX_CPUS];
+	char online[1024];
+	long ncpu, i, unreachable = 0;
+	cpu_set_t *previous;
+	size_t setsize;
+	int ret;
+
+	ret = read_file_str(JENT_SYSFS_CPU "/online", online, sizeof(online));
+	if (ret) {
+		fprintf(stderr, "Cannot read " JENT_SYSFS_CPU "/online: %s\n",
+			strerror(-ret));
+		return ret;
+	}
+
+	ncpu = parse_cpu_list(online, cpu_ids, JENT_MAX_CPUS);
+	if (ncpu < 0) {
+		fprintf(stderr, "Cannot parse the list of online CPUs \"%s\"\n",
+			online);
+		return (int)ncpu;
+	}
+
+	list->ncpu = ncpu;
+	list->pinning = 1;
+	list->backend = "linux";
+
+	/* Before cpu_ids is read below: only that many of them were stored. */
+	if (ncpu > JENT_MAX_CPUS) {
+		fprintf(stderr, "Only the first %d of %ld online CPUs are "
+			"reported\n", JENT_MAX_CPUS, ncpu);
+		ncpu = JENT_MAX_CPUS;
+	}
+
+	/*
+	 * The affinity of this thread, restored once every CPU has been
+	 * visited. Allocated for the highest CPU number, which on a large
+	 * machine exceeds the CPU_SETSIZE a plain cpu_set_t covers.
+	 */
+	{
+		unsigned int ncpu_set = (unsigned int)(cpu_ids[ncpu - 1] + 1);
+
+		previous = CPU_ALLOC(ncpu_set);
+		setsize = previous ? CPU_ALLOC_SIZE(ncpu_set) : 0;
+		if (previous && sched_getaffinity(0, setsize, previous)) {
+			CPU_FREE(previous);
+			previous = NULL;
+			setsize = 0;
+		}
+	}
+
+	for (i = 0; i < ncpu; i++) {
+		struct jent_cpu_info *info = &list->cpu[i];
+
+		jent_cpu_info_init(info);
+		info->cpu = cpu_ids[i];
+		info->cpu_valid = 1;
+
+		if (read_cpu_signed(info->cpu, "topology/physical_package_id",
+				    &info->pkg))
+			info->pkg = -1;
+		if (read_cpu_signed(info->cpu, "topology/core_id", &info->core))
+			info->core = -1;
+		if (read_cpu_val(info->cpu, "cpufreq/cpuinfo_max_freq",
+				 &info->max_khz))
+			info->max_khz = 0;
+		/* Exported by the intel-pstate driver, per CPU. */
+		if (read_cpu_val(info->cpu, "cpufreq/base_frequency",
+				 &info->base_khz))
+			info->base_khz = 0;
+
+		/*
+		 * AMD exports no base_frequency and CPUID carries none, which
+		 * leaves the CPPC nominal frequency - the same quantity by
+		 * another name. Second, not first: it is package-wide, and on a
+		 * hybrid Intel part it reports the P-core value for the E-cores
+		 * as well.
+		 */
+		if (!info->base_khz) {
+			unsigned long nominal;
+
+			if (!read_cpu_val(info->cpu, "acpi_cppc/nominal_freq",
+					  &nominal) && nominal)
+				info->base_khz = nominal * 1000;
+		}
+
+		/* Likewise where amd-pstate is the driver but cpufreq is not. */
+		if (!info->max_khz &&
+		    read_cpu_val(info->cpu, "cpufreq/amd_pstate_max_freq",
+				 &info->max_khz))
+			info->max_khz = 0;
+
+		jent_caches_linux(info);
+		jent_ident_sysfs(info);
+
+		/*
+		 * The rest has to be read on the CPU it describes. Tried for
+		 * every CPU, not just those of the current affinity mask: a
+		 * mask narrowed with taskset can be widened again. A cpuset
+		 * cgroup cannot, and those CPUs keep what sysfs reported alone.
+		 */
+		if (pin_to_cpu(info->cpu)) {
+			unreachable++;
+			continue;
+		}
+
+		jent_ident_local(info);
+	}
+
+	if (previous) {
+		sched_setaffinity(0, setsize, previous);
+		CPU_FREE(previous);
+	}
+
+	list->entries = ncpu;
+
+	/* Names the CPUs the loop above could not visit, among others. */
+	jent_cpuinfo_linux(list);
+
+	if (unreachable) {
+		/* One note, not a line per CPU - that would bury the listing. */
+		snprintf(unreachable_note, sizeof(unreachable_note),
+			 "%ld of the %ld CPUs could not be visited: this "
+			 "process is confined to a cpuset\nthat does not "
+			 "include them - a container or a cgroup - so what only "
+			 "the CPU\nitself reports is missing for them, its "
+			 "core type on Intel among it. Run outside\nthat "
+			 "confinement to describe every CPU.",
+			 unreachable, ncpu);
+		list->note = unreachable_note;
+	}
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_LINUX */
+
+/***************************************************************************
+ * macOS backend
+ *
+ * macOS offers no thread-to-CPU pinning and no per-CPU description, but it
+ * groups the cores into performance levels - hw.perflevel0 the P cores,
+ * hw.perflevel1 the E cores - and reports the caches per level, which is
+ * exactly the distinction this tool exists for. Systems with a single core
+ * type report no levels and are described by the flat hw.* names.
+ ***************************************************************************/
+
+#ifdef JENT_CPUINFO_MACOS
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+static int sysctl_str(const char *name, char *buf, size_t buflen)
+{
+	size_t len = buflen;
+
+	if (!buflen)
+		return -EINVAL;
+
+	/*
+	 * Terminated before the call as well: a name the kernel does not know
+	 * leaves the buffer untouched, and the callers read it regardless of
+	 * what this returns.
+	 */
+	buf[0] = '\0';
+	if (sysctlbyname(name, buf, &len, NULL, 0))
+		return -errno;
+	buf[buflen - 1] = '\0';
+
+	return 0;
+}
+
+/* Numeric sysctl of either width - macOS reports both, so ask the node. */
+static int sysctl_num(const char *name, unsigned long long *val)
+{
+	size_t len = 0;
+
+	if (sysctlbyname(name, NULL, &len, NULL, 0))
+		return -errno;
+
+	if (len == sizeof(uint32_t)) {
+		uint32_t v = 0;
+
+		len = sizeof(v);
+		if (sysctlbyname(name, &v, &len, NULL, 0))
+			return -errno;
+		*val = v;
+		return 0;
+	}
+	if (len == sizeof(uint64_t)) {
+		uint64_t v = 0;
+
+		len = sizeof(v);
+		if (sysctlbyname(name, &v, &len, NULL, 0))
+			return -errno;
+		*val = v;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+/* Read hw.perflevel<level>.<attr>, or hw.<attr> when there are no levels. */
+static int sysctl_level_num(int level, const char *attr,
+			    unsigned long long *val)
+{
+	char name[64];
+
+	if (level < 0)
+		snprintf(name, sizeof(name), "hw.%s", attr);
+	else
+		snprintf(name, sizeof(name), "hw.perflevel%d.%s", level, attr);
+
+	return sysctl_num(name, val);
+}
+
+/*
+ * The counter the Jitter RNG times with: the generic timer on Apple Silicon,
+ * the TSC on the Intel Macs. The kernel publishes the TSC rate but not how it
+ * arrived at it, so the counter properties stay unknown rather than assumed.
+ */
+static void jent_timer_macos(struct jent_cpu_info *info)
+{
+#ifdef JENT_CPUINFO_ARM64
+	jent_timer_arm64(info);
+#elif defined(JENT_CPUINFO_X86)
+	unsigned long long freq = 0;
+
+	if (!sysctl_num("machdep.tsc.frequency", &freq) && freq)
+		info->tsc_khz = (unsigned long)(freq / 1000);
+#else
+	(void)info;
+#endif
+}
+
+static int jent_get_cpus(struct jent_cpu_list *list)
+{
+	unsigned long long nlevels = 0, freq = 0, ncpu = 0, packages = 0;
+	/* Sized so that vendor, blank and model always fit into ident. */
+	char ident[JENT_IDENT_LEN - 64] = "", vendor[63] = "";
+	int level, levels;
+	long n = 0;
+
+	if (sysctl_num("hw.logicalcpu", &ncpu) || !ncpu)
+		return -ENOENT;
+	list->ncpu = (long)ncpu;
+
+	/*
+	 * The affinity tags macOS offers only hint that threads belong
+	 * together, and Apple Silicon does not implement them at all.
+	 */
+	list->pinning = 0;
+	list->backend = "macos";
+	list->note =
+		"macOS describes the cores per performance level, not per "
+		"CPU: the CPU\ncolumn is the position in this listing, "
+		"fastest level first, and Core\ncounts within a level - equal "
+		"Core numbers of different Types are\ndifferent cores.";
+	/*
+	 * The E-cores are still reachable: macOS schedules the lowest
+	 * quality-of-service class on them alone, which is what --e-cores asks
+	 * for. The P-cores are where a measurement runs by default anyway.
+	 */
+	list->select =
+		"  jitterentropy-hashtime <rounds> <repeats> <file> --e-cores\n"
+		"  No thread-to-CPU pinning here: --e-cores selects the "
+		"efficiency cores and\n  --p-cores asks for the performance "
+		"ones, which a recording uses anyway\n  unless the process was "
+		"put in the background.";
+
+	/* Present on Intel Macs only; Apple Silicon reports the model alone. */
+	sysctl_str("machdep.cpu.vendor", vendor, sizeof(vendor));
+	sysctl_str("machdep.cpu.brand_string", ident, sizeof(ident));
+	if (sysctl_num("hw.cpufrequency_max", &freq))
+		freq = 0;
+
+	/* Which CPU sits in which package is not reported, so a single one
+	 * is all that can be known - every Mac but the two-socket Pros. */
+	if (sysctl_num("hw.packages", &packages) || packages != 1)
+		packages = 0;
+
+	if (sysctl_num("hw.nperflevels", &nlevels) || nlevels < 2)
+		nlevels = 0;
+	levels = nlevels ? (int)nlevels : 1;
+
+	for (level = 0; level < levels && n < JENT_MAX_CPUS; level++) {
+		unsigned long long logical = 0, physical = 0, l1d = 0, l1i = 0;
+		unsigned long long l2 = 0, l3 = 0, per_l2 = 0, i;
+		/* Negative selects the flat hw.* names for a uniform system. */
+		int sel = nlevels ? level : -1;
+		char name[64], type[64] = "", core_type[JENT_TYPE_LEN] = "";
+
+		if (sysctl_level_num(sel, "logicalcpu", &logical) || !logical)
+			continue;
+		/*
+		 * More cores than threads is not a machine that exists, and
+		 * the ratio below is a divisor: take the level as one thread
+		 * per core rather than divide by zero.
+		 */
+		if (sysctl_level_num(sel, "physicalcpu", &physical) ||
+		    !physical || physical > logical)
+			physical = logical;
+
+		sysctl_level_num(sel, "l1dcachesize", &l1d);
+		sysctl_level_num(sel, "l1icachesize", &l1i);
+		sysctl_level_num(sel, "l2cachesize", &l2);
+		if (sysctl_level_num(sel, "cpusperl2", &per_l2))
+			per_l2 = 0;
+		/* No L3 per level; the flat node covers the Macs with one. */
+		if (sysctl_num("hw.l3cachesize", &l3))
+			l3 = 0;
+
+		/*
+		 * One performance level means one core type, and the type
+		 * stays empty as it does in the other backends.
+		 */
+		if (nlevels) {
+			snprintf(name, sizeof(name), "hw.perflevel%d.name",
+				 level);
+			if (sysctl_str(name, type, sizeof(type)))
+				type[0] = '\0';
+
+			/*
+			 * The level names are "Performance" and "Efficiency";
+			 * fall back to the order, documented as fastest first.
+			 */
+			if (type[0] == 'P' || (!type[0] && level == 0))
+				snprintf(core_type, sizeof(core_type),
+					 "P-core");
+			else if (type[0] == 'E' || !type[0])
+				snprintf(core_type, sizeof(core_type),
+					 "E-core");
+			else
+				snprintf(core_type, sizeof(core_type), "%s",
+					 type);
+		}
+
+		for (i = 0; i < logical && n < JENT_MAX_CPUS; i++, n++) {
+			struct jent_cpu_info *info = &list->cpu[n];
+
+			jent_cpu_info_init(info);
+			info->cpu = (unsigned long)n;
+			info->cpu_valid = 1;
+			if (packages)
+				info->pkg = 0;
+			/*
+			 * SMT siblings are consecutive on the Intel Macs. The
+			 * count restarts per performance level, as macOS has
+			 * no numbering spanning them - so equal numbers in
+			 * different levels are different cores, as the note
+			 * below says.
+			 */
+			info->core = (long)(i / (logical / physical));
+			info->max_khz = (unsigned long)(freq / 1000);
+			jent_timer_macos(info);
+
+			info->l1d.size = (unsigned long)l1d;
+			info->l1d.shared = 1;
+			info->l1i.size = (unsigned long)l1i;
+			info->l1i.shared = 1;
+			info->l2.size = (unsigned long)l2;
+			info->l2.shared = (unsigned long)per_l2;
+			info->l3.size = (unsigned long)l3;
+			info->l3.shared = (unsigned long)ncpu;
+
+			jent_set_ident(info, vendor, ident);
+
+			snprintf(info->type, sizeof(info->type), "%s",
+				 core_type);
+		}
+	}
+
+	if (!n)
+		return -ENOENT;
+
+	list->entries = n;
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_MACOS */
+
+/***************************************************************************
+ * Windows backend
+ *
+ * GetLogicalProcessorInformationEx() describes the caches, cores and packages
+ * with the group affinity mask of the CPUs each covers, plus the efficiency
+ * class Windows tells a P-core from an E-core by. The model is not part of it
+ * and comes from the registry, which covers the ARM64 machines as well.
+ ***************************************************************************/
+
+#ifdef JENT_CPUINFO_WINDOWS
+
+#include <windows.h>
+
+/* Windows has never defined more than this many processor groups. */
+#define JENT_MAX_GROUPS		64
+
+/* Number of CPUs in a group affinity mask. */
+static unsigned long affinity_count(KAFFINITY mask)
+{
+	unsigned long count = 0;
+
+	while (mask) {
+		count += mask & 1;
+		mask >>= 1;
+	}
+
+	return count;
+}
+
+/* One processor group, and where its CPUs start in the flat numbering. */
+struct jent_group {
+	unsigned long base;	/* flat number of the first active CPU */
+	KAFFINITY active;	/* which bits of the group hold an active CPU */
+};
+
+/*
+ * Flat number of the CPU at bit @bit of group @group, or -1 where that bit
+ * holds no active CPU.
+ *
+ * The flat numbering is the one jitterentropy-hashtime --cpu takes, so it has
+ * to be the one jent_thread_pin_to_cpu() resolves: the CPUs of the preceding
+ * groups, then the n-th *set* bit of this group's ActiveProcessorMask. The bit
+ * position itself is not that number - it is only equal to it while the active
+ * CPUs of a group occupy its lowest bits without a gap, which stops holding as
+ * soon as one is parked or disabled. Numbering by bit position there would
+ * name a different CPU than --cpu pins to, leaving one row of the listing
+ * unwritten and another written twice.
+ */
+static long flat_cpu(const struct jent_group *groups, WORD ngroups,
+		     WORD group, unsigned long bit)
+{
+	KAFFINITY below;
+
+	if (group >= ngroups || bit >= sizeof(KAFFINITY) * 8)
+		return -1;
+	if (!((groups[group].active >> bit) & (KAFFINITY)1))
+		return -1;
+
+	/* The active CPUs of the group sitting below @bit. */
+	below = groups[group].active & (((KAFFINITY)1 << bit) - 1);
+
+	return (long)(groups[group].base + affinity_count(below));
+}
+
+/* Apply @fn to every CPU covered by @mask. */
+static void for_each_cpu(struct jent_cpu_list *list,
+			 const struct jent_group *groups, WORD ngroups,
+			 const GROUP_AFFINITY *mask,
+			 void (*fn)(struct jent_cpu_info *, void *), void *ctx)
+{
+	unsigned long bit;
+
+	for (bit = 0; bit < sizeof(KAFFINITY) * 8; bit++) {
+		long cpu;
+
+		if (!((mask->Mask >> bit) & 1))
+			continue;
+
+		cpu = flat_cpu(groups, ngroups, mask->Group, bit);
+		if (cpu < 0 || cpu >= list->entries)
+			continue;
+
+		fn(&list->cpu[cpu], ctx);
+	}
+}
+
+/*
+ * Describe the processor groups in @out, up to @max of them, and return the
+ * number of CPUs across those described or a negative errno.
+ *
+ * The groups are enumerated rather than counted with
+ * GetActiveProcessorGroupCount() / GetActiveProcessorCount(): those report how
+ * many CPUs are active, and only ActiveProcessorMask says which bit positions
+ * they are - what the flat numbering above is built from. This is the source
+ * jent_thread_pin_to_cpu() reads as well.
+ */
+static long jent_groups_windows(struct jent_group *out, WORD max,
+				WORD *ngroups)
+{
+	SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *rec;
+	const GROUP_RELATIONSHIP *rel;
+	/* Bytes that must be readable before Relationship and Size are read. */
+	const size_t hdr = offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+				    Group);
+	size_t need;
+	DWORD len = 0;
+	BYTE *buf;
+	long ncpu = 0;
+	WORD group;
+
+	if (GetLogicalProcessorInformationEx(RelationGroup, NULL, &len) ||
+	    GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+		return -EFAULT;
+
+	buf = (BYTE *)malloc(len);
+	if (!buf)
+		return -ENOMEM;
+
+	if (!GetLogicalProcessorInformationEx(
+			RelationGroup,
+			(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)buf, &len)) {
+		free(buf);
+		return -EFAULT;
+	}
+
+	/*
+	 * RelationGroup is reported as a single record covering every group,
+	 * with the per-group entries as a trailing array. Validate the header,
+	 * then the array the announced ActiveGroupCount implies, before either
+	 * is dereferenced.
+	 */
+	rec = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)buf;
+	need = hdr + offsetof(GROUP_RELATIONSHIP, GroupInfo);
+	if ((size_t)len < hdr || (size_t)len < rec->Size ||
+	    rec->Relationship != RelationGroup || rec->Size < need) {
+		free(buf);
+		return -EFAULT;
+	}
+
+	rel = &rec->Group;
+	need += (size_t)rel->ActiveGroupCount * sizeof(PROCESSOR_GROUP_INFO);
+	if (rec->Size < need) {
+		free(buf);
+		return -EFAULT;
+	}
+
+	*ngroups = rel->ActiveGroupCount < max ? rel->ActiveGroupCount : max;
+
+	/* Groups number from zero, so one starts at the count before it. */
+	for (group = 0; group < *ngroups; group++) {
+		const PROCESSOR_GROUP_INFO *gi = &rel->GroupInfo[group];
+
+		out[group].base = (unsigned long)ncpu;
+		out[group].active = gi->ActiveProcessorMask;
+		ncpu += (long)gi->ActiveProcessorCount;
+	}
+
+	free(buf);
+
+	return ncpu;
+}
+
+struct cache_ctx {
+	struct jent_cache_info cache;
+	BYTE level;
+	int instruction;
+};
+
+static void set_cache(struct jent_cpu_info *info, void *arg)
+{
+	const struct cache_ctx *ctx = (const struct cache_ctx *)arg;
+	struct jent_cache_info *cache;
+
+	if (ctx->level == 1 && ctx->instruction)
+		cache = &info->l1i;
+	else if (ctx->level == 1)
+		cache = &info->l1d;
+	else if (ctx->level == 2 && !ctx->instruction)
+		cache = &info->l2;
+	else if (ctx->level == 3 && !ctx->instruction)
+		cache = &info->l3;
+	else
+		return;
+
+	*cache = ctx->cache;
+}
+
+struct core_ctx {
+	long index;
+	BYTE efficiency_class;
+};
+
+static void set_core(struct jent_cpu_info *info, void *arg)
+{
+	const struct core_ctx *ctx = (const struct core_ctx *)arg;
+
+	info->core = ctx->index;
+	/*
+	 * Held here until the highest class in the system is known, one above
+	 * the class itself: zero then marks a CPU no core record covered, which
+	 * class 0 is otherwise indistinguishable from.
+	 */
+	info->max_khz = (unsigned long)ctx->efficiency_class + 1;
+}
+
+static void set_package(struct jent_cpu_info *info, void *arg)
+{
+	info->pkg = *(const long *)arg;
+}
+
+/* Model, vendor and nominal frequency as published by the kernel per CPU. */
+static void jent_ident_windows(struct jent_cpu_info *info)
+{
+	/* Sized so that vendor, blank and model always fit into ident. */
+	char key[128], name[JENT_IDENT_LEN - 64] = "", vendor[63] = "";
+	DWORD len, mhz = 0;
+
+	/*
+	 * The subkeys carry the numbering the system assigned the processors,
+	 * which is the flat numbering used here as long as all of them are
+	 * active. Where one is not, the model is read from a neighbouring CPU -
+	 * a different string only on a machine mixing models across packages.
+	 */
+	snprintf(key, sizeof(key),
+		 "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\%lu",
+		 info->cpu);
+
+	len = sizeof(vendor);
+	if (RegGetValueA(HKEY_LOCAL_MACHINE, key, "VendorIdentifier",
+			 RRF_RT_REG_SZ, NULL, vendor, &len) != ERROR_SUCCESS)
+		vendor[0] = '\0';
+
+	len = sizeof(name);
+	if (RegGetValueA(HKEY_LOCAL_MACHINE, key, "ProcessorNameString",
+			 RRF_RT_REG_SZ, NULL, name, &len) != ERROR_SUCCESS)
+		name[0] = '\0';
+
+	jent_set_ident(info, vendor, name);
+
+	/*
+	 * "~MHz" is the base speed, not a maximum, and Windows publishes no
+	 * boost figure anywhere - the MaxMhz of CallNtPowerInformation() is
+	 * this same value. The key is per CPU, so as on Linux it wins over the
+	 * package-wide CPUID leaf 0x16, which only fills in what is left.
+	 */
+	len = sizeof(mhz);
+	if (RegGetValueA(HKEY_LOCAL_MACHINE, key, "~MHz", RRF_RT_REG_DWORD,
+			 NULL, &mhz, &len) == ERROR_SUCCESS)
+		info->base_khz = mhz * 1000;
+}
+
+/*
+ * Does @p hold the member its Relationship names, in the space it announces?
+ * The records are variable-length and the trailing GroupMask array is as long
+ * as GroupCount says, so the fixed part and that array both have to fit into
+ * Size before either is read. @hdr is what the walk has already checked.
+ */
+static int record_fits(const SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *p,
+		       size_t hdr)
+{
+	size_t need;
+
+	if (p->Relationship == RelationCache)
+		return p->Size >= hdr + sizeof(CACHE_RELATIONSHIP);
+
+	if (p->Relationship != RelationProcessorCore &&
+	    p->Relationship != RelationProcessorPackage)
+		return 1;	/* not read below */
+
+	/* GroupCount sits before the array, so the fixed part comes first. */
+	need = hdr + offsetof(PROCESSOR_RELATIONSHIP, GroupMask);
+	if (p->Size < need)
+		return 0;
+
+	return (size_t)(p->Size - need) >=
+	       (size_t)p->Processor.GroupCount * sizeof(GROUP_AFFINITY);
+}
+
+static int jent_get_cpus(struct jent_cpu_list *list)
+{
+	SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *buf;
+	struct jent_group groups[JENT_MAX_GROUPS];
+	/* Efficiency class plus one, zero where no core record was seen. */
+	unsigned int classes[JENT_MAX_CPUS];
+	unsigned int max_class = 0;
+	/* Bytes that must be readable before Relationship and Size are read. */
+	const size_t hdr = offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+				    Processor);
+	WORD ngroups = 0;
+	DWORD len = 0;
+	BYTE *pos, *end;
+	long ncpu, cores = 0, packages = 0, i;
+
+	ncpu = jent_groups_windows(groups, JENT_MAX_GROUPS, &ngroups);
+	if (ncpu < 0)
+		return (int)ncpu;
+	if (!ngroups || !ncpu)
+		return -ENOENT;
+
+	list->ncpu = ncpu;
+	list->pinning = 1;
+	list->backend = "windows";
+	if (ncpu > JENT_MAX_CPUS) {
+		fprintf(stderr, "Only the first %d of %ld CPUs are reported\n",
+			JENT_MAX_CPUS, ncpu);
+		ncpu = JENT_MAX_CPUS;
+	}
+	list->entries = ncpu;
+
+	for (i = 0; i < ncpu; i++) {
+		jent_cpu_info_init(&list->cpu[i]);
+		list->cpu[i].cpu = (unsigned long)i;
+		list->cpu[i].cpu_valid = 1;
+	}
+
+	if (GetLogicalProcessorInformationEx(RelationAll, NULL, &len) ||
+	    GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+		return -EFAULT;
+
+	buf = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)malloc(len);
+	if (!buf)
+		return -ENOMEM;
+
+	if (!GetLogicalProcessorInformationEx(RelationAll, buf, &len)) {
+		free(buf);
+		return -EFAULT;
+	}
+
+	pos = (BYTE *)buf;
+	end = pos + len;
+	while ((size_t)(end - pos) >= hdr) {
+		SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *p =
+			(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)pos;
+		WORD n;
+
+		/*
+		 * A record shorter than the header would make the walk spin,
+		 * one longer than what is left would be read past the buffer,
+		 * and one too small for what it claims to describe would be
+		 * read past its own end. None of the data after such a record
+		 * can be located, so the walk stops rather than skipping it.
+		 */
+		if (p->Size < hdr || (size_t)(end - pos) < p->Size ||
+		    !record_fits(p, hdr))
+			break;
+		pos += p->Size;
+
+		/*
+		 * Not a switch: -Wswitch-enum would ask for every value of the
+		 * enumeration although only three matter. Trace caches hold no
+		 * data and are skipped as well.
+		 */
+		if (p->Relationship == RelationCache &&
+		    p->Cache.Type != CacheTrace) {
+			struct cache_ctx ctx;
+
+			ctx.level = p->Cache.Level;
+			ctx.instruction = (p->Cache.Type == CacheInstruction);
+			ctx.cache.size = (unsigned long)p->Cache.CacheSize;
+			ctx.cache.shared =
+				affinity_count(p->Cache.GroupMask.Mask);
+			for_each_cpu(list, groups, ngroups,
+				     &p->Cache.GroupMask, set_cache, &ctx);
+		} else if (p->Relationship == RelationProcessorCore) {
+			struct core_ctx ctx;
+
+			ctx.index = cores++;
+			ctx.efficiency_class = p->Processor.EfficiencyClass;
+			if (ctx.efficiency_class > max_class)
+				max_class = ctx.efficiency_class;
+			for (n = 0; n < p->Processor.GroupCount; n++)
+				for_each_cpu(list, groups, ngroups,
+					     &p->Processor.GroupMask[n],
+					     set_core, &ctx);
+		} else if (p->Relationship == RelationProcessorPackage) {
+			long pkg = packages++;
+
+			for (n = 0; n < p->Processor.GroupCount; n++)
+				for_each_cpu(list, groups, ngroups,
+					     &p->Processor.GroupMask[n],
+					     set_package, &pkg);
+		}
+	}
+
+	free(buf);
+
+	/*
+	 * The efficiency class is a ranking without a fixed scale, so it names
+	 * a core type only once the highest class is known: that one is the
+	 * P-cores, everything below it an E-core. There can be several such
+	 * classes, which jent_mark_lp_cores() separates afterwards.
+	 */
+	for (i = 0; i < ncpu; i++) {
+		classes[i] = (unsigned int)list->cpu[i].max_khz;
+		list->cpu[i].max_khz = 0;
+	}
+
+	for (i = 0; i < ncpu; i++) {
+		struct jent_cpu_info *info = &list->cpu[i];
+
+		/*
+		 * A CPU no core record covered - the CPU numbering and the
+		 * records disagreeing about which one exists, say - is left
+		 * without a type instead of taking the lower one by default.
+		 */
+		if (max_class && classes[i])
+			snprintf(info->type, sizeof(info->type), "%s",
+				 classes[i] - 1 == max_class ?
+					"P-core" : "E-core");
+
+		jent_ident_windows(info);
+	}
+
+#ifdef JENT_CPUINFO_X86
+	/*
+	 * The base frequency and the counter are only in CPUID, which answers
+	 * for the core executing it - so unlike everything above, this visits
+	 * each CPU. The first call reports the affinity restored afterwards.
+	 */
+	{
+		GROUP_AFFINITY previous;
+		int restore = 0;
+		WORD group;
+
+		for (group = 0; group < ngroups; group++) {
+			unsigned long bit;
+
+			for (bit = 0; bit < sizeof(KAFFINITY) * 8; bit++) {
+				GROUP_AFFINITY affinity, old;
+				PROCESSOR_NUMBER current;
+				long cpu = flat_cpu(groups, ngroups, group,
+						    bit);
+
+				if (cpu < 0 || cpu >= ncpu)
+					continue;
+
+				memset(&affinity, 0, sizeof(affinity));
+				affinity.Group = group;
+				affinity.Mask = (KAFFINITY)1 << bit;
+				if (!SetThreadGroupAffinity(GetCurrentThread(),
+							    &affinity, &old))
+					continue;
+				if (!restore) {
+					previous = old;
+					restore = 1;
+				}
+
+				/*
+				 * A parked or offline CPU leaves the thread
+				 * where it was, and CPUID would then describe
+				 * the wrong core.
+				 */
+				GetCurrentProcessorNumberEx(&current);
+				if (current.Group != group ||
+				    current.Number != (BYTE)bit)
+					continue;
+
+				jent_freq_x86(&list->cpu[cpu]);
+			}
+		}
+
+		if (restore)
+			SetThreadGroupAffinity(GetCurrentThread(), &previous,
+					       NULL);
+	}
+#endif /* JENT_CPUINFO_X86 */
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_WINDOWS */
+
+/***************************************************************************
+ * Generic backend for the BSDs and everything else
+ *
+ * None of these enumerates the caches of the individual CPUs, and OpenBSD has
+ * no thread affinity API at all. What is left is the CPU this tool runs on:
+ * CPUID for its caches and core type on x86, hw.model for its name on the BSDs.
+ *
+ * The numeric sysctl MIB is preferred over sysctlbyname(), which OpenBSD lacks.
+ * Solaris, Haiku and Cygwin have no sysctl at all - hence
+ * JENT_CPUINFO_HAVE_SYSCTL - and are left with the CPU count and CPUID.
+ ***************************************************************************/
+
+#ifdef JENT_CPUINFO_GENERIC
+
+#include <unistd.h>
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__)
+# include <sys/types.h>
+# include <sys/param.h>
+# include <sys/sysctl.h>
+# define JENT_CPUINFO_HAVE_SYSCTL
+/*
+ * Every BSD but OpenBSD has sysctlbyname(). The MIB is used where it covers
+ * the node, the name interface for those without a portable MIB constant.
+ */
+# ifndef __OpenBSD__
+#  define JENT_CPUINFO_HAVE_SYSCTLBYNAME
+# endif
+#endif
+
+/*
+ * FreeBSD is the one system here that can place a thread on a chosen CPU, so
+ * the one whose CPUs can be described individually. Same call the library
+ * pins its counting thread with (arch/jitterentropy-arch-thread.c).
+ */
+#ifdef __FreeBSD__
+# include <sys/cpuset.h>
+# define JENT_CPUINFO_BSD_AFFINITY
+
+static int pin_to_cpu(unsigned long cpu)
+{
+	cpuset_t set;
+
+	if (cpu >= (unsigned long)CPU_SETSIZE)
+		return -EINVAL;
+
+	CPU_ZERO(&set);
+	CPU_SET((int)cpu, &set);
+	if (cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(set),
+			       &set))
+		return -errno;
+
+	return 0;
+}
+#endif /* __FreeBSD__ */
+
+#ifdef JENT_CPUINFO_HAVE_SYSCTL
+
+static int sysctl_hw_str(int node, char *buf, size_t buflen)
+{
+	int mib[2] = { CTL_HW, node };
+	size_t len = buflen;
+
+	if (sysctl(mib, 2, buf, &len, NULL, 0))
+		return -errno;
+	buf[buflen - 1] = '\0';
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_HAVE_SYSCTL */
+
+/* The clock rate in kHz, or 0 where the system does not report one. */
+static unsigned long jent_clockrate(void)
+{
+#if defined(__OpenBSD__) && defined(HW_CPUSPEED)
+	int mib[2] = { CTL_HW, HW_CPUSPEED };
+	int speed = 0;
+	size_t len = sizeof(speed);
+
+	if (sysctl(mib, 2, &speed, &len, NULL, 0) || speed <= 0)
+		return 0;
+
+	return (unsigned long)speed * 1000;		/* MHz -> kHz */
+#elif defined(JENT_CPUINFO_HAVE_SYSCTLBYNAME)
+	/* hw.clockrate is FreeBSD and DragonFly, in MHz. */
+	int speed = 0;
+	size_t len = sizeof(speed);
+
+	if (!sysctlbyname("hw.clockrate", &speed, &len, NULL, 0) && speed > 0)
+		return (unsigned long)speed * 1000;
+
+	/* NetBSD states the counter rate instead, in Hz. */
+	{
+		uint64_t freq = 0;
+
+		len = sizeof(freq);
+		if (!sysctlbyname("machdep.tsc_freq", &freq, &len, NULL, 0) &&
+		    freq)
+			return (unsigned long)(freq / 1000);
+	}
+
+	return 0;
+#else
+	return 0;
+#endif
+}
+
+/* Everything that can be said about the CPU this thread is running on. */
+static void jent_describe_current(struct jent_cpu_info *info)
+{
+#ifdef JENT_CPUINFO_HAVE_SYSCTL
+	char model[JENT_IDENT_LEN] = "";
+
+	if (!sysctl_hw_str(HW_MODEL, model, sizeof(model)) && model[0])
+		jent_set_ident(info, NULL, model);
+#endif
+
+	info->base_khz = jent_clockrate();
+
+#ifdef JENT_CPUINFO_X86
+	/* Overrides hw.model with the vendor and brand string of this core. */
+	jent_ident_x86(info);
+	jent_caches_x86(info);
+	jent_freq_x86(info);
+#endif
+}
+
+static int jent_get_cpus(struct jent_cpu_list *list)
+{
+	long ncpu, n = 0;
+
+	ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+	list->ncpu = (ncpu > 0) ? ncpu : 1;
+	list->backend = "generic";
+
+	/* No affinity API on OpenBSD, so --cpu is unavailable there. */
+#ifdef __OpenBSD__
+	list->pinning = 0;
+#else
+	list->pinning = 1;
+#endif
+
+#ifdef JENT_CPUINFO_BSD_AFFINITY
+	for (n = 0; n < list->ncpu && n < JENT_MAX_CPUS; n++) {
+		struct jent_cpu_info *info = &list->cpu[n];
+
+		/* Whatever was reached is kept; the note below says so. */
+		if (pin_to_cpu((unsigned long)n))
+			break;
+
+		jent_cpu_info_init(info);
+		info->cpu = (unsigned long)n;
+		info->cpu_valid = 1;
+		jent_describe_current(info);
+	}
+#endif
+
+	if (!n) {
+		struct jent_cpu_info *info = &list->cpu[0];
+
+		jent_cpu_info_init(info);
+		/* Without affinity, which CPU this is cannot be known. */
+		info->cpu_valid = 0;
+		jent_describe_current(info);
+		n = 1;
+
+		list->note =
+			"This system describes no CPU but the one this tool "
+			"runs on. On a\nhybrid CPU, run it repeatedly to see "
+			"the other core types.";
+	} else if (n < list->ncpu) {
+		list->note =
+			"Only the CPUs this tool could place itself on are "
+			"described.";
+	}
+
+	list->entries = n;
+
+	return 0;
+}
+
+#endif /* JENT_CPUINFO_GENERIC */
+
+/***************************************************************************
+ * Unsupported systems
+ ***************************************************************************/
+
+#if !defined(JENT_CPUINFO_LINUX) && !defined(JENT_CPUINFO_MACOS) && \
+    !defined(JENT_CPUINFO_WINDOWS) && !defined(JENT_CPUINFO_GENERIC)
+
+static int jent_get_cpus(struct jent_cpu_list *list)
+{
+	list->backend = "none";
+	return -ENOSYS;
+}
+
+#endif
+
+/*
+ * Separate the low-power E-cores from the regular ones. Neither CPUID nor the
+ * Windows efficiency class distinguishes them - what does is where they sit,
+ * outside the L3 domain, so they are the E-cores seeing no L3 on a system
+ * whose other cores do.
+ *
+ * A derivation from the cache topology rather than something the hardware
+ * states, so it only refines cores already identified as E-cores, and only
+ * where some CPU does report an L3.
+ */
+static void jent_mark_lp_cores(struct jent_cpu_list *list)
+{
+	int have_l3 = 0;
+	long i;
+
+	for (i = 0; i < list->entries; i++) {
+		if (list->cpu[i].l3.size) {
+			have_l3 = 1;
+			break;
+		}
+	}
+
+	if (!have_l3)
+		return;
+
+	for (i = 0; i < list->entries; i++) {
+		struct jent_cpu_info *info = &list->cpu[i];
+
+		if (!strcmp(info->type, "E-core") && !info->l3.size)
+			snprintf(info->type, sizeof(info->type), "LP-E-core");
+	}
+}
+
+/***************************************************************************
+ * Output
+ ***************************************************************************/
+
+/* Format a cache as "<size in KiB>/<CPUs sharing it>", e.g. "1280K/2". */
+static void format_cache(const struct jent_cache_info *cache, char *buf,
+			 size_t buflen)
+{
+	if (!cache->size) {
+		snprintf(buf, buflen, "-");
+		return;
+	}
+
+	if (cache->shared)
+		snprintf(buf, buflen, "%luK/%lu", cache->size / 1024,
+			 cache->shared);
+	else
+		snprintf(buf, buflen, "%luK", cache->size / 1024);
+}
+
+static void format_num(long val, char *buf, size_t buflen)
+{
+	if (val < 0)
+		snprintf(buf, buflen, "-");
+	else
+		snprintf(buf, buflen, "%ld", val);
+}
+
+/* Summary of one tri-state CPU property over all CPUs. */
+#define JENT_FLAG_NONE	(-1)	/* no CPU reports it */
+#define JENT_FLAG_MIXED	(-2)	/* the CPUs disagree */
+
+/* What the counter of this architecture is called, named mid-sentence. */
+#ifdef JENT_CPUINFO_ARM64
+# define JENT_TIMER_NAME	"generic timer"
+#else
+# define JENT_TIMER_NAME	"timestamp counter"
+#endif
+
+enum jent_tsc_prop {
+	jent_tsc_invariant,
+	jent_tsc_nonstop,
+	jent_tsc_known_freq,
+};
+
+static int jent_tsc_flag(const struct jent_cpu_list *list,
+			 enum jent_tsc_prop prop)
+{
+	int value = JENT_FLAG_NONE;
+	long i;
+
+	for (i = 0; i < list->entries; i++) {
+		const struct jent_cpu_info *info = &list->cpu[i];
+		int cur;
+
+		switch (prop) {
+		case jent_tsc_nonstop:
+			cur = info->tsc_nonstop;
+			break;
+		case jent_tsc_known_freq:
+			cur = info->tsc_known_freq;
+			break;
+		case jent_tsc_invariant:
+		default:
+			cur = info->tsc_invariant;
+			break;
+		}
+
+		if (cur < 0)
+			continue;
+		if (value == JENT_FLAG_NONE)
+			value = cur;
+		else if (value != cur)
+			return JENT_FLAG_MIXED;
+	}
+
+	return value;
+}
+
+/* Does any CPU report @vendor? The model string starts with the vendor ID. */
+static int jent_vendor_is(const struct jent_cpu_list *list, const char *vendor)
+{
+	size_t len = strlen(vendor);
+	long i;
+
+	for (i = 0; i < list->entries; i++) {
+		if (!strncmp(list->cpu[i].ident, vendor, len))
+			return 1;
+	}
+
+	return 0;
+}
+
+static const char *jent_flag_str(int value)
+{
+	switch (value) {
+	case 1:
+		return "yes";
+	case 0:
+		return "no";
+	case JENT_FLAG_MIXED:
+		return "differs between CPUs";
+	default:
+		return "unknown";
+	}
+}
+
+/* Does any CPU report a type starting with @prefix - "cap ", "perf "? */
+static int jent_have_type(const struct jent_cpu_list *list, const char *prefix)
+{
+	size_t len = strlen(prefix);
+	long i;
+
+	for (i = 0; i < list->entries; i++) {
+		if (!strncmp(list->cpu[i].type, prefix, len))
+			return 1;
+	}
+
+	return 0;
+}
+
+/*
+ * One note below the table, printed as a bullet with its wrapped lines
+ * indented to match. The heading is emitted before the first note, so a system
+ * with nothing to report gets no empty section.
+ */
+static void print_note(int *heading, const char *text)
+{
+	const char *p;
+
+	if (!*heading) {
+		printf("\nNotes:\n");
+		*heading = 1;
+	}
+
+	printf("  - ");
+	for (p = text; *p; p++) {
+		putchar(*p);
+		if (*p == '\n')
+			printf("    ");
+	}
+	putchar('\n');
+}
+
+/*
+ * The model of @info as "#<N>", numbering the distinct ones in the order met
+ * and collecting them in @idents for the list below the table. On a hybrid x86
+ * CPU every core reports the same brand string, so one entry commonly stands
+ * for the whole machine.
+ */
+static void format_ident(const struct jent_cpu_info *info, const char **idents,
+			 int *nidents, char *buf, size_t buflen)
+{
+	int j;
+
+	if (!info->ident[0]) {
+		snprintf(buf, buflen, "-");
+		return;
+	}
+
+	for (j = 0; j < *nidents; j++) {
+		if (!strcmp(idents[j], info->ident))
+			break;
+	}
+	if (j == *nidents && *nidents < JENT_MAX_CPUS)
+		idents[(*nidents)++] = info->ident;
+
+	snprintf(buf, buflen, "#%d", j + 1);
+}
+
+/* Everything of a CPU that is not the CPU, package and core number. */
+#define JENT_ROW_FMT	"%-9s %7s %7s %7s %10s %10s %10s %11s %6s\n"
+
+static void format_row(const struct jent_cpu_info *info, const char **idents,
+		       int *nidents, char *buf, size_t buflen)
+{
+	char base[16], mhz[16], tsc[16], ident[16];
+	char l1d[24], l1i[24], l2[24], l3[24];
+
+	format_num(info->base_khz ? (long)(info->base_khz / 1000) : -1,
+		   base, sizeof(base));
+	format_num(info->max_khz ? (long)(info->max_khz / 1000) : -1,
+		   mhz, sizeof(mhz));
+	format_num(info->tsc_khz ? (long)(info->tsc_khz / 1000) : -1,
+		   tsc, sizeof(tsc));
+	format_cache(&info->l1d, l1d, sizeof(l1d));
+	format_cache(&info->l1i, l1i, sizeof(l1i));
+	format_cache(&info->l2, l2, sizeof(l2));
+	format_cache(&info->l3, l3, sizeof(l3));
+	format_ident(info, idents, nidents, ident, sizeof(ident));
+
+	snprintf(buf, buflen, JENT_ROW_FMT, info->type[0] ? info->type : "-",
+		 base, mhz, tsc, l1d, l1i, l2, l3, ident);
+}
+
+static void print_table(const struct jent_cpu_list *list, const char **idents,
+			int *nidents)
+{
+	long i;
+
+	printf("%4s %4s %5s " JENT_ROW_FMT,
+	       "CPU", "Pkg", "Core", "Type", "BaseMHz", "MaxMHz", "TmrMHz",
+	       "L1d", "L1i", "L2", "L3", "Model");
+
+	for (i = 0; i < list->entries; i++) {
+		const struct jent_cpu_info *info = &list->cpu[i];
+		char cpu[16], pkg[16], core[16], row[256];
+
+		if (info->cpu_valid)
+			snprintf(cpu, sizeof(cpu), "%lu", info->cpu);
+		else
+			snprintf(cpu, sizeof(cpu), "?");
+		format_num(info->pkg, pkg, sizeof(pkg));
+		format_num(info->core, core, sizeof(core));
+		format_row(info, idents, nidents, row, sizeof(row));
+
+		printf("%4s %4s %5s %s", cpu, pkg, core, row);
+	}
+}
+
+/*
+ * Do two CPUs need to be measured separately? Package and core numbers are
+ * left out: they name a CPU rather than describe it. What remains is what a
+ * recording depends on.
+ */
+static int same_kind(const struct jent_cpu_info *a,
+		     const struct jent_cpu_info *b)
+{
+	return !strcmp(a->type, b->type) && !strcmp(a->ident, b->ident) &&
+	       a->base_khz == b->base_khz && a->max_khz == b->max_khz &&
+	       a->tsc_khz == b->tsc_khz &&
+	       !memcmp(&a->l1d, &b->l1d, sizeof(a->l1d)) &&
+	       !memcmp(&a->l1i, &b->l1i, sizeof(a->l1i)) &&
+	       !memcmp(&a->l2, &b->l2, sizeof(a->l2)) &&
+	       !memcmp(&a->l3, &b->l3, sizeof(a->l3));
+}
+
+/* Append @cpu to a list of ranges, "0-3,8,10-11". */
+static void append_range(char *buf, size_t buflen, unsigned long first,
+			 unsigned long last)
+{
+	size_t len = strlen(buf);
+
+	if (len && len + 1 < buflen)
+		buf[len++] = ',';
+
+	if (first == last)
+		snprintf(buf + len, buflen - len, "%lu", first);
+	else
+		snprintf(buf + len, buflen - len, "%lu-%lu", first, last);
+}
+
+/*
+ * One row per kind of CPU instead of one per CPU: on a server with a hundred
+ * alike, the full listing says the same thing a hundred times.
+ */
+static void print_summary(const struct jent_cpu_list *list, const char **idents,
+			  int *nidents)
+{
+	long i, j;
+	int printed = 0;
+
+	printf("%5s " JENT_ROW_FMT,
+	       "CPUs", "Type", "BaseMHz", "MaxMHz", "TmrMHz",
+	       "L1d", "L1i", "L2", "L3", "Model");
+
+	for (i = 0; i < list->entries; i++) {
+		const struct jent_cpu_info *info = &list->cpu[i];
+		char row[256], cpus[512] = "";
+		unsigned long first = 0, last = 0;
+		int open = 0;
+		long count = 0;
+
+		/* Already covered by a kind printed earlier. */
+		for (j = 0; j < i; j++) {
+			if (same_kind(&list->cpu[j], info))
+				break;
+		}
+		if (j < i)
+			continue;
+
+		for (j = i; j < list->entries; j++) {
+			const struct jent_cpu_info *other = &list->cpu[j];
+
+			if (!same_kind(other, info))
+				continue;
+			count++;
+			if (!other->cpu_valid)
+				continue;
+
+			if (open && other->cpu == last + 1) {
+				last = other->cpu;
+				continue;
+			}
+			if (open)
+				append_range(cpus, sizeof(cpus), first, last);
+			first = other->cpu;
+			last = other->cpu;
+			open = 1;
+		}
+		if (open)
+			append_range(cpus, sizeof(cpus), first, last);
+
+		format_row(info, idents, nidents, row, sizeof(row));
+		printf("%5ld %s", count, row);
+		if (cpus[0])
+			printf("      CPUs %s\n", cpus);
+		printed++;
+	}
+
+	/*
+	 * Only where the listing covers the machine: a backend describing the
+	 * one CPU it runs on has every row alike by construction.
+	 */
+	if (printed == 1 && list->entries == list->ncpu)
+		printf("\nEvery CPU of this machine is of the same kind: any "
+		       "one of them can be\nrecorded for all.\n");
+}
+
+static void print_cpus(const struct jent_cpu_list *list, int summary)
+{
+	const char *idents[JENT_MAX_CPUS];
+	int nidents = 0, j;
+	long i;
+
+	if (summary)
+		print_summary(list, idents, &nidents);
+	else
+		print_table(list, idents, &nidents);
+
+	printf("\nColumns:\n");
+	if (!summary)
+		printf("  Pkg, Core  package and core ID - equal in both means "
+		       "SMT siblings of one core\n");
+	else
+		printf("  CPUs       how many CPUs are of this kind, and which "
+		       "ones they are\n");
+	printf("  Type       core type as the system reports it\n");
+	/*
+	 * Where a ranking stands in for the core type, its scale has to be
+	 * said - not least that a uniform machine has every core at the top.
+	 */
+	if (jent_have_type(list, "cap "))
+		printf("             \"cap <N>\" is the compute capacity the "
+		       "scheduler works with,\n             1024 being the "
+		       "most capable core of the system\n");
+	if (jent_have_type(list, "perf "))
+		printf("             \"perf <N>\" is the performance ranking "
+		       "the firmware gives the\n             core, 255 being "
+		       "the maximum - AMD reports no core type\n");
+	printf("  BaseMHz    nominal base frequency, not the clock the CPU "
+	       "currently runs at\n");
+	printf("  TmrMHz     rate of the %s, which the Jitter RNG times "
+	       "with\n", JENT_TIMER_NAME);
+	printf("  L1d - L3   cache size in KiB, followed by the number of "
+	       "CPUs sharing it\n");
+
+	/*
+	 * The properties of that counter belong to the part, not the core, so
+	 * they are summarized here rather than taking three more columns.
+	 */
+	if (jent_tsc_flag(list, jent_tsc_invariant) != JENT_FLAG_NONE ||
+	    jent_tsc_flag(list, jent_tsc_nonstop) != JENT_FLAG_NONE ||
+	    jent_tsc_flag(list, jent_tsc_known_freq) != JENT_FLAG_NONE) {
+		printf("\nTimer: invariant %s, nonstop %s, known rate %s\n",
+		       jent_flag_str(jent_tsc_flag(list, jent_tsc_invariant)),
+		       jent_flag_str(jent_tsc_flag(list, jent_tsc_nonstop)),
+		       jent_flag_str(jent_tsc_flag(list,
+						   jent_tsc_known_freq)));
+	}
+
+	{
+		int have_freq = 0, have_tsc = 0, heading = 0;
+
+		/* What the listing covers comes before what it is missing. */
+		if (list->note)
+			print_note(&heading, list->note);
+
+		/* Which of the two columns are a dash for every CPU. */
+		for (i = 0; i < list->entries; i++) {
+			if (list->cpu[i].base_khz || list->cpu[i].max_khz)
+				have_freq = 1;
+			if (list->cpu[i].tsc_khz)
+				have_tsc = 1;
+		}
+
+		/*
+		 * A dash there is not an unread value: on AMD no CPUID leaf
+		 * carries the rate, and the operating system may still know
+		 * it. Spelled out per case so that each reads as one sentence.
+		 */
+		if (!have_tsc) {
+			int amd = jent_vendor_is(list, "AuthenticAMD");
+			int known = jent_tsc_flag(list, jent_tsc_known_freq);
+
+			if (amd && known == 1)
+				print_note(&heading,
+					   "The counter rate is not enumerated "
+					   "by this CPU: AMD implements neither\n"
+					   "CPUID leaf carrying it, so only the "
+					   "operating system knows it.");
+			else if (amd)
+				print_note(&heading,
+					   "The counter rate is not enumerated "
+					   "by this CPU: AMD implements neither\n"
+					   "CPUID leaf carrying it, and the "
+					   "operating system determines it on "
+					   "its own.");
+			else if (known == 1)
+				print_note(&heading,
+					   "The counter rate is not enumerated "
+					   "by this CPU, so only the operating\n"
+					   "system knows it.");
+			else
+				print_note(&heading,
+					   "The counter rate is not enumerated "
+					   "by this CPU, and the operating "
+					   "system\ndetermines it on its own.");
+		}
+
+		if (!have_freq)
+			print_note(&heading,
+				   "No frequency is reported: neither the CPU "
+				   "nor the operating system\nstates one.");
+	}
+
+	if (nidents) {
+		printf("\nModels:\n");
+		for (j = 0; j < nidents; j++)
+			printf("  #%d: %s\n", j + 1, idents[j]);
+	}
+
+	printf("\nRecording:\n");
+	if (list->pinning)
+		printf("  jitterentropy-hashtime <rounds> <repeats> <file> "
+		       "--cpu <CPU>\n");
+	else if (list->select)
+		printf("%s\n", list->select);
+	else
+		printf("  This system offers no thread-to-CPU pinning, so a "
+		       "recording cannot be\n  confined to one core.\n");
+	printf("  Add --status to print the configuration a recording is made "
+	       "with.\n");
+}
+
+/*
+ * JSON output: the same data as the table, for scripts driving a recording per
+ * core type. Unreported values are null rather than absent, so that every CPU
+ * carries the same set of keys.
+ */
+static void print_json_string(const char *str)
+{
+	putchar('"');
+	for (; *str; str++) {
+		unsigned char c = (unsigned char)*str;
+
+		switch (c) {
+		case '"':
+		case '\\':
+			printf("\\%c", c);
+			break;
+		case '\n':
+			printf("\\n");
+			break;
+		case '\t':
+			printf("\\t");
+			break;
+		default:
+			if (c < 0x20)
+				printf("\\u%04x", c);
+			else
+				putchar(c);
+			break;
+		}
+	}
+	putchar('"');
+}
+
+/* A tri-state CPU property as a JSON literal. */
+static const char *jent_json_flag(int value)
+{
+	if (value < 0)
+		return "null";
+	return value ? "true" : "false";
+}
+
+static void print_json_cache(const char *name,
+			     const struct jent_cache_info *cache, int last)
+{
+	printf("\t\t\t\t\"%s\": ", name);
+
+	if (!cache->size) {
+		printf("null%s\n", last ? "" : ",");
+		return;
+	}
+
+	printf("{ \"sizeBytes\": %lu, \"sharedCpus\": ", cache->size);
+	if (cache->shared)
+		printf("%lu", cache->shared);
+	else
+		printf("null");
+	printf(" }%s\n", last ? "" : ",");
+}
+
+static void print_json(const struct jent_cpu_list *list)
+{
+	long i;
+
+	printf("{\n");
+	printf("\t\"cpus\": %ld,\n", list->ncpu);
+	printf("\t\"pinning\": %s,\n", list->pinning ? "true" : "false");
+	printf("\t\"backend\": ");
+	print_json_string(list->backend ? list->backend : "none");
+	printf(",\n");
+
+	printf("\t\"processors\": [\n");
+	for (i = 0; i < list->entries; i++) {
+		const struct jent_cpu_info *info = &list->cpu[i];
+
+		printf("\t\t{\n");
+
+		printf("\t\t\t\"cpu\": ");
+		if (info->cpu_valid)
+			printf("%lu,\n", info->cpu);
+		else
+			printf("null,\n");
+
+		printf("\t\t\t\"package\": ");
+		if (info->pkg < 0)
+			printf("null,\n");
+		else
+			printf("%ld,\n", info->pkg);
+
+		printf("\t\t\t\"core\": ");
+		if (info->core < 0)
+			printf("null,\n");
+		else
+			printf("%ld,\n", info->core);
+
+		printf("\t\t\t\"coreType\": ");
+		if (info->type[0])
+			print_json_string(info->type);
+		else
+			printf("null");
+		printf(",\n");
+
+		printf("\t\t\t\"baseFrequencyKHz\": ");
+		if (info->base_khz)
+			printf("%lu,\n", info->base_khz);
+		else
+			printf("null,\n");
+
+		printf("\t\t\t\"maxFrequencyKHz\": ");
+		if (info->max_khz)
+			printf("%lu,\n", info->max_khz);
+		else
+			printf("null,\n");
+
+		printf("\t\t\t\"timer\": { \"frequencyKHz\": ");
+		if (info->tsc_khz)
+			printf("%lu", info->tsc_khz);
+		else
+			printf("null");
+		printf(", \"invariant\": %s",
+		       jent_json_flag(info->tsc_invariant));
+		printf(", \"nonstop\": %s", jent_json_flag(info->tsc_nonstop));
+		printf(", \"knownFrequency\": %s },\n",
+		       jent_json_flag(info->tsc_known_freq));
+
+		printf("\t\t\t\"model\": ");
+		if (info->ident[0])
+			print_json_string(info->ident);
+		else
+			printf("null");
+		printf(",\n");
+
+		printf("\t\t\t\"caches\": {\n");
+		print_json_cache("l1d", &info->l1d, 0);
+		print_json_cache("l1i", &info->l1i, 0);
+		print_json_cache("l2", &info->l2, 0);
+		print_json_cache("l3", &info->l3, 1);
+		printf("\t\t\t}\n");
+
+		printf("\t\t}%s\n", (i + 1 < list->entries) ? "," : "");
+	}
+	printf("\t]\n");
+	printf("}\n");
+}
+
+static void usage(const char *name)
+{
+	printf("%s [--summary] [--json]\n", name);
+	printf("List the identification and the caches of all CPUs.\n\n");
+	printf("  --summary  one row per kind of CPU instead of one per CPU\n");
+	printf("  --json     report the same data as JSON, one entry per CPU\n");
+	printf("  --help     print this text\n");
+}
+
+int main(int argc, char *argv[])
+{
+	static struct jent_cpu_list list;
+	int json = 0, summary = 0, i, ret;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "--json")) {
+			json = 1;
+		} else if (!strcmp(argv[i], "--summary")) {
+			summary = 1;
+		} else if (!strcmp(argv[i], "--help") ||
+			   !strcmp(argv[i], "-h")) {
+			usage(argv[0]);
+			return 0;
+		} else {
+			fprintf(stderr, "Unknown option %s\n", argv[i]);
+			usage(argv[0]);
+			return 1;
+		}
+	}
+
+	ret = jent_get_cpus(&list);
+	if (ret) {
+		fprintf(stderr, "Cannot obtain the CPU information: %s\n",
+			strerror(-ret));
+		return 1;
+	}
+
+	jent_mark_lp_cores(&list);
+
+	if (json) {
+		print_json(&list);
+		return 0;
+	}
+
+	printf("CPUs: %ld\n\n", list.ncpu);
+	print_cpus(&list, summary);
+
+	return 0;
+}

--- a/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
+++ b/tests/raw-entropy/recording_userspace/jitterentropy-hashtime.c
@@ -37,6 +37,16 @@
 #include <unistd.h>
 #endif
 
+#ifdef __linux__
+#include <sched.h>	/* sched_setaffinity() for --cpu */
+#endif
+
+#ifdef __APPLE__
+#include <pthread.h>
+#include <sys/qos.h>		/* QoS classes for --e-cores and --p-cores */
+#include <sys/resource.h>	/* PRIO_DARWIN_PROCESS for --p-cores */
+#endif
+
 #include "jitterentropy-sha3.c"
 #include "jitterentropy-gcd.c"
 #include "jitterentropy-health.c"
@@ -83,6 +93,108 @@ enum jent_es {
 	jent_hashloop,		/* SHA3 loop exclusively */
 	jent_memaccess_loop,	/* Memory access loop exclusively */
 };
+
+/*
+ * Pin the measuring thread to the given CPU. On a hybrid CPU the timing of the
+ * noise sources depends on the core, so a recording is only meaningful for one
+ * core type at a time - jitterentropy-cpuinfo says which core is which.
+ *
+ * The memory block is unaffected: the library sizes it from the largest cache
+ * in the system, not from the core it runs on (arch/jitterentropy-arch-cache.c),
+ * so --max-mem is what matches it to an efficiency core.
+ *
+ * The library's portable pinning primitive is compiled with the internal timer
+ * only. Without it the native affinity call is used, which covers Linux alone;
+ * elsewhere the request is rejected rather than measuring an arbitrary core.
+ */
+static int jent_pin_cpu(unsigned long cpu)
+{
+#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
+	return jent_thread_pin_to_cpu(cpu);
+#elif defined(__linux__)
+	cpu_set_t set;
+
+	if (cpu >= (unsigned long)CPU_SETSIZE)
+		return -EINVAL;
+	CPU_ZERO(&set);
+	CPU_SET((size_t)cpu, &set);
+	if (sched_setaffinity(0, sizeof(set), &set))
+		return -errno;
+	return 0;
+#else
+	(void)cpu;
+	return -ENOSYS;
+#endif
+}
+
+/*
+ * Whether the function above can place the measurement, and so whether --cpu is
+ * offered: the library's primitive covers the systems named here and no other,
+ * and without it only the Linux fallback is left. The option is parsed where it
+ * is not offered, so passing it yields the reason rather than "unknown option".
+ */
+#ifdef JENT_CONF_ENABLE_INTERNAL_TIMER
+# if defined(_MSC_VER) || defined(__MINGW32__) || defined(__linux__) || \
+     defined(__FreeBSD__) || defined(__NetBSD__)
+#  define JENT_HAVE_CPU_PINNING
+# endif
+#elif defined(__linux__)
+# define JENT_HAVE_CPU_PINNING
+#endif
+
+#ifdef JENT_HAVE_CPU_PINNING
+# define JENT_USAGE_CPU		"|--cpu <NUM>"
+#else
+# define JENT_USAGE_CPU		""
+#endif
+
+/* Set when --cpu confined the measurement to a single CPU. */
+static int jent_cpu_pinned = 0;
+
+/*
+ * Ask for the core type the measurement is to run on. macOS has no CPU pinning
+ * (see jent_pin_cpu()) but schedules the core types by quality-of-service
+ * class: QOS_CLASS_BACKGROUND runs on the E-cores alone and so confines a
+ * recording to them, while QOS_CLASS_USER_INTERACTIVE is only a preference,
+ * and the class a shell command carries anyway.
+ *
+ * The class does not lift a background task policy ("taskpolicy -b"), under
+ * which the same workload stays at 815 ms against 240 ms in the foreground, so
+ * --p-cores clears that first - 244 ms. Other ways of holding a process there
+ * remain, hence a request rather than a guarantee.
+ *
+ * Later threads inherit the class, so the counting thread follows. As with
+ * jent_pin_cpu(), --max-mem is what matches the memory block to the E-caches.
+ * Note that --e-cores records those cores at the lower clock the background
+ * class is given; no interface exposes them at their own maximum.
+ */
+static int jent_select_cores(int performance)
+{
+#ifdef __APPLE__
+	int ret;
+
+	/* Priority zero is what takes the process out of the background. */
+	if (performance && setpriority(PRIO_DARWIN_PROCESS, 0, 0))
+		return -errno;
+
+	ret = pthread_set_qos_class_self_np(performance ?
+					    QOS_CLASS_USER_INTERACTIVE :
+					    QOS_CLASS_BACKGROUND, 0);
+
+	/* The call reports the error directly rather than through errno. */
+	return ret ? -ret : 0;
+#else
+	(void)performance;
+	return -ENOSYS;
+#endif
+}
+
+/* Offered where they can be honored, parsed everywhere, as --cpu above. */
+#ifdef __APPLE__
+# define JENT_USAGE_CORES	"|--e-cores|--p-cores"
+#else
+# define JENT_USAGE_CORES	""
+#endif
 
 /***************************************************************************
  * Statistical test logic not compiled for regular operation
@@ -133,6 +245,14 @@ static int jent_one_test(const char *pathname, unsigned long rounds,
 	 */
 	ec = jent_entropy_collector_alloc_internal(osr, flags);
 	if (!ec) {
+		printf("Allocation of the entropy collector failed\n");
+		/*
+		 * The counting thread needs a CPU of its own, and
+		 * jent_notime_init() refuses to start with a single-CPU
+		 * affinity mask - exactly what --cpu establishes.
+		 */
+		if (jent_cpu_pinned)
+			printf("Note: --cpu leaves one CPU in the affinity mask, which rules out the internal timer\n");
 		ret = 1;
 		goto out;
 	}
@@ -288,19 +408,33 @@ out:
  * --hashloop Perform the measurement of the hash loop only
  * --memaccess Perform the measurement of the memory access loop only
  * --hloopcnt Number of hashloop operations at runtime
+ * --cpu Pin the measurement to the given CPU - use this on hybrid CPUs to
+ *	 record one core type at a time (see jitterentropy-cpuinfo). Note that
+ *	 the internal timer cannot be used together with this option as its
+ *	 counting thread requires a CPU of its own.
+ * --e-cores Confine the measurement to the efficiency cores. macOS only, where
+ *	 there is no CPU pinning and the quality-of-service class of the thread
+ *	 is what selects a core type instead.
+ * --p-cores Ask for the performance cores - a preference, not a confinement.
+ *	 macOS only, and of use where the tool is started with a lower class
+ *	 than a shell command carries, which would otherwise take the recording
+ *	 onto the efficiency cores unnoticed.
+ *
+ * --cpu, --e-cores and --p-cores are mutually exclusive.
  */
 int main(int argc, char * argv[])
 {
 	const char *file;
-	unsigned long i, rounds, repeats;
+	unsigned long i, rounds, repeats, cpu = 0;
 	unsigned int flags = 0, osr = 0, loopcnt = 0;
 	unsigned int status = 0;
+	int e_cores = 0, p_cores = 0;
 	enum jent_es jent_es = jent_common;
 	int ret;
 	char pathname[4096];
 
 	if (argc < 4) {
-		printf("%s <rounds per repeat> <number of repeats> <filename> [--ntg1|--force-fips|--disable-memory-access|--disable-internal-timer|--force-internal-timer|--osr <OSR>|--loopcnt <NUM>|--max-mem <NUM>|--hashloop|--memaccess|--all-caches|--hloopcnt <NUM>|--status]\n", argv[0]);
+		printf("%s <rounds per repeat> <number of repeats> <filename> [--ntg1|--force-fips|--disable-memory-access|--disable-internal-timer|--force-internal-timer|--osr <OSR>|--loopcnt <NUM>|--max-mem <NUM>|--hashloop|--memaccess|--all-caches|--hloopcnt <NUM>" JENT_USAGE_CPU JENT_USAGE_CORES "|--status]\n", argv[0]);
 		return 1;
 	}
 
@@ -500,6 +634,24 @@ int main(int argc, char * argv[])
 				printf("Unknown hashloop value\n");
 				return 1;
 			}
+		} else if (!strncmp(argv[1], "--cpu", 5)) {
+			unsigned long val;
+
+			argc--;
+			argv++;
+			if (argc <= 1) {
+				printf("CPU value missing\n");
+				return 1;
+			}
+
+			if (parse_ulong(argv[1], &val))
+				return 1;
+			cpu = val;
+			jent_cpu_pinned = 1;
+		} else if (!strncmp(argv[1], "--e-cores", 9)) {
+			e_cores = 1;
+		} else if (!strncmp(argv[1], "--p-cores", 9)) {
+			p_cores = 1;
 		} else if (!strncmp(argv[1], "--status", 8)) {
 			status = 1;
 		} else {
@@ -509,6 +661,44 @@ int main(int argc, char * argv[])
 
 		argc--;
 		argv++;
+	}
+
+	/* Each names the core to measure on, in ways that cannot be combined. */
+	if (jent_cpu_pinned + e_cores + p_cores > 1) {
+		printf("--cpu, --e-cores and --p-cores are mutually exclusive\n");
+		return 1;
+	}
+
+	/*
+	 * Before the first initialization, so that the self tests, the memory
+	 * allocation and the recording all run on the selected core.
+	 */
+	if (jent_cpu_pinned) {
+		ret = jent_pin_cpu(cpu);
+		if (ret) {
+			printf("Cannot pin the measurement to CPU %lu: %s\n",
+			       cpu, strerror(-ret));
+			return 1;
+		}
+		printf("Measurement pinned to CPU %lu\n", cpu);
+	}
+
+	if (e_cores || p_cores) {
+		ret = jent_select_cores(p_cores);
+		if (ret) {
+			printf("Cannot ask for the %s cores: %s\n",
+			       p_cores ? "performance" : "efficiency",
+			       strerror(-ret));
+			return 1;
+		}
+		/*
+		 * Only the efficiency cores are a confinement; the performance
+		 * ones are a preference the scheduler is free to leave.
+		 */
+		if (e_cores)
+			printf("Measurement confined to the efficiency cores\n");
+		else
+			printf("Measurement asked for the performance cores\n");
 	}
 
 	/*


### PR DESCRIPTION
On hybrid CPUs - Intel P/E cores, ARM big.LITTLE - the core types differ in their micro-architecture and their caches, so the Jitter RNG shows a different timing behavior on each of them. A raw noise recording only characterizes the core type it was taken on and each of them has to be recorded separately.

Add jitterentropy-cpuinfo, which lists the vendor, the model, the core type, the topology, the data cache sizes and, on x86, the base frequency and the timestamp counter of every CPU, and add the --cpu option to jitterentropy-hashtime, which pins the measurement to one of those CPUs before the entropy collector is initialized. With --json the tool writes the same data machine-readably, for scripts driving one recording per core type.

The tool reports what the system in use offers: Linux and Windows describe every CPU individually (sysfs plus CPUID or MIDR_EL1, respectively GetLogicalProcessorInformationEx() plus the registry), macOS describes the cores per performance level, which is how Apple Silicon exposes its P and E cores, and the BSDs and the remaining systems have neither interface and are left with the CPU the tool runs on. The core type comes from the hybrid leaf of CPUID on Intel, the efficiency class on Windows, the performance level on macOS and the compute capacity on ARM; AMD reports none, so the per-core ranking of the amd-pstate driver is used where it is available. The low-power efficiency cores of the recent Intel parts are Atom cores like the regular ones and are reported as such by every one of those interfaces; they are identified by sitting outside the L3 domain instead.

CI runs the tool on every platform it is built for, which is what compiles the individual backends at all.