### PR TITLE
Reject timestamps that do not track the work they claim to measure

### DIFF
--- a/arch/jitterentropy-arch-timer.c
+++ b/arch/jitterentropy-arch-timer.c
@@ -381,3 +381,67 @@ void jent_get_nstime(uint64_t *out)
 
 #endif
 }
+
+#if (defined(__x86_64__) || defined(__i386__) || \
+     defined(_M_X64) || defined(_M_IX86)) && !defined(LINUX_KERNEL)
+
+int jent_tpause_supported(void)
+{
+	uint32_t a, b, c, d;
+
+#if defined(_MSC_VER)
+	int regs[4];
+
+	__cpuidex(regs, 7, 0);
+	(void)a;
+	(void)b;
+	(void)d;
+	return ((unsigned int)regs[2] >> 5) & 1u;
+#else
+	__asm__ __volatile__("cpuid"
+			     : "=a" (a), "=b" (b), "=c" (c), "=d" (d)
+			     : "a" (7), "c" (0));
+	return (c >> 5) & 1u;
+#endif
+}
+
+uint64_t jent_raw_tsc(void)
+{
+#if defined(_MSC_VER)
+	return (uint64_t)__rdtsc();
+#else
+	return (uint64_t)__rdtsc();
+#endif
+}
+
+void jent_tpause_until(uint64_t deadline)
+{
+	uint32_t lo = (uint32_t)deadline;
+	uint32_t hi = (uint32_t)(deadline >> 32);
+	/* C0.1: light wait. r32 in ECX; EDX:EAX is the absolute TSC deadline. */
+	uint32_t ctrl = 0;
+
+	__asm__ __volatile__(".byte 0x66, 0x0f, 0xae, 0xf1"
+			     :
+			     : "c" (ctrl), "a" (lo), "d" (hi)
+			     : "memory");
+}
+
+#else /* !x86 userspace */
+
+int jent_tpause_supported(void)
+{
+	return 0;
+}
+
+uint64_t jent_raw_tsc(void)
+{
+	return 0;
+}
+
+void jent_tpause_until(uint64_t deadline)
+{
+	(void)deadline;
+}
+
+#endif

--- a/arch/jitterentropy-arch-timer.h
+++ b/arch/jitterentropy-arch-timer.h
@@ -100,4 +100,18 @@
 
 void jent_get_nstime(uint64_t *out);
 
+/*
+ * WAITPKG TPAUSE helpers. Used by init to see whether jent_get_nstime
+ * advances in the same ballpark as a real TSC wait. On non-x86, or when
+ * the CPU lacks WAITPKG, jent_tpause_supported() is 0 and the others
+ * are no-ops.
+ *
+ * jent_raw_tsc() is the instruction, not jent_get_nstime(): the deadline
+ * must be a hardware TSC value or TPAUSE can sleep for seconds / forever
+ * if the software stamp is a closed form in the call index.
+ */
+int jent_tpause_supported(void);
+uint64_t jent_raw_tsc(void);
+void jent_tpause_until(uint64_t deadline);
+
 #endif /* _JITTERENTROPY_ARCH_TIMER_H */

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -483,6 +483,7 @@ void jent_notime_fini(void *ctx);
 #define EHASH		11 /* Hash self test failed */
 #define EMEM		12 /* Can't allocate memory for initialization */
 #define EGCD		13 /* GCD self-test failed */
+#define EINCONSISTENT	14 /* Timer does not track the work it claims to measure */
 /* -- END error codes for init function -- */
 
 /* -- BEGIN error masks for health tests -- */

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -916,6 +916,50 @@ void jent_entropy_collector_free(struct rand_data *entropy_collector)
 	}
 }
 
+/*
+ * The timestamp must get larger when the measured loops get larger.
+ * RCT/APT/lag/GCD already accept any live-looking monotonic function of the
+ * call index (a cubic, a counter with mixed low bits, a bounded Fibonacci
+ * increment). Those functions do not observe the hash or memory work, so
+ * stretching loop_cnt must not stretch their deltas.
+ *
+ * This is not an entropy estimate. It only asks whether the stopwatch is
+ * attached to the work.
+ *
+ * jent_measure_jitter stamps after memaccess and before hash_loop, so a
+ * sample's delta is (previous hash_loop) + (this memaccess). A light
+ * sample therefore needs loop_cnt==1 on both the previous and the current
+ * call; a heavy sample needs the high count on both. The discarded call
+ * in the middle switches the pending hash_loop count.
+ */
+#define JENT_WORKTRACK_LIGHT		1ULL
+#define JENT_WORKTRACK_HEAVY		32ULL
+#define JENT_WORKTRACK_BLOCKS		16
+#define JENT_WORKTRACK_MIN_SCALE	12
+
+static int jent_timer_tracks_work(struct rand_data *ec)
+{
+	unsigned int ok = 0;
+	unsigned int i;
+
+	for (i = 0; i < JENT_WORKTRACK_BLOCKS; i++) {
+		uint64_t light = 0, heavy = 0;
+
+		jent_measure_jitter(ec, JENT_WORKTRACK_LIGHT, NULL);
+		jent_measure_jitter(ec, JENT_WORKTRACK_LIGHT, &light);
+		jent_measure_jitter(ec, JENT_WORKTRACK_HEAVY, NULL);
+		jent_measure_jitter(ec, JENT_WORKTRACK_HEAVY, &heavy);
+
+		if (light && (heavy / light) >= 2)
+			ok++;
+	}
+
+	if (ok < JENT_WORKTRACK_MIN_SCALE)
+		return EINCONSISTENT;
+
+	return 0;
+}
+
 int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 {
 	struct rand_data *ec;
@@ -956,9 +1000,9 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 	/* To initialize the prior time. */
 	jent_measure_jitter(ec, 0, NULL);
 
-	/* We could perform statistical tests here, but the problem is
-	 * that we only have a few loop counts to do testing. These
-	 * loop counts may show some slight skew leading to false positives.
+	/* Statistical tests on this short window false-positive too easily.
+	 * jent_timer_tracks_work() below is not one of those: it only checks
+	 * that stretching the work stretches the stamp.
 	 */
 
 	/*
@@ -1044,6 +1088,9 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 	 */
 	if (JENT_STUCK_INIT_THRES(JENT_POWERUP_TESTLOOPCOUNT) < count_stuck)
 		ret = ESTUCK;
+
+	if (!ret)
+		ret = jent_timer_tracks_work(ec);
 
 out:
 	jent_gcd_fini(delta_history, JENT_POWERUP_TESTLOOPCOUNT);

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -1050,7 +1050,9 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 	/* To initialize the prior time. */
 	jent_measure_jitter(ec, 0, NULL);
 
-	/* Statistical tests on this short window false-positive too easily.
+	/* We could perform statistical tests here, but the problem is
+	 * that we only have a few loop counts to do testing. These
+	 * loop counts may show some slight skew leading to false positives.
 	 * jent_timer_tracks_work() below is not one of those: it only checks
 	 * that stretching the work stretches the stamp.
 	 */

--- a/src/jitterentropy-base.c
+++ b/src/jitterentropy-base.c
@@ -960,6 +960,56 @@ static int jent_timer_tracks_work(struct rand_data *ec)
 	return 0;
 }
 
+/*
+ * TPAUSE sleeps until a hardware TSC deadline. Then jent_get_nstime must
+ * have moved by about as much as the TSC actually slept. A closed form in
+ * the call index moves by one f(n) step, not by the wait.
+ *
+ * The deadline is always raw RDTSC, never the software stamp: passing
+ * n^3+n into TPAUSE would wait until the real TSC reached that value.
+ *
+ * Windows wakes TPAUSE early. Compare against the observed TSC sleep,
+ * and retry until that sleep is long enough to judge.
+ */
+#define JENT_TPAUSE_REQUEST	2000000ULL
+#define JENT_TPAUSE_MIN_SLEEP	1000000ULL
+#define JENT_TPAUSE_TRIES	8
+
+static int jent_timer_tracks_tpause(void)
+{
+	unsigned int i;
+
+	if (!jent_tpause_supported())
+		return 0;
+
+	for (i = 0; i < JENT_TPAUSE_TRIES; i++) {
+		uint64_t t0 = 0, t1 = 0, raw0, raw1, hooked, slept;
+
+		jent_get_nstime(&t0);
+		raw0 = jent_raw_tsc();
+		jent_tpause_until(raw0 + JENT_TPAUSE_REQUEST);
+		jent_get_nstime(&t1);
+		raw1 = jent_raw_tsc();
+
+		if (raw1 <= raw0 || t1 <= t0)
+			continue;
+
+		slept = raw1 - raw0;
+		hooked = t1 - t0;
+
+		if (slept < JENT_TPAUSE_MIN_SLEEP)
+			continue;
+
+		if (hooked < slept / 2 || hooked > slept * 8)
+			return EINCONSISTENT;
+
+		return 0;
+	}
+
+	/* Every try was interrupted. Do not fail a real CPU. */
+	return 0;
+}
+
 int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 {
 	struct rand_data *ec;
@@ -1091,6 +1141,8 @@ int jent_time_entropy_init(unsigned int osr, unsigned int flags)
 
 	if (!ret)
 		ret = jent_timer_tracks_work(ec);
+	if (!ret)
+		ret = jent_timer_tracks_tpause();
 
 out:
 	jent_gcd_fini(delta_history, JENT_POWERUP_TESTLOOPCOUNT);


### PR DESCRIPTION
## Summary

`jent_time_entropy_init` already rejects a dead, coarse, or non-monotonic timer. It does not ask whether `jent_get_nstime` is attached to the hash and memory work it is supposed to time.

RCT, APT, lag, and GCD all accept any live-looking monotonic function of the call index. A cubic ramp (`n^3+n`), a counter with mixed low bits, or a bounded Fibonacci increment all pass stock 3.7.1 under `JENT_FORCE_FIPS | JENT_DISABLE_INTERNAL_TIMER` and then produce a **repeatable** 32-byte seed. That is a consistency failure, not “not random enough.”

This PR adds two init-only checks after the existing battery. Failure is a new code, `EINCONSISTENT` (14). Neither check is an entropy estimate, and neither turns the short 1024-sample window into a statistical test (the existing comment on that window still stands).

## Why not tighten the existing tests

- **Raising RCT / APT cutoffs** would mostly brick quiet real TSCs. The closed forms still produce varying deltas, so they are not collapsed.
- **Fitting a low-degree polynomial** catches `n^3+n` (`Δ³ = 6`) and misses the other two.
- **Requiring a P-state change** fails honest servers, VMs, and boards that sit in one frequency.
- **Band-checking absolute MHz** is the old DOS calibrated-loop mistake. A faster chip is still a clock.

The operational rule is a same-CPU ratio: when the measured loops get larger, the stamp must get larger.

## Work-tracking (`jent_timer_tracks_work`)

`jent_measure_jitter` stamps after `memaccess` and before `hash_loop`, so one sample’s delta is `(previous hash_loop) + (this memaccess)`. `loop_cnt` already overrides both counts. A 4-call block is therefore:

| Call | `loop_cnt` | δ kept? | Contents |
|---|---|---|---|
| 1 | 1 | no | primes pending `hash(1)` |
| 2 | 1 | light | `hash(1) + mem(1)` |
| 3 | 32 | no | switches pending hash to 32 |
| 4 | 32 | heavy | `hash(32) + mem(32)` |

Sixteen blocks. A block passes when `light != 0` and `heavy / light >= 2` (integer division). Init fails unless at least 12 of 16 pass, so one interrupt or a turbo dip does not reject a real TSC.

Both sides of the ratio scale with the same clock, so a 100 MHz part and a 6 GHz part should both see that 32 SHA-3 finals plus 32 memory walks cost more than 1. Absolute deltas shrink; the ratio does not.

## TPAUSE ballpark (`jent_timer_tracks_tpause`)

A work-scaling implant can still be a closed form if it also scales with `loop_cnt`. Intel WAITPKG `TPAUSE` sleeps until a **hardware** TSC deadline. The clock under test must then have moved by about as much as the TSC actually slept. A function of the call index moves by one `f(n)` step, not by the wait.

- Deadline is always raw `RDTSC`, never `jent_get_nstime`. Passing `n^3+n` into `TPAUSE` would return immediately or hang for seconds.
- Compare the hooked delta to the **observed** sleep (`raw1 - raw0`). Windows wakes `TPAUSE` early; the request is not the reference.
- Up to 8 tries. A try with observed sleep below 10⁶ cycles is skipped. The first long-enough try is judged once: pass band `[slept/2, 8 × slept]`; outside that band is `EINCONSISTENT`. This is not “retry until it fits.”
- No WAITPKG, non-x86, or every try interrupted: return 0. Do not fail a real CPU.

## Measured on one host (fresh process per row)

| Clock | Stock 3.7.1 | This PR |
|---|---|---|
| `n^3+n` | init ok, 32 bytes | `EINCONSISTENT` |
| counter + mix16 | init ok, 32 bytes | `EINCONSISTENT` |
| `t += 1+(F(n) mod 256)` | init ok, 32 bytes | `EINCONSISTENT` |
| RDTSC | ok | still ok, distinct seeds |
| wall-clock increment | not re-run | ok |
| const / seq / fib-xor | `ECOARSETIME` / `ERCT` / `ENOMONOTONIC` | unchanged |

The three closed forms die at work-tracking; TPAUSE does not run on them in the combined path. Either check alone is enough for those three. A hypervisor that exits `RDTSC` and returns **real** time still passes: more work really does take more time.

## What this does not claim

- A faithfully emulated TSC still determines the seed. Mixing a required OS pool into the conditioner (as AWS-LC already does) means a fake stamp can bias, not determine, the output.
- A VMM that virtualises TSC **and** `TPAUSE` against the same fake timeline can still lie. A hook that only replaces `jent_get_nstime` cannot.
- A two-phase hook that feeds a real TSC during init and `f(n)` afterwards is a different class (JEnt-aware implant). Out of scope here.

## Compatibility

- New init error only: `EINCONSISTENT = 14`. Codes 1–13 are unchanged.
- Called only after the stock battery returns 0.
- No new fields on `struct rand_data`.
- No change to `jent_stuck`, GCD, SHA-3, OSR, or the timer backend used for collection.
- TPAUSE helpers are no-ops where WAITPKG is absent.

## Test plan

- [ ] `jent_entropy_init_ex(0, JENT_FORCE_FIPS | JENT_DISABLE_INTERNAL_TIMER)` still succeeds on a real TSC (x86 with and without WAITPKG, and a non-x86 build).
- [ ] Existing failures (`ENOTIME`, `ECOARSETIME`, `ENOMONOTONIC`, `ERCT`, `ESTUCK`, `EGCD`) still fire before the new checks.
- [ ] A monotonic closed form of the call index (`n^3+n` is enough) now returns 14.
- [ ] `jent_read_entropy` after a successful init still produces distinct output across process restarts when the platform timer is real.

Full resaerch:
[jent-deterministic-clocks.pdf](https://github.com/user-attachments/files/31069119/jent-deterministic-clocks.pdf)
